### PR TITLE
fix: disabling cache by template not working

### DIFF
--- a/src/runtime/server/og-image/context.ts
+++ b/src/runtime/server/og-image/context.ts
@@ -155,9 +155,10 @@ export function extractAndNormaliseOgImageOptions(html: string): OgImageOptions 
   let options: OgImageOptions | false = false
   try {
     const payload = parse(_payload)
-    // remove empty values, allow route rules to override, these comes from template param values like title
+    // remove empty values, allow route rules to override, these come from template param values like title,
+    // but allow zero values, for example cacheMaxAgeSeconds = 0
     Object.entries(payload).forEach(([key, value]) => {
-      if (!value)
+      if (!value && value !== 0)
         delete payload[key]
     })
     options = payload


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Disabling the cache by setting `cacheMaxAgeSecond` to 0 in `defineOgImageComponent` (as per the documentation, https://nuxtseo.com/docs/og-image/guides/cache#bypassing-the-cache), for example
```typescript
defineOgImageComponent('NuxtSeo', {
  title: 'Test'
}, {
  cacheMaxAgeSeconds: 0
})
```
does not work and returns the default value (259200 seconds).

This is because when the og image options are extracted to generate the h3 context any falsy value is deleted from the payload: https://github.com/nuxt-modules/og-image/blob/0a698094e17663fcd5bfa805b91a4041ac06c0b4/src/runtime/server/og-image/context.ts#L158-L162

This seems to be intentional as the comment states, so I only added an extra check to avoid deleting options that have the value `0`.

With this change setting `cacheMaxAgeSeconds` to `0` disables the cache as expected (this can be tested by checking the cache-control header of the og image). 

