### PR TITLE
feat(devtools): eject templates

### DIFF
--- a/client/components/CreateOgImageDialog.vue
+++ b/client/components/CreateOgImageDialog.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import {
+  RadioGroup,
+  RadioGroupLabel,
+  RadioGroupOption,
+} from '@headlessui/vue'
+import { fetchGlobalDebug } from '~/composables/fetch'
+import { CreateOgImageDialogPromise } from '../composables/templates'
+
+function handleClose(a: any, resolve: (value: boolean) => void) {
+  resolve(false)
+}
+
+const { data: globalDebug } = await fetchGlobalDebug()
+
+const component = ref(globalDebug.value?.runtimeConfig?.componentDirs?.[0])
+</script>
+
+<template>
+  <CreateOgImageDialogPromise v-slot="{ resolve, args }">
+    <div my-10>
+      <NDialog :model-value="true" style="max-height: 80vh;" @update:model-value="handleClose('a', resolve)" @close="handleClose('b', resolve)">
+        <div flex="~ col gap-2" w-200 p4 border="t base">
+          <h2 text-xl class="text-primary">
+            Eject Component
+          </h2>
+
+          <p>Copy a community template to a OG Image component directory in your project. You can configure directories using <span class="opacity-50">componentDirs</span> in nuxt.config.</p>
+
+          <RadioGroup v-model="component">
+            <div class="mb-3 mt-6 font-medium text-sm">
+              <RadioGroupLabel>Choose Output Path</RadioGroupLabel>
+            </div>
+            <div class="space-y-2">
+              <RadioGroupOption
+                v-for="dir in globalDebug?.runtimeConfig?.componentDirs"
+                :key="dir"
+                v-slot="{ active, checked }"
+                as="template"
+                :value="dir"
+              >
+                <div
+                  :class="[
+                    active
+                      ? 'ring-2 ring-white/60 ring-offset-2 ring-offset-sky-300'
+                      : '',
+                    checked ? 'bg-sky-700/75 text-white ' : 'bg-white ',
+                  ]"
+                  class="relative flex cursor-pointer rounded-lg px-5 py-4 shadow-md focus:outline-none"
+                >
+                  <div class="flex w-full items-center justify-between">
+                    <div class="flex items-center">
+                      <div class="text-sm">
+                        <RadioGroupLabel
+                          as="p"
+                          :class="checked ? 'text-white' : 'text-gray-900'"
+                          class="font-medium"
+                        >
+                          ./components/{{ dir }}/{{ args[0] }}.vue
+                        </RadioGroupLabel>
+                      </div>
+                    </div>
+                    <div v-show="checked" class="shrink-0 text-white">
+                      <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none">
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="12"
+                          fill="#fff"
+                          fill-opacity="0.2"
+                        />
+                        <path
+                          d="M7 13l3 3 7-7"
+                          stroke="#fff"
+                          stroke-width="1.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </RadioGroupOption>
+            </div>
+          </RadioGroup>
+
+          <div flex="~ gap-3" mt2 justify-end>
+            <NButton @click="resolve(false)">
+              Cancel
+            </NButton>
+            <NButton n="solid" capitalize class="n-blue px-3 py-1.5 rounded" @click="resolve(component)">
+              Create Component
+            </NButton>
+          </div>
+        </div>
+      </NDialog>
+    </div>
+  </CreateOgImageDialogPromise>
+</template>

--- a/client/components/TemplateComponentPreview.vue
+++ b/client/components/TemplateComponentPreview.vue
@@ -32,7 +32,7 @@ const loadStats = ref<{ timeTaken: string, sizeKb: string }>()
 
 <template>
   <div class="group">
-    <div class="opacity-70 text-sm transition group-hover:opacity-100">
+    <div class="opacity-70 flex px-3 justify-between text-sm transition group-hover:opacity-100">
       <NLink :href="creditSite" external class="underline">
         {{ component.pascalName }}
       </NLink>

--- a/client/composables/fetch.ts
+++ b/client/composables/fetch.ts
@@ -42,7 +42,7 @@ export function fetchPathDebug() {
 }
 
 export function fetchGlobalDebug() {
-  return useAsyncData<{ runtimeConfig: OgImageRuntimeConfig, componentNames: OgImageComponent[] }>(() => {
+  return useAsyncData<{ runtimeConfig: OgImageRuntimeConfig, componentNames: OgImageComponent[] }>('global-debug', () => {
     if (!appFetch.value)
       return { runtimeConfig: {} }
     return appFetch.value('/__og-image__/debug.json')

--- a/client/composables/rpc.ts
+++ b/client/composables/rpc.ts
@@ -1,4 +1,5 @@
 import type { NuxtDevtoolsClient, NuxtDevtoolsIframeClient } from '@nuxt/devtools-kit/types'
+import type { BirpcReturn } from 'birpc'
 import type { $Fetch } from 'nitropack'
 import type { ClientFunctions, ServerFunctions } from '../../src/rpc-types'
 import { onDevtoolsClientConnected } from '@nuxt/devtools-kit/iframe-client'
@@ -12,6 +13,8 @@ export const devtools = ref<NuxtDevtoolsClient>()
 export const devtoolsClient = ref<NuxtDevtoolsIframeClient>()
 
 export const colorMode = ref<'dark' | 'light'>('dark')
+
+export const ogImageRpc = ref<BirpcReturn<ServerFunctions>>()
 
 onDevtoolsClientConnected(async (client) => {
   appFetch.value = client.host.app.$fetch
@@ -28,7 +31,7 @@ onDevtoolsClientConnected(async (client) => {
   })
   devtools.value = client.devtools
   devtoolsClient.value = client
-  client.devtools.extendClientRpc<ServerFunctions, ClientFunctions>('nuxt-og-image', {
+  ogImageRpc.value = client.devtools.extendClientRpc<ServerFunctions, ClientFunctions>('nuxt-og-image', {
     refreshRouteData(path) {
       // if path matches
       if (devtoolsClient.value?.host.nuxt.vueApp.config?.globalProperties?.$route.matched[0].components?.default.__file.includes(path) || path.endsWith('.md'))

--- a/client/composables/templates.ts
+++ b/client/composables/templates.ts
@@ -1,0 +1,3 @@
+import { createTemplatePromise } from '@vueuse/core'
+
+export const CreateOgImageDialogPromise = createTemplatePromise<boolean, [any]>()

--- a/src/module.ts
+++ b/src/module.ts
@@ -542,6 +542,7 @@ export default defineNuxtModule<ModuleOptions>({
       },
       options: { mode: 'server' },
     })
+
     nuxt.options.nitro.virtual = nuxt.options.nitro.virtual || {}
     nuxt.options.nitro.virtual['#og-image-virtual/component-names.mjs'] = () => {
       return `export const componentNames = ${JSON.stringify(ogImageComponentCtx.components)}`
@@ -649,6 +650,9 @@ declare module '#og-image/unocss-config' {
         strictNuxtContentPaths: config.strictNuxtContentPaths,
         // @ts-expect-error runtime type
         isNuxtContentDocumentDriven: config.strictNuxtContentPaths || !!nuxt.options.content?.documentDriven,
+      }
+      if (nuxt.options.dev) {
+        runtimeConfig.componentDirs = config.componentDirs
       }
       // @ts-expect-error untyped
       nuxt.hooks.callHook('nuxt-og-image:runtime-config', runtimeConfig)

--- a/src/rpc-types.ts
+++ b/src/rpc-types.ts
@@ -1,4 +1,6 @@
-export interface ServerFunctions {}
+export interface ServerFunctions {
+  ejectCommunityTemplate: (path: string) => Promise<string>
+}
 
 export interface ClientFunctions {
   refresh: () => void


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

https://github.com/nuxt-modules/og-image/issues/343

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allows you click the "Eject" button in the devtools to create the current component in your own directory. This is useful as you don't need to remember what the og image component dirs are and you don't need to manually copy+paste the file over.

![image](https://github.com/user-attachments/assets/8902363c-ee1f-4764-9627-da28dba466eb)


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
