### PR TITLE
perf(devtools): optimize shiki bundle size

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -734,7 +734,7 @@ const currentPageFile = computed(() => {
                 SVG
               </h3>
             </template>
-            <OCodeBlock :code="debug?.svg.replaceAll('>', '>\n')" lang="html" />
+            <OCodeBlock :code="debug?.svg.replaceAll('>', '>\n')" lang="xml" />
           </OSectionBlock>
           <OSectionBlock>
             <template #text>

--- a/client/components/OCodeBlock.vue
+++ b/client/components/OCodeBlock.vue
@@ -5,7 +5,7 @@ import { renderCodeHighlight } from '../composables/shiki'
 const props = withDefaults(
   defineProps<{
     code: string
-    lang: 'json' | 'html'
+    lang: 'json' | 'xml'
     lines?: boolean
     transformRendered?: (code: string) => string
   }>(),

--- a/client/components/OCodeBlock.vue
+++ b/client/components/OCodeBlock.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import type { BundledLanguage } from 'shiki'
 import { computed } from 'vue'
 import { renderCodeHighlight } from '../composables/shiki'
 
 const props = withDefaults(
   defineProps<{
     code: string
-    lang?: BundledLanguage
+    lang: 'json' | 'html'
     lines?: boolean
     transformRendered?: (code: string) => string
   }>(),

--- a/client/composables/shiki.ts
+++ b/client/composables/shiki.ts
@@ -1,27 +1,29 @@
 import type { MaybeRef } from '@vueuse/core'
-import type { BundledLanguage, Highlighter } from 'shiki'
-import { createHighlighter } from 'shiki'
+import type { HighlighterCore } from 'shiki'
+import { createHighlighterCore } from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import { computed, ref, toValue } from 'vue'
 import { devtools } from './rpc'
 
-export const shiki = ref<Highlighter>()
+export const shiki = ref<HighlighterCore>()
 
 export async function loadShiki() {
-  // Only loading when needed
-  shiki.value = await createHighlighter({
+  shiki.value = await createHighlighterCore({
     themes: [
-      'vitesse-dark',
-      'vitesse-light',
+      import('@shikijs/themes/vitesse-light'),
+      import('@shikijs/themes/vitesse-dark'),
     ],
     langs: [
-      'html',
-      'json',
+      import('@shikijs/langs/html'),
+      import('@shikijs/langs/json'),
     ],
+    engine: createJavaScriptRegexEngine(),
   })
+
   return shiki.value
 }
 
-export function renderCodeHighlight(code: MaybeRef<string>, lang: BundledLanguage) {
+export function renderCodeHighlight(code: MaybeRef<string>, lang: 'json' | 'html') {
   return computed(() => {
     const colorMode = devtools.value?.colorMode || 'light'
     return shiki.value!.codeToHtml(toValue(code) || '', {

--- a/client/composables/shiki.ts
+++ b/client/composables/shiki.ts
@@ -14,7 +14,7 @@ export async function loadShiki() {
       import('@shikijs/themes/vitesse-dark'),
     ],
     langs: [
-      import('@shikijs/langs/html'),
+      import('@shikijs/langs/xml'),
       import('@shikijs/langs/json'),
     ],
     engine: createJavaScriptRegexEngine(),
@@ -23,7 +23,7 @@ export async function loadShiki() {
   return shiki.value
 }
 
-export function renderCodeHighlight(code: MaybeRef<string>, lang: 'json' | 'html') {
+export function renderCodeHighlight(code: MaybeRef<string>, lang: 'json' | 'xml') {
   return computed(() => {
     const colorMode = devtools.value?.colorMode || 'light'
     return shiki.value!.codeToHtml(toValue(code) || '', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,15 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0(vue@3.5.13(typescript@5.6.3))
 
+  playground:
+    dependencies:
+      nuxt-og-image:
+        specifier: workspace:*
+        version: link:..
+      nuxt-og-image-devtools:
+        specifier: workspace:*
+        version: link:../client
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -7423,7 +7432,7 @@ snapshots:
       eslint-plugin-regexp: 2.7.0(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-toml: 0.12.0(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-unicorn: 56.0.1(eslint@9.20.1(jiti@2.4.2))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@6.21.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-vue: 9.32.0(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-yml: 1.16.0(eslint@9.20.1(jiti@2.4.2))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.13)(eslint@9.20.1(jiti@2.4.2))
@@ -11865,7 +11874,7 @@ snapshots:
       semver: 7.7.1
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@6.21.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.6.3))(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
       eslint: 9.20.1(jiti@2.4.2)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
-  - .playground
+  - playground
   - client


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

|           |  gziped (`- 1.5 MB`)  | unpacked |
| :-------: | :------: | :------: |
| `v4.1.3`  |  2.1 MB  | 10.7 MB  |
| optimized | 518.6 kB |  1.7 MB  |

#### Shiki

- Use [fine grained bundle](https://shiki.style/guide/bundles#fine-grained-bundle) to only bundle needed languages and themes.
- Use [Javascript RegExp Engine](https://shiki.style/guide/regex-engines#javascript-regexp-engine).
- Use `xml` for svg highlighting (removes dependency on lang/javascript ~30kb gziped).

I will create PRs for other similar repos like `nuxt/scripts` & the seo suite once this PR is reviewed 🚀 
