### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,7 @@ Generate OG Images with Vue templates in Nuxt.
 1. Install `nuxt-og-image` dependency to your project:
 
 ```bash
-#
-yarn add -D nuxt-og-image
-#
-npm install -D nuxt-og-image
-#
-pnpm i -D nuxt-og-image
+npx nuxi@latest module add og-image
 ```
 
 2. Add it to your `modules` section in your `nuxt.config`:


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
