### PR TITLE
fix: don't skip normalising routes with `.` in final segment

### DIFF
--- a/src/runtime/pure.ts
+++ b/src/runtime/pure.ts
@@ -14,8 +14,7 @@ export function toBase64Image(fileName: string, data: string | ArrayBuffer) {
 }
 
 export function isInternalRoute(path: string) {
-  const lastSegment = path.split('/').pop() || path
-  return lastSegment.includes('.') || path.startsWith('/__') || path.startsWith('@')
+  return path.startsWith('/__') || path.startsWith('@')
 }
 
 function filterIsOgImageOption(key: string) {


### PR DESCRIPTION
With new URL pattern for og images, I wonder if we can now omit this part of `isInternalRoute`?

In some cases users will have routes with a full-stop but this will still have OG images, for example https://github.com/danielroe/page-speed.dev.

related https://github.com/danielroe/page-speed.dev/commit/53e968666bb10ebbaf648e72e15768fcc3ffaf12.