### PR TITLE
chore: safer string escape

### DIFF
--- a/client/components/TemplateComponentPreview.vue
+++ b/client/components/TemplateComponentPreview.vue
@@ -24,7 +24,7 @@ const creditName = computed(() => {
   return props.component.credits?.split('<')[0].trim()
 })
 const creditSite = computed(() => {
-  return props.component.credits?.split('<')[1].trim().replace('>', '')
+  return props.component.credits?.split('<')[1].trim().replace(/>/g, '')
 })
 
 const loadStats = ref<{ timeTaken: string, sizeKb: string }>()


### PR DESCRIPTION
Potential fix for [https://github.com/nuxt-modules/og-image/security/code-scanning/4](https://github.com/nuxt-modules/og-image/security/code-scanning/4)

To fix the problem, we need to ensure that all occurrences of the '>' character are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we will replace the line that uses `replace('>', '')` with `replace(/>/g, '')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
