### PR TITLE
fix: handle _query in og-image without breaking render path

### DIFF
--- a/src/runtime/server/og-image/context.ts
+++ b/src/runtime/server/og-image/context.ts
@@ -89,22 +89,23 @@ export async function resolveContext(e: H3Event): Promise<H3Error | OgImageRende
     }
   }
   queryParams = separateProps(queryParams)
-  let basePath = withoutTrailingSlash(path
+  const basePath = withoutTrailingSlash(path
     .replace(`/__og-image__/image`, '')
     .replace(`/__og-image__/static`, '')
     .replace(`/og.${extension}`, ''),
   )
-  if (queryParams._query && typeof queryParams._query === 'object')
-    basePath = withQuery(basePath, queryParams._query)
+  const basePathWithQuery = queryParams._query && typeof queryParams._query === 'object'
+    ? withQuery(basePath, queryParams._query)
+    : basePath
   const isDebugJsonPayload = extension === 'json' && runtimeConfig.debug
-  const key = resolvePathCacheKey(e, basePath)
+  const key = resolvePathCacheKey(e, basePathWithQuery)
   let options: OgImageOptions | null | undefined = queryParams.options as OgImageOptions
   if (!options) {
     if (import.meta.prerender) {
       options = await prerenderOptionsCache!.getItem(key)
     }
     if (!options) {
-      const payload = await fetchPathHtmlAndExtractOptions(e, basePath, key)
+      const payload = await fetchPathHtmlAndExtractOptions(e, basePathWithQuery, key)
       if (payload instanceof Error)
         return payload
       options = payload


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #402 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Stopped `_query` parameter from being passed to renderers
<!-- Why is this change required? What problem does it solve? -->
Before the fix, using the chromium renderer, 404s were thrown when `_query` was provided as a parameter with valid JSON