### PR TITLE
fix(devtools): community template display

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -618,7 +618,7 @@ const currentPageFile = computed(() => {
                 </h3>
               </template>
               <NTip>These are the OG Image templates that belong to your project.</NTip>
-              <div class="flex flex-nowrap overflow-x-auto space-x-3 p2" style="-webkit-overflow-scrolling: touch; -ms-overflow-style: -ms-autohiding-scrollbar;">
+              <div class="flex flex-wrap overflow-x-auto space-x-3 p2" style="-webkit-overflow-scrolling: touch; -ms-overflow-style: -ms-autohiding-scrollbar;">
                 <button v-for="name in appComponents" :key="name.pascalName" class="!p-0" @click="patchOptions({ component: name.pascalName })">
                   <TemplateComponentPreview
                     :component="name"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Community OGImage templates are not visible (or scrollable) with the `flex-nowrap` class on the container.

#### Before 

![before](https://github.com/user-attachments/assets/a5545b95-4c66-4ff4-83a1-14803c099f4b)

#### After

![after](https://github.com/user-attachments/assets/0207e64d-56ca-432b-b5cd-0662ebd32b0c)
