### PR TITLE
fix: throw error when using `defineOgImage*` fns client-side

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,0 @@
-import { useLogger } from '@nuxt/kit'
-import { colorize } from 'consola/utils'
-
-export const logger = useLogger('@nuxtjs/og-image')
-
-export const gray = (s: string) => colorize('gray', s)

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -1,0 +1,10 @@
+import { createConsola } from 'consola'
+import { colorize } from 'consola/utils'
+
+export const logger = createConsola({
+  defaults: {
+    tag: '@nuxtjs/og-image',
+  },
+})
+
+export const gray = (s: string) => colorize('gray', s)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#286

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For users who don't quite understand the magic of Nuxt SSR or how OG Image tags need to work, it's quite easy to use the `defineOgImage*` composables in a way where no image is generated.

This appears when users try to call these functions client-side only, as either we'll be inserting the `og:image` payload too late for Nuxt OG Image to generate the image or inserting the tags too late for any bots to pick them up.

Previously no warning was shown and it would silently fail in these instances, this was because we were tree-shaking these composables out client-side.

This PR changes it so we avoid tree-shaking them in development, allowing us to show an error message that can be debugged.

### :heavy_check_mark: Correct Usage

```vue
<script lang="ts" setup>
defineOgImageComponent('MyComponent', {
  foo: 'bar',
})
</script>
```

```vue
<script lang="ts" setup>
// async functions, awaiting first
const someAsyncData = await myAsyncDataFunction()
defineOgImageComponent('MyComponent', {
  foo: () => someAsyncData.value.title,
})
</script>
```

```vue
<script lang="ts" setup>
// async functions, awaiting after
const someAsyncData = ref()
defineOgImageComponent('MyComponent', {
  foo: () => someAsyncData.value?.title,
})
someAsyncData.value = await myAsyncDataFunction()
</script>
```

### :x: Incorrect Usage

```vue
<script lang="ts" setup>
// onMounted is only called client-side
onMounted(() => {
  defineOgImageComponent('MyComponent', {
    foo: 'bar',
  })
})
</script>
```

```vue
<script lang="ts" setup>
// watch is only called client-side 
watch(foo, (val) => {
  defineOgImageComponent('MyComponent', {
    foo: val,
  })
})
</script>
```


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
