### PR TITLE
fix: reworked `sharp` compatibility checks for JPEG rendering

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -531,7 +531,7 @@ async function ejectComponent(component: string) {
             <Pane size="60" class="flex h-full justify-center items-center relative n-panel-grids-center pr-4" style="padding-top: 30px;">
               <div class="flex justify-between items-center text-sm w-full absolute pr-[30px] top-0 left-0">
                 <div class="flex items-center text-lg space-x-1 w-[100px]">
-                  <NButton v-if="!!globalDebug?.compatibility?.sharp || renderer === 'chromium'" icon="carbon:jpg" :class="imageFormat === 'jpeg' || imageFormat === 'jpg' ? 'border border-zinc-300 dark:border-zinc-700 opacity-100' : ''" @click="patchOptions({ extension: 'jpg' })" />
+                  <NButton v-if="!!globalDebug?.compatibility?.sharp || renderer === 'chromium' || options?.extension === 'jpeg'" icon="carbon:jpg" :class="imageFormat === 'jpeg' || imageFormat === 'jpg' ? 'border border-zinc-300 dark:border-zinc-700 opacity-100' : ''" @click="patchOptions({ extension: 'jpg' })" />
                   <NButton icon="carbon:png" :class="imageFormat === 'png' ? 'border border-zinc-300 dark:border-zinc-700 opacity-100' : ''" @click="patchOptions({ extension: 'png' })" />
                   <NButton v-if="renderer !== 'chromium'" icon="carbon:svg" :class="imageFormat === 'svg' ? 'border border-zinc-300 dark:border-zinc-700 opacity-100' : ''" @click="patchOptions({ extension: 'svg' })" />
                   <NButton v-if="!isPageScreenshot" icon="carbon:html" :class="imageFormat === 'html' ? 'border border-zinc-300 dark:border-zinc-700 opacity-100' : ''" @click="patchOptions({ extension: 'html' })" />

--- a/playground/components/OgImage/WithImage.vue
+++ b/playground/components/OgImage/WithImage.vue
@@ -24,8 +24,8 @@ const containerStyles = {
     <div :style="{ position: 'absolute', top: '170px', left: '250px', fontSize: '25px', display: 'flex', alignItems: 'center' }">
       <img src="/harlan-wilton.jpeg" width="100" height="100" :style="{ borderRadius: '12px', marginRight: '8px' }">
     </div>
-    <img src="harlan-wilton.jpeg" width="100" height="100" :style="{ borderRadius: '12px', marginRight: '8px' }">
-    <img src="assets/static/images/picture.jpg" width="100" height="100" :style="{ borderRadius: '12px', marginRight: '8px' }">
+    <img src="/harlan-wilton.jpeg" width="100" height="100" :style="{ borderRadius: '12px', marginRight: '8px' }">
+    <img src="/assets/static/images/picture.jpg" width="100" height="100" :style="{ borderRadius: '12px', marginRight: '8px' }">
     <img src="https://avatars.githubusercontent.com/u/5326365?v=4" width="200" height="200" alt="absolute test">
   </div>
 </template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -55,6 +55,7 @@ export default defineNuxtConfig({
     plugins: ['plugins/hooks.ts'],
     prerender: {
       routes: [
+        '/satori/jpeg',
         '/chromium/component',
         '/chromium/delayed',
         '/chromium/screenshot',

--- a/playground/pages/satori/jpeg.vue
+++ b/playground/pages/satori/jpeg.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+import { defineOgImage } from '#imports'
+
+defineOgImage({
+  extension: 'jpeg',
+  sharp: {
+    quality: 10,
+    progressive: true,
+  },
+  props: {
+    title: 'This is a long title 😮 that will exceed 60 chars',
+    description: 'And perhpas a long description? 😮 Yup, here it is. A max of 100 characters, will see. Guess we can go really long, maybe even 3 lines, will see what happens now.',
+  },
+})
+</script>
+
+<template>
+  <div>inline</div>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -643,7 +643,6 @@ declare module '#og-image/unocss-config' {
         colorPreference = 'light'
       const runtimeConfig = <OgImageRuntimeConfig> {
         version,
-        compatibility: config.compatibility || {},
         // binding options
         satoriOptions: config.satoriOptions || {},
         resvgOptions: config.resvgOptions || {},

--- a/src/runtime/server/og-image/satori/renderer.ts
+++ b/src/runtime/server/og-image/satori/renderer.ts
@@ -107,8 +107,9 @@ async function createJpeg(event: OgImageRenderEventContext) {
     console.error('Sharp dependency is not accessible. Please check you have it installed and are using a compatible runtime. Falling back to png.')
     return createPng(event)
   }
-  return sharp(svgBuffer, defu(event.options.sharp, sharpOptions))
-    .jpeg(sharp as JpegOptions)
+  const options = defu(event.options.sharp, sharpOptions)
+  return sharp(svgBuffer, options)
+    .jpeg(options as JpegOptions)
     .toBuffer()
 }
 

--- a/src/runtime/server/og-image/satori/renderer.ts
+++ b/src/runtime/server/og-image/satori/renderer.ts
@@ -9,6 +9,8 @@ import { normaliseFontInput, useOgImageRuntimeConfig } from '../../../shared'
 import { loadFont } from './font'
 import { useResvg, useSatori, useSharp } from './instances'
 import { createVNodes } from './vnodes'
+// @ts-expect-error untyped
+import compatibility from '#og-image/compatibility'
 
 const fontPromises: Record<string, Promise<ResolvedFontConfig>> = {}
 
@@ -78,9 +80,8 @@ async function createPng(event: OgImageRenderEventContext) {
 }
 
 async function createJpeg(event: OgImageRenderEventContext) {
-  const { sharpOptions, compatibility } = useOgImageRuntimeConfig()
-  const key = import.meta.prerender ? 'prerender' : 'runtime'
-  if (compatibility[key].sharp === false) {
+  const { sharpOptions } = useOgImageRuntimeConfig()
+  if (compatibility.sharp === false) {
     if (import.meta.dev) {
       throw new Error('Sharp dependency is not accessible. Please check you have it installed and are using a compatible runtime.')
     }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -28,7 +28,6 @@ export type IconifyEmojiIconSets = 'twemoji' | 'noto' | 'fluent-emoji' | 'fluent
 
 export interface OgImageRuntimeConfig {
   version: string
-  compatibility: CompatibilityFlagEnvOverrides
   satoriOptions: SatoriOptions
   resvgOptions: ResvgRenderOptions
   sharpOptions: SharpOptions

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -7,7 +7,7 @@ import type { NitroOptions } from 'nitropack'
 import type { NitroApp } from 'nitropack/types'
 import type { SatoriOptions } from 'satori'
 import type { html } from 'satori-html'
-import type { SharpOptions } from 'sharp'
+import type { JpegOptions, SharpOptions } from 'sharp'
 import type { Ref } from 'vue'
 
 export interface OgImageRenderEventContext {
@@ -28,6 +28,7 @@ export type IconifyEmojiIconSets = 'twemoji' | 'noto' | 'fluent-emoji' | 'fluent
 
 export interface OgImageRuntimeConfig {
   version: string
+  compatibility: CompatibilityFlagEnvOverrides
   satoriOptions: SatoriOptions
   resvgOptions: ResvgRenderOptions
   sharpOptions: SharpOptions
@@ -130,7 +131,7 @@ export interface OgImageOptions<T extends keyof OgImageComponents = 'NuxtSeo'> {
   resvg?: ResvgRenderOptions
   satori?: SatoriOptions
   screenshot?: Partial<ScreenshotOptions>
-  sharp?: SharpOptions
+  sharp?: SharpOptions & JpegOptions
   fonts?: InputFontConfig[]
   // cache
   cacheMaxAgeSeconds?: number

--- a/test/integration/dev-debugging.test.ts
+++ b/test/integration/dev-debugging.test.ts
@@ -256,17 +256,12 @@ describe('dev', () => {
     const debug = await $fetch('/__og-image__/debug.json')
     delete debug.runtimeConfig.baseCacheKey
     delete debug.runtimeConfig.version
+    delete debug.runtimeConfig.compatibility
     delete debug.componentNames
     delete debug.baseCacheKey
-    delete debug.compatibility.chromium // github ci will have playwright
-    delete debug.compatibility.sharp // github ci will have playwright
+    delete debug.compatibility // github ci will have playwright
     expect(debug).toMatchInlineSnapshot(`
       {
-        "compatibility": {
-          "css-inline": "node",
-          "resvg": "node",
-          "satori": "node",
-        },
         "runtimeConfig": {
           "app": {
             "baseURL": "/",

--- a/test/integration/dev-debugging.test.ts
+++ b/test/integration/dev-debugging.test.ts
@@ -259,30 +259,19 @@ describe('dev', () => {
     delete debug.componentNames
     delete debug.baseCacheKey
     delete debug.compatibility.chromium // github ci will have playwright
+    delete debug.compatibility.sharp // github ci will have playwright
     expect(debug).toMatchInlineSnapshot(`
       {
         "compatibility": {
           "css-inline": "node",
           "resvg": "node",
           "satori": "node",
-          "sharp": "node",
         },
         "runtimeConfig": {
           "app": {
             "baseURL": "/",
           },
           "colorPreference": "light",
-          "compatibility": {
-            "dev": {
-              "chromium": "chrome-launcher",
-            },
-            "prerender": {
-              "chromium": "",
-            },
-            "runtime": {
-              "chromium": "",
-            },
-          },
           "componentDirs": [
             "OgImage",
             "og-image",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
https://github.com/nuxt-modules/og-image/issues/367

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

JPEG support via `sharp` is still quite unstable, this PR aims to get it slightly more stable by adding several checks when we try and render at runtime.

We also loosen up the compatibility checks. If `sharp` is installed and the target supports it, then we try and see if it can be imported, if so, then we switch to it.

There's cases where `sharp` may be installed and supported but can't be imported, this is quite common for CI environments where it can't install the correct binary needed.

This _might_ introduce some regressions related to these resolutions but hoppefully the get caught with the `catch(() => {})`, it's difficult to test it.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
