### PR TITLE
chore(ci): move renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,5 @@
+{
+  // https://github.com/nuxt/renovate-config-nuxt
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['github>nuxt/renovate-config-nuxt'],
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>nuxt/renovate-config-nuxt"
-  ]
-}


### PR DESCRIPTION
### 🔗 Linked issue

related nuxt-modules/sitemap#292

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As with Nuxt Sitemap, I moved the Renovate config to `.github/`.
Also, I rename from `renovate.json` to `renovate.json5`. `renovate.json5` is able to add comment.

- ref: https://docs.renovatebot.com/configuration-options/