### PR TITLE
fix: images broken for non-jpeg, extension-less paths

### DIFF
--- a/src/runtime/nitro/og-image/satori/plugins/imageSrc.ts
+++ b/src/runtime/nitro/og-image/satori/plugins/imageSrc.ts
@@ -44,7 +44,7 @@ export default defineSatoriTransformer([
       if (imageBuffer)
         imageBuffer = Buffer.from(imageBuffer as ArrayBuffer)
       if (imageBuffer) {
-        node.props.src = toBase64Image(src, imageBuffer)
+        node.props.src = toBase64Image(imageBuffer)
 
         try {
           const imageSize = sizeOf(imageBuffer)
@@ -90,7 +90,7 @@ export default defineSatoriTransformer([
           if (await useStorage().hasItem(key)) {
             const imageBuffer = await useStorage().getItemRaw(key)
             if (imageBuffer) {
-              const base64 = toBase64Image(src, Buffer.from(imageBuffer as ArrayBuffer))
+              const base64 = toBase64Image(Buffer.from(imageBuffer as ArrayBuffer))
               node.props.style!.backgroundImage = `url(${base64})`
             }
           }

--- a/src/runtime/pure.ts
+++ b/src/runtime/pure.ts
@@ -1,15 +1,26 @@
 import { defu } from 'defu'
 import type { InputFontConfig, OgImageOptions, ResolvedFontConfig } from './types'
 
+function detectMimeType(b64: string) {
+  const signatures = {
+    R0lGODdh: 'image/gif',
+    R0lGODlh: 'image/gif',
+    iVBORw0KGgo: 'image/png',
+    '/9j/': 'image/jpeg'
+  };
+
+  for (var s in signatures) {
+    if (b64.indexOf(s) === 0) {
+      return signatures[s];
+    }
+  }
+  return 'image/svg+xml'
+}
+
 export function toBase64Image(fileName: string, data: string | ArrayBuffer) {
   const base64 = typeof data === 'string' ? data : Buffer.from(data).toString('base64')
-  let type = 'image/jpeg'
-  // guess type from file name
-  const ext = fileName.split('.').pop()
-  if (ext === 'svg')
-    type = 'image/svg+xml'
-  else if (ext === 'png')
-    type = 'image/png'
+  const type = detectMimeType(base64)
+
   return `data:${type};base64,${base64}`
 }
 

--- a/src/runtime/pure.ts
+++ b/src/runtime/pure.ts
@@ -17,7 +17,7 @@ function detectMimeType(b64: string) {
   return 'image/svg+xml'
 }
 
-export function toBase64Image(fileName: string, data: string | ArrayBuffer) {
+export function toBase64Image(data: string | ArrayBuffer) {
   const base64 = typeof data === 'string' ? data : Buffer.from(data).toString('base64')
   const type = detectMimeType(base64)
 


### PR DESCRIPTION
Currently `toBase64Image`function use file extension to define MIME Type and the default is jpeg.

https://avatars.githubusercontent.com/maximepvrt => it's a jpeg image => OK
https://avatars.githubusercontent.com/shinGangan =>  it's a png image => KO

I use this code https://stackoverflow.com/questions/57976898/how-to-get-mime-type-from-base-64-string and I defined `image/svg+xml` as the default value because a svg file that can start with a multitude of things (`<svg`, `<?xml`, a comment, …)

Fix #194, certainly #197