### PR TITLE
docs: align `cacheMaxAgeSeconds` value with comment

### DIFF
--- a/docs/content/3.guides/3.cache.md
+++ b/docs/content/3.guides/3.cache.md
@@ -48,7 +48,7 @@ Alternatively, you can change the default cache time in your nuxt.config.
 export default defineNuxtConfig({
   ogImage: {
     defaults: {
-      cacheMaxAgeSeconds: 60 * 60 * 24 * 7 * 1000 // 7 days
+      cacheMaxAgeSeconds: 60 * 60 * 24 * 7 // 7 days
     }
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The `cacheMaxAgeSeconds` is defined as seconds and not as `milliseconds`. Just use the value of 7 days instead of 7.000 days.