### PR TITLE
fix: handle undefined `link`/`style` in server component response

### DIFF
--- a/src/runtime/server/og-image/satori/transforms/inlineCss.ts
+++ b/src/runtime/server/og-image/satori/transforms/inlineCss.ts
@@ -9,10 +9,10 @@ export async function applyInlineCss(ctx: OgImageRenderEventContext, island: Nux
   let html = island.html
   // inline styles from the island
   // empty.mjs returns an __unenv__ object as true
-  let css = island.head.style.map(s => s.innerHTML).filter(Boolean).join('\n')
+  let css = island.head.style?.map(s => s.innerHTML).filter(Boolean).join('\n') || ''
   // TODO this has an island bug in that it's rendering styles for components that aren't used because they're used in app.vue
   // TODO need to make an upstream issue
-  const componentInlineStyles = island.head.link.filter(l => l.href.startsWith('/_nuxt/components') && l.href.replaceAll('/', '').includes(ctx.options.component))
+  const componentInlineStyles = island.head.link?.filter(l => l.href.startsWith('/_nuxt/components') && l.href.replaceAll('/', '').includes(ctx.options.component)) || []
   // stricter opt-in for runtime
   if (!import.meta.prerender && !componentInlineStyles.length) {
     return false


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this is a change in nuxt v4 - these arrays are now optional

(opened https://github.com/nuxt-modules/og-image/pull/369 to address the snapshot failure, which also occurs on ecosystem-ci)