### PR TITLE
feat: `cloudflare_module` support

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -35,8 +35,8 @@ export async function setupBuildHandler(config: ModuleOptions, resolve: Resolver
       let serverEntry = resolve(_nitro.options.output.serverDir, typeof configuredEntry === 'string'
         ? configuredEntry
         : 'index.mjs')
-      const isCloudflarePages = target === 'cloudflare-pages'
-      if (isCloudflarePages)
+      const isCloudflarePagesOrModule = target === 'cloudflare-pages' || target === 'cloudflare-module'
+      if (isCloudflarePagesOrModule)
         // this is especially hacky
         serverEntry = resolve(dirname(serverEntry), './chunks/wasm.mjs')
       const contents = (await readFile(serverEntry, 'utf-8'))
@@ -44,7 +44,7 @@ export async function setupBuildHandler(config: ModuleOptions, resolve: Resolver
       const yogaHash = sha1(await readFile(await resolvePath('yoga-wasm-web/dist/yoga.wasm')))
       const cssInlineHash = sha1(await readFile(await resolvePath('@css-inline/css-inline-wasm/index_bg.wasm')))
       const postfix = target === 'vercel-edge' ? '?module' : ''
-      const path = isCloudflarePages ? `../wasm/` : `./wasm/`
+      const path = isCloudflarePagesOrModule ? `../wasm/` : `./wasm/`
       await writeFile(serverEntry, contents
         .replaceAll('"@resvg/resvg-wasm/index_bg.wasm"', `"${path}index_bg-${resvgHash}.wasm${postfix}"`)
         .replaceAll('"@css-inline/css-inline-wasm/index_bg.wasm"', `"${path}index_bg-${cssInlineHash}.wasm${postfix}"`)

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -91,6 +91,7 @@ export const RuntimeCompatibility: Record<string, RuntimeCompatibilitySchema> = 
   },
   'cloudflare-pages': cloudflare,
   'cloudflare': cloudflare,
+  'cloudflare-module': cloudflare,
 } as const
 
 export function detectTarget(options: { static?: boolean } = {}) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -259,7 +259,7 @@ export default defineNuxtModule<ModuleOptions>({
     if (!config.fonts.length)
       config.fonts = ['Inter:400', 'Inter:700']
 
-    if (preset === 'cloudflare') {
+    if (preset === 'cloudflare' || preset === 'cloudflare-module') {
       config.fonts = config.fonts.filter((f) => {
         if (typeof f !== 'string' && f.path) {
           logger.warn(`The ${f.name}:${f.weight} font was skipped because remote fonts are not available in Cloudflare Workers, please use a Google font.`)
@@ -472,7 +472,7 @@ ${componentImports}
           .forEach((entry, key) => {
             const { name, weight } = entry
             // we need to access using nitro
-            if (preset !== 'cloudflare') {
+            if (preset !== 'cloudflare' && preset !== 'cloudflare-module') {
               entry.path = `/__og-image__/font/${name}/${weight}.ttf`
               nuxt.options.nitro.prerender!.routes!.unshift(entry.path)
             }


### PR DESCRIPTION
Resolves #143 

This PR adds support for the `cloudflare_module` preset of Nitro.
- For runtime compatibility, it is the same as `cloudflare` and `cloudflare-pages`.
- The font asset behavior is similar to `cloudflare`, so I include it with the conditional on `module.ts`.
- The behavior of compiled wasm is similar to `cloudflare-pages`, so I added `isCloudflarePagesOrModule` on nitro `compiled` hook.