### PR TITLE
fix: resolve ``publicDirAbs`` correctly

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -278,6 +278,7 @@ export default defineNuxtModule<ModuleOptions>({
       ]
     }
 
+    const publicDirAbs = nuxt.options.alias[basename(nuxt.options.dir.public)]
     const serverFontsDir = resolve(nuxt.options.buildDir, 'cache', `nuxt-og-image@${version}`, '_fonts')
     // mkdir@
     const fontStorage = createStorage({
@@ -311,7 +312,7 @@ export default defineNuxtModule<ModuleOptions>({
           // resolve relative paths from public dir
           // move to assets folder as base64 and set key
           if (!f.absolutePath)
-            f.path = join(nuxt.options.rootDir, nuxt.options.dir.public, withoutLeadingSlash(f.path))
+            f.path = join(publicDirAbs, withoutLeadingSlash(f.path))
           if (!existsSync(f.path)) {
             logger.warn(`The ${f.name}:${f.weight} font was skipped because the file does not exist at path ${f.path}.`)
             return false
@@ -520,7 +521,6 @@ declare module '#nuxt-og-image/unocss-config' {
         colorPreference = colorModeOptions.fallback
       if (!colorPreference || colorPreference === 'system')
         colorPreference = 'light'
-      const publicDirAbs = nuxt.options.alias[nuxt.options.dir.public]
       const runtimeConfig = <OgImageRuntimeConfig> {
         version,
         // binding options


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

In the latest version of Nuxt, ``nuxt.options.dir.public`` may be an absolute path.