### PR TITLE
chore: re-order escaping

### DIFF
--- a/src/runtime/server/util/encoding.ts
+++ b/src/runtime/server/util/encoding.ts
@@ -7,7 +7,6 @@ export function htmlDecodeQuotes(html: string) {
 export function decodeHtml(html: string) {
   return html.replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
     // money symbols
     .replace(/&cent;/g, '¢')
     .replace(/&pound;/g, '£')
@@ -22,6 +21,7 @@ export function decodeHtml(html: string) {
     .replace(/&#(\d+);/g, (full, int) => {
       return String.fromCharCode(Number.parseInt(int))
     })
+    .replace(/&amp;/g, '&')
 }
 export function decodeObjectHtmlEntities(obj: Record<string, string | any>) {
   Object.entries(obj).forEach(([key, value]) => {


### PR DESCRIPTION
Potential fix for [https://github.com/nuxt-modules/og-image/security/code-scanning/5](https://github.com/nuxt-modules/og-image/security/code-scanning/5)

To fix the problem, we need to ensure that the `&amp;` entity is decoded last in the `decodeHtml` function. This will prevent any double unescaping issues by ensuring that `&amp;` is not prematurely converted to `&` before other entities are fully decoded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
