### PR TITLE
fix(satori): encoding bug for array text children

### DIFF
--- a/src/runtime/server/og-image/satori/plugins/encoding.ts
+++ b/src/runtime/server/og-image/satori/plugins/encoding.ts
@@ -2,21 +2,29 @@ import type { VNode } from '../../../../types'
 import { decodeHtml } from '../../../util/encoding'
 import { defineSatoriTransformer } from '../utils'
 
-// automatically add missing flex rules
 export default defineSatoriTransformer([
-  // clean up
+  // clean up vue inspector data attributes
   {
     filter: (node: VNode) => node.props?.['data-v-inspector'],
     transform: (node: VNode) => {
       delete node.props['data-v-inspector']
     },
   },
+  // decode HTML entities in string children
   {
     filter: (node: VNode) => typeof node.props?.children === 'string',
     transform: (node: VNode) => {
-      // for the payload, we unencode any html
-      // unescape all html tokens
       node.props.children = decodeHtml(node.props.children as string)
+    },
+  },
+  // decode HTML entities in array children (text nodes with siblings)
+  {
+    filter: (node: VNode) => Array.isArray(node.props?.children),
+    transform: (node: VNode) => {
+      // @ts-expect-error untyped
+      node.props.children = (node.props.children as (string | VNode)[]).map(
+        child => typeof child === 'string' ? decodeHtml(child) : child,
+      )
     },
   },
 ])

--- a/test/unit/encoding.test.ts
+++ b/test/unit/encoding.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import encoding from '../../src/runtime/server/og-image/satori/plugins/encoding'
+import { decodeHtml } from '../../src/runtime/server/util/encoding'
+
+describe('encoding', () => {
+  describe('decodeHtml', () => {
+    it('decodes common html entities', () => {
+      expect(decodeHtml('&lt;test&gt;')).toBe('<test>')
+      expect(decodeHtml('&amp;')).toBe('&')
+      expect(decodeHtml('&quot;')).toBe('"')
+      expect(decodeHtml('&#39;')).toBe('\'')
+    })
+
+    it('decodes numeric entities', () => {
+      expect(decodeHtml('&#60;')).toBe('<')
+      expect(decodeHtml('&#62;')).toBe('>')
+    })
+  })
+
+  describe('encoding plugin - text with siblings', () => {
+    const [_inspectorTransform, stringTransform, arrayTransform] = encoding
+
+    it('decodes string children', () => {
+      const node = { props: { children: '&lt;test&gt;' } }
+      expect(stringTransform.filter(node)).toBe(true)
+      stringTransform.transform(node, {} as any)
+      expect(node.props.children).toBe('<test>')
+    })
+
+    it('decodes strings in array children (text with siblings)', () => {
+      const node = {
+        props: {
+          children: [
+            '&lt;a&gt;',
+            { type: 'p', props: { children: 'elem' } },
+            '&lt;b&gt;',
+          ],
+        },
+      }
+      expect(arrayTransform.filter(node)).toBe(true)
+      arrayTransform.transform(node, {} as any)
+      expect(node.props.children).toEqual([
+        '<a>',
+        { type: 'p', props: { children: 'elem' } },
+        '<b>',
+      ])
+    })
+
+    it('handles array with null (comments become null)', () => {
+      const node = {
+        props: {
+          children: [null, '&lt;test&gt;'],
+        },
+      }
+      expect(arrayTransform.filter(node)).toBe(true)
+      arrayTransform.transform(node, {} as any)
+      expect(node.props.children).toEqual([null, '<test>'])
+    })
+
+    it('handles array with only VNodes (no text)', () => {
+      const node = {
+        props: {
+          children: [
+            { type: 'p', props: { children: 'a' } },
+            { type: 'p', props: { children: 'b' } },
+          ],
+        },
+      }
+      expect(arrayTransform.filter(node)).toBe(true)
+      arrayTransform.transform(node, {} as any)
+      // Should not throw, VNodes unchanged
+      expect(node.props.children).toEqual([
+        { type: 'p', props: { children: 'a' } },
+        { type: 'p', props: { children: 'b' } },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#376
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

It wasn't properly encoding whee thre were multiple children text nodes.