### PR TITLE
chore(ci): use `node-version-file` option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version-file: 'package.json'
 
       - run: npx changelogithub
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version-file: ['package.json']
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ubuntu-latest]
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       "require": "./dist/module.cjs"
     }
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "main": "./dist/module.cjs",
   "types": "./dist/module.d.ts",
   "files": [


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

setup-node can reference the engine options in package.json as the node version.

- https://github.com/actions/setup-node?tab=readme-ov-file#usage

Using the `engine` makes it easier to manage workflow versions.

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
