### PR TITLE
fix: dynamic runtime cache storage

### DIFF
--- a/docs/content/3.guides/3.cache.md
+++ b/docs/content/3.guides/3.cache.md
@@ -88,6 +88,43 @@ export default defineNuxtConfig({
 })
 ````
 
+### Using Runtime Config
+
+If you need to configure the cache storage with runtime environment variables (e.g., for different Redis hosts per environment), you can mount your own storage driver and reference it by key.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  ogImage: {
+    // Reference your own storage mount by key
+    runtimeCacheStorage: 'og-image-cache'
+  }
+})
+```
+
+Then mount the storage in a Nitro plugin where you have access to runtime config:
+
+```ts [server/plugins/og-image-cache.ts]
+import redisDriver from 'unstorage/drivers/redis'
+
+export default defineNitroPlugin(() => {
+  const config = useRuntimeConfig()
+
+  const driver = redisDriver({
+    base: 'og-image',
+    host: config.redis.host,
+    port: config.redis.port,
+    password: config.redis.password,
+  })
+
+  useStorage().mount('og-image-cache', driver)
+})
+```
+
+This approach lets you:
+- Use environment variables for connection details
+- Share a single Redis connection across multiple features
+- Configure the driver dynamically at runtime
+
 ## Cache Time
 
 You can change the cache time of an image by providing `cacheMaxAgeSeconds` in milliseconds when defining the image.

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -12,7 +12,7 @@ import { applyNitroPresetCompatibility, getPresetNitroPresetCompatibility, resol
 export async function setupBuildHandler(config: ModuleOptions, resolve: Resolver, nuxt: Nuxt = useNuxt()) {
   nuxt.options.nitro.storage = nuxt.options.nitro.storage || {}
   if (typeof config.runtimeCacheStorage === 'object')
-    nuxt.options.nitro.storage['og-image'] = config.runtimeCacheStorage
+    nuxt.options.nitro.storage['nuxt-og-image'] = config.runtimeCacheStorage
 
   nuxt.hooks.hook('nitro:config', async (nitroConfig) => {
     await applyNitroPresetCompatibility(nitroConfig, { compatibility: config.compatibility?.runtime, resolve })

--- a/src/module.ts
+++ b/src/module.ts
@@ -110,17 +110,18 @@ export interface ModuleOptions {
    */
   componentOptions?: Pick<AddComponentOptions, 'global'>
   /**
-   * Modify the cache behavior.
-   *
-   * Passing a boolean will enable or disable the runtime cache with the default options.
-   *
-   * Providing a record will allow you to configure the runtime cache fully.
+   * Configure the runtime cache storage for generated OG images.
+   * - `true` - Use Nitro's default cache storage (default)
+   * - `false` - Disable caching
+   * - `string` - Use a custom storage mount key (e.g., `'redis'`). You must mount the storage yourself via a Nitro plugin.
+   * - `object` - Provide a driver config that the module will mount for you (build-time only)
    *
    * @default true
    * @see https://nitro.unjs.io/guide/storage#mountpoints
-   * @example { driver: 'redis', host: 'localhost', port: 6379, password: 'password' }
+   * @example runtimeCacheStorage: 'redis' // Use your own mounted 'redis' storage
+   * @example runtimeCacheStorage: { driver: 'redis', host: 'localhost', port: 6379 }
    */
-  runtimeCacheStorage: boolean | (Record<string, any> & {
+  runtimeCacheStorage: boolean | string | (Record<string, any> & {
     driver: string
   })
   /**
@@ -694,14 +695,28 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     const cacheEnabled = typeof config.runtimeCacheStorage !== 'undefined' && config.runtimeCacheStorage !== false
-    const runtimeCacheStorage = typeof config.runtimeCacheStorage === 'boolean' ? 'default' : config.runtimeCacheStorage.driver
-    let baseCacheKey: string | false = runtimeCacheStorage === 'default' ? `/cache/nuxt-og-image/${version}` : `/nuxt-og-image/${version}`
+    let baseCacheKey: string | false
+    if (config.runtimeCacheStorage === true) {
+      // default: use nitro's built-in cache storage
+      baseCacheKey = `/cache/nuxt-og-image/${version}`
+    }
+    else if (typeof config.runtimeCacheStorage === 'string') {
+      // string: user provides their own storage mount key
+      baseCacheKey = `/${config.runtimeCacheStorage}/nuxt-og-image/${version}`
+    }
+    else if (typeof config.runtimeCacheStorage === 'object') {
+      // object: module mounts the storage
+      baseCacheKey = `/nuxt-og-image/${version}`
+      if (!nuxt.options.dev) {
+        nuxt.options.nitro.storage = nuxt.options.nitro.storage || {}
+        nuxt.options.nitro.storage['nuxt-og-image'] = config.runtimeCacheStorage
+      }
+    }
+    else {
+      baseCacheKey = false
+    }
     if (!cacheEnabled)
       baseCacheKey = false
-    if (!nuxt.options.dev && config.runtimeCacheStorage && typeof config.runtimeCacheStorage === 'object') {
-      nuxt.options.nitro.storage = nuxt.options.nitro.storage || {}
-      nuxt.options.nitro.storage['nuxt-og-image'] = config.runtimeCacheStorage
-    }
 
     // Build cache for CI persistence (absolute path)
     const buildCachePath = typeof config.buildCache === 'object' && config.buildCache.base


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Fixes #179
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allows overriding the runtime cache storage at runtime.

If you need to configure the cache storage with runtime environment variables (e.g., for different Redis hosts per environment), you can mount your own storage driver and reference it by key.

```ts [nuxt.config.ts]
export default defineNuxtConfig({
  ogImage: {
    // Reference your own storage mount by key
    runtimeCacheStorage: 'og-image-cache'
  }
})
```

Then mount the storage in a Nitro plugin where you have access to runtime config:

```ts [server/plugins/og-image-cache.ts]
import redisDriver from 'unstorage/drivers/redis'
export default defineNitroPlugin(() => {
  const config = useRuntimeConfig()
  const driver = redisDriver({
    base: 'og-image',
    host: config.redis.host,
    port: config.redis.port,
    password: config.redis.password,
  })
  useStorage().mount('og-image-cache', driver)
})
```

This approach lets you:
- Use environment variables for connection details
- Share a single Redis connection across multiple features
- Configure the driver dynamically at runtime


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
