### PR TITLE
fix: always fallback to emoji fetching in edge runtimes

### DIFF
--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -33,6 +33,7 @@ export const NodeRuntime: RuntimeCompatibilitySchema = {
   'satori': 'node',
   'takumi': 'node',
   'sharp': 'node', // will be disabled if they're missing the dependency
+  'emoji': 'local', // can bundle icons, no size constraints
 }
 
 const NodeDevRuntime: RuntimeCompatibilitySchema = {
@@ -47,6 +48,7 @@ const cloudflare: RuntimeCompatibilitySchema = {
   'satori': 'node',
   'takumi': 'wasm',
   'sharp': false,
+  'emoji': 'fetch', // edge size limits - use API instead of bundling 24MB icons
   'wasm': {
     esmImport: true,
     lazy: true,
@@ -59,6 +61,7 @@ const awsLambda: RuntimeCompatibilitySchema = {
   'satori': 'node',
   'takumi': 'node',
   'sharp': false, // 0.33.x has issues
+  'emoji': 'local', // serverless has larger size limits
 }
 
 export const WebContainer: RuntimeCompatibilitySchema = {
@@ -68,6 +71,7 @@ export const WebContainer: RuntimeCompatibilitySchema = {
   'satori': 'wasm-fs',
   'takumi': 'wasm',
   'sharp': false,
+  'emoji': 'fetch', // webcontainer has size constraints
 }
 
 export const RuntimeCompatibility: Record<string, RuntimeCompatibilitySchema> = {
@@ -85,6 +89,7 @@ export const RuntimeCompatibility: Record<string, RuntimeCompatibilitySchema> = 
     'satori': 'node',
     'takumi': 'wasm',
     'sharp': false,
+    'emoji': 'fetch', // edge size limits
     'wasm': {
       rollup: {
         targetEnv: 'auto-inline',
@@ -101,6 +106,7 @@ export const RuntimeCompatibility: Record<string, RuntimeCompatibilitySchema> = 
     'satori': 'node',
     'takumi': 'wasm',
     'sharp': false,
+    'emoji': 'fetch', // edge size limits - bundling 24MB icons not viable
     'wasm': {
       // lowers workers kb size
       esmImport: true,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -193,6 +193,8 @@ export interface RuntimeCompatibilitySchema {
   satori: 'node' | 'wasm' | 'wasm-fs' | false
   takumi: 'node' | 'wasm' | false
   sharp: 'node' | false
+  // emoji strategy: 'local' bundles icons (24MB), 'fetch' uses iconify API at runtime
+  emoji?: 'local' | 'fetch'
   wasm?: any
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We introduced a requirement of using the NPM package for emojis locally, this is working well but the package is like 24MB so causes issues in edge runtimes. Emojis should already be replaced by the build-time plugin now, so we just fallback to the fetch.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
