### PR TITLE
fix: allow disabling emoji support and remove 24MB bundle

### DIFF
--- a/src/runtime/server/og-image/satori/transforms/emojis/local.ts
+++ b/src/runtime/server/og-image/satori/transforms/emojis/local.ts
@@ -56,7 +56,7 @@ export async function getEmojiSvg(ctx: OgImageRenderEventContext, emojiChar: str
 
   const { icons, width: pkgWidth, height: pkgHeight } = nitroApp._ogImageIconsData
   const codePoint = getEmojiCodePoint(emojiChar)
-  const possibleNames = getEmojiIconNames(codePoint, ctx.options.emojis!)
+  const possibleNames = getEmojiIconNames(codePoint, ctx.options.emojis as string)
 
   // Try each possible name until we find a match
   for (const iconName of possibleNames) {

--- a/src/runtime/server/og-image/satori/transforms/emojis/noop.ts
+++ b/src/runtime/server/og-image/satori/transforms/emojis/noop.ts
@@ -1,0 +1,6 @@
+/**
+ * Noop emoji transform - emojis are disabled
+ */
+export function getEmojiSvg(): null {
+  return null
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -139,7 +139,7 @@ export interface OgImageOptions<T extends keyof OgImageComponents = keyof OgImag
    */
   renderer?: RendererType
   extension?: 'png' | 'jpeg' | 'jpg' | 'svg' | 'html'
-  emojis?: IconifyEmojiIconSets
+  emojis?: IconifyEmojiIconSets | false
   /**
    * Provide a static HTML template to render the OG Image instead of a component.
    */
@@ -198,8 +198,8 @@ export interface SatoriFontConfig extends FontConfig {
 export interface RuntimeCompatibilitySchema {
   chromium: 'chrome-launcher' | 'on-demand' | 'playwright' | false
   ['css-inline']: 'node' | 'wasm' | 'wasm-fs' | false
-  resvg: 'node' | 'node-dev' | 'wasm' | 'wasm-fs' | false
-  satori: 'node' | 'wasm' | '0-15-wasm' | 'wasm-fs' | false
+  resvg: 'node' | 'node-dev' | 'wasm' | 'wasm-fs' | 'wasm-edge' | false
+  satori: 'node' | 'wasm' | '0-15-wasm' | 'wasm-fs' | 'wasm-edge' | false
   takumi: 'node' | 'wasm' | false
   sharp: 'node' | false
   // emoji strategy: 'local' bundles icons (24MB), 'fetch' uses iconify API at runtime


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #443

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Users were hitting OOM errors when `@iconify-json/noto` was installed because the 24MB icons.json was being bundled into the server output. This was unnecessary since build-time transforms already inline static emojis.

Changed emoji strategy: build-time uses local icons if available (with fetch fallback), runtime always uses Iconify API. This eliminates the 24MB bundle entirely. Also added `emojis: false` option to disable emoji support completely.

```ts
// Disable emojis entirely
export default defineNuxtConfig({
  ogImage: {
    defaults: {
      emojis: false
    }
  }
})
```

| Scenario | Build-time | Runtime |
|----------|------------|---------|
| Has `@iconify-json/noto` | Local (fast) | Fetch API |
| No local package | Fetch API | Fetch API |
| `emojis: false` | Skip | Skip |