### PR TITLE
test: configure `dir.public` for app-dir test (for v4 compat)

### DIFF
--- a/test/fixtures/app-dir/nuxt.config.ts
+++ b/test/fixtures/app-dir/nuxt.config.ts
@@ -11,6 +11,9 @@ export default defineNuxtConfig({
   ogImage: {
     debug: true,
   },
+  dir: {
+    public: 'app/public',
+  },
   srcDir: 'app/',
   devtools: { enabled: false },
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this addresses [an ecosystem-ci failure](https://github.com/nuxt/ecosystem-ci/actions/runs/15733079061/job/44338650528), because in v4, `public/` is not inside the srcDir, but inside the rootDir, by default.