### PR TITLE
fix(prerender,i18n): broken cache key

### DIFF
--- a/src/runtime/server/og-image/context.ts
+++ b/src/runtime/server/og-image/context.ts
@@ -32,7 +32,7 @@ export function resolvePathCacheKey(e: H3Event, path: string) {
     (!basePath || basePath === '/') ? 'index' : basePath,
     hash([
       basePath,
-      siteConfig.url,
+      import.meta.prerender ? '' : siteConfig.url,
       hash(getQuery(e)),
     ]),
   ].join(':')

--- a/test/fixtures/i18n/app.vue
+++ b/test/fixtures/i18n/app.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <header>
+      <nav>
+        <ul>
+          <li>
+            <NuxtLink to="/">
+              Home
+            </NuxtLink>
+          </li>
+          <li>
+            <NuxtLink to="/no-i18n">
+              No I18n
+            </NuxtLink>
+          </li>
+        </ul>
+      </nav>
+    </header>
+    <div>Welcome to the OG Image basic demo.</div>
+    <div>Open the Nuxt DevTools OG Image tab (ctrl+alt+d) to get started.</div>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/i18n/i18n/locales/en.ts
+++ b/test/fixtures/i18n/i18n/locales/en.ts
@@ -1,3 +1,4 @@
 export default {
-  welcome: 'Welcome to I18n example',
+  welcome: 'Nuxt OG Image x I18n: EN',
+  description: 'You can modify the og:image by changing these props.',
 }

--- a/test/fixtures/i18n/i18n/locales/es.ts
+++ b/test/fixtures/i18n/i18n/locales/es.ts
@@ -1,0 +1,4 @@
+export default {
+  welcome: 'Nuxt OG Image x I18n: ES',
+  description: 'Puede modificar la og:image cambiando estas propiedades',
+}

--- a/test/fixtures/i18n/i18n/locales/fr.ts
+++ b/test/fixtures/i18n/i18n/locales/fr.ts
@@ -1,3 +1,4 @@
 export default {
-  welcome: 'Bienvenue à l\'exemple i18n',
+  welcome: 'Nuxt OG Image x I18n: FR',
+  description: 'Vous pouvez modifier l\'og:image en changeant ces propriétés',
 }

--- a/test/fixtures/i18n/nuxt.config.ts
+++ b/test/fixtures/i18n/nuxt.config.ts
@@ -13,11 +13,9 @@ export default defineNuxtConfig({
     debug: true,
   },
   i18n: {
-    baseUrl: 'https://nuxtseo.com',
-    detectBrowserLanguage: false,
+    // baseUrl: 'https://nuxtseo.com',
     defaultLocale: 'en',
     langDir: 'locales',
-    strategy: 'prefix',
     locales: [
       {
         code: 'en',

--- a/test/fixtures/i18n/pages/index.vue
+++ b/test/fixtures/i18n/pages/index.vue
@@ -1,19 +1,28 @@
 <script setup lang="ts">
-import { prerenderRoutes } from '#imports'
+import { switchLocalePath, useI18n } from '#imports'
 
-prerenderRoutes([
-  '/en/dynamic/foo',
-  '/en/dynamic/bar',
-])
+const { locales, t } = useI18n()
 
-const i18n = useNuxtApp().$i18n
-defineOgImage({
-  title: i18n.t('welcome'),
+defineOgImageComponent('NuxtSeo', {
+  title: t('welcome'),
+  description: t('description'),
+  colorMode: 'dark',
 })
 </script>
 
 <template>
   <div>
     <h1>{{ $t('welcome') }}</h1>
+    <div>
+      <NuxtLink
+        v-for="locale in locales"
+        :key="locale.code"
+        :to="switchLocalePath(locale.code)"
+      >
+        <button type="button">
+          {{ locale.code }}
+        </button>
+      </NuxtLink>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

https://github.com/nuxt-modules/og-image/issues/326

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The cache key is changing as the site config URL changes at different stages based on the Nuxt I18n `baseUrl`.

To fix this we omit the site URL segment in the cache generation when prerendering as there can only be a single host 