### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/src/build/devtools.ts
+++ b/src/build/devtools.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import { existsSync } from 'node:fs'
 import type { Nuxt } from 'nuxt/schema'
 import type { Resolver } from '@nuxt/kit'
@@ -42,6 +43,7 @@ export function setupDevToolsUI(options: ModuleOptions, resolve: Resolver['resol
     const rpc = extendServerRpc<ClientFunctions, ServerFunctions>('nuxt-og-image', {})
 
     nuxt.hook('builder:watch', (e, path) => {
+      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
       // needs to be for a page change
       if ((e === 'change' || e.includes('link')) && path.startsWith('pages')) {
         rpc.broadcast.refreshRouteData(path) // client needs to figure it if it's for the page we're on


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

