### PR TITLE
fix: broken font resolution for woff2-only subsets

### DIFF
--- a/src/runtime/server/og-image/bindings/font-assets/dev-prerender.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/dev-prerender.ts
@@ -3,6 +3,7 @@ import type { FontConfig } from '../../../../types'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { buildDir } from '#og-image-virtual/build-dir.mjs'
+import { getNitroOrigin } from '#site-config/server/composables'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { withBase } from 'ufo'
 
@@ -78,6 +79,13 @@ export async function resolve(event: H3Event, font: FontConfig): Promise<Buffer>
 
   const { app } = useRuntimeConfig()
   const fullPath = withBase(path, app.baseURL)
+  if (import.meta.dev) {
+    const arrayBuffer = await $fetch(fullPath, {
+      responseType: 'arrayBuffer',
+      baseURL: getNitroOrigin(event),
+    }) as ArrayBuffer
+    return Buffer.from(arrayBuffer)
+  }
   const arrayBuffer = await event.$fetch(fullPath, {
     responseType: 'arrayBuffer',
   }) as ArrayBuffer


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No specific issue -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When @nuxt/fonts provided both `.woff` and `.woff2` variants across different unicode subsets (e.g. latin as `.woff`, vietnamese as `.woff2`), the woff2-only subsets were incorrectly skipped during TTF conversion because the dedup key didn't include `unicodeRange`. Additionally, variable fonts that can't be converted to TTF still got a fake `.ttf` satoriSrc URL, causing Vue Router warnings from failed `$fetch` requests at runtime.

Fixed the `hasNonWoff2` dedup key to include `unicodeRange`, and moved `satoriSrc` generation to only fire after successful WOFF2→TTF conversion via a shared `convertedWoff2Files` set. Dev mode font resolution also now uses `$fetch` with `getNitroOrigin` instead of `event.$fetch`.