### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/src/runtime/server/og-image/templates/html.ts
+++ b/src/runtime/server/og-image/templates/html.ts
@@ -114,7 +114,11 @@ svg[data-emoji] {
   })
 
   // need to remove ALL script tags from the html
-  html = html.replaceAll(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+  let previousHtml;
+  do {
+    previousHtml = html;
+    html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+  } while (html !== previousHtml);
 
   const headChunk = await renderSSRHead(head)
   return `<!DOCTYPE html>


### PR DESCRIPTION
Potential fix for [https://github.com/nuxt-modules/og-image/security/code-scanning/2](https://github.com/nuxt-modules/og-image/security/code-scanning/2)

To fix the problem, we need to ensure that all instances of `<script>` tags are removed from the HTML string, even if they are nested or malformed. The best way to achieve this is to apply the regular expression replacement repeatedly until no more replacements can be performed. This approach ensures that all script tags are effectively removed.

We will modify the code on line 117 to repeatedly apply the regular expression replacement until the HTML string no longer changes. This will involve using a loop to check for changes in the HTML string after each replacement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
