### PR TITLE
fix: resolve fonts from @theme when other fonts already exist

### DIFF
--- a/src/build/fontless.ts
+++ b/src/build/fontless.ts
@@ -335,10 +335,10 @@ export async function resolveOgImageFonts(options: {
     if (fontRequirements.families.length > 0) {
       missingFamilies = fontRequirements.families.filter(f => !coveredFamilies.has(f))
     }
-    else if (allFonts.length === 0) {
+    else {
       const defaultVar = tw4FontVars['font-sans']
       if (defaultVar)
-        missingFamilies = extractCustomFontFamilies(defaultVar)
+        missingFamilies = extractCustomFontFamilies(defaultVar).filter(f => !coveredFamilies.has(f))
     }
 
     if (missingFamilies.length > 0) {


### PR DESCRIPTION
### 🔗 Linked issue

Related to #435

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Fonts declared in `@theme static { --font-sans: 'Public Sans', sans-serif; }` were silently ignored when `@nuxt/fonts` already provided any other font (e.g. Inter). The `--font-sans` fallback in `resolveOgImageFonts()` only triggered when zero fonts existed, skipping the user's custom font family entirely.

Changed the condition to always check `--font-sans` for missing families when no explicit font classes are detected in components, filtering out already-covered fonts.