### PR TITLE
feat: component-driven renderer dependency resolution

### DIFF
--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -212,6 +212,15 @@ export async function ensureProviderDependencies(
   return { success: true, installed }
 }
 
+export async function promptForRendererSelection(): Promise<ProviderName> {
+  const renderer = await logger.prompt('Which OG image renderer would you like to use?', {
+    type: 'select',
+    options: PROVIDER_DEPENDENCIES.map(p => p.name),
+    initial: 'satori',
+  })
+  return (renderer as ProviderName) || 'satori'
+}
+
 export async function promptForDependencyInstall(
   pkg: string,
   nuxt: Nuxt,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- None directly linked -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Users upgrading to v6 or missing onboarding got cryptic runtime errors when renderer dependencies (satori, resvg, takumi, etc.) weren't installed. The old approach checked satori and resvg individually with hardcoded logic.

This replaces the per-package checks with component-driven dependency resolution. The module now scans user OgImage component suffixes (`.satori.vue`, `.takumi.vue`, `.chromium.vue`) to determine which renderers are needed, checks the nitro preset to pick the right binding (node vs wasm), then prompts to install missing deps in dev or errors in CI/build. Community templates are filtered to only register those matching available renderers.

**No user components?** Dev server prompts which renderer to use. Production defaults to `satori`.

**Add a new renderer mid-session?** HMR detects the new suffix and warns about missing deps.

```
# Flow:
# 1. Pre-scan component dirs → detect renderer suffixes
# 2. No components? → prompt for renderer choice (dev) / use default (prod)
# 3. For each renderer → getRecommendedBinding(renderer, nitroPreset)
#    → check missing deps → prompt install (dev) / error (prod)
# 4. Community templates registered with pattern filter: **/*.{renderer}.vue
# 5. HMR: components:extend warns on new renderers with missing deps
```