### PR TITLE
fix(devtools): eject modal empty and template path resolution broken

### DIFF
--- a/client/components/CreateOgImageDialog.vue
+++ b/client/components/CreateOgImageDialog.vue
@@ -7,7 +7,7 @@ import {
   RadioGroupLabel,
   RadioGroupOption,
 } from '@headlessui/vue'
-import { ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { GlobalDebugKey } from '../composables/keys'
 import { CreateOgImageDialogPromise } from '../composables/templates'
 
@@ -17,7 +17,12 @@ function handleClose(_a: unknown, resolve: (value: string | false) => void) {
 
 const globalDebug = inject(GlobalDebugKey) as Ref<GlobalDebugResponse | null>
 
-const component = ref(globalDebug.value?.runtimeConfig?.componentDirs?.[0])
+const componentDirs = computed(() => globalDebug.value?.runtimeConfig?.componentDirs || [])
+const component = ref(componentDirs.value[0])
+watch(componentDirs, (dirs) => {
+  if (!component.value && dirs.length > 0)
+    component.value = dirs[0]
+})
 </script>
 
 <template>
@@ -37,7 +42,7 @@ const component = ref(globalDebug.value?.runtimeConfig?.componentDirs?.[0])
             </div>
             <div class="space-y-2">
               <RadioGroupOption
-                v-for="dir in globalDebug?.runtimeConfig?.componentDirs"
+                v-for="dir in componentDirs"
                 :key="dir"
                 v-slot="{ active, checked }"
                 as="template"

--- a/src/build/devtools.ts
+++ b/src/build/devtools.ts
@@ -7,13 +7,14 @@ import { existsSync, mkdirSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { addCustomTab, extendServerRpc, onDevToolsInitialized } from '@nuxt/devtools-kit'
 import { updateTemplates, useNuxt } from '@nuxt/kit'
-import { relative } from 'pathe'
+import { join, relative } from 'pathe'
 
 const DEVTOOLS_UI_ROUTE = '/__nuxt-og-image'
 const DEVTOOLS_UI_LOCAL_PORT = 3030
 
 export function setupDevToolsUI(options: ModuleOptions, resolve: Resolver['resolve'], nuxt: Nuxt = useNuxt()) {
   const clientPath = resolve('./client')
+  const communityTemplatesDir = resolve('./runtime/app/components/Templates/Community')
   const isProductionBuild = existsSync(clientPath)
 
   // Serve production-built client (used when package is published)
@@ -51,15 +52,13 @@ export function setupDevToolsUI(options: ModuleOptions, resolve: Resolver['resol
     const rpc = extendServerRpc<ClientFunctions, ServerFunctions>('nuxt-og-image', {
       async ejectCommunityTemplate(path: string) {
         const [dirName, componentName] = path.split('/')
-        const dir = resolve(nuxt.options.srcDir, 'components', dirName || '')
+        const dir = join(nuxt.options.srcDir, 'components', dirName || '')
         if (!existsSync(dir)) {
-          mkdirSync(dir)
+          mkdirSync(dir, { recursive: true })
         }
-        const newPath = resolve(dir, componentName || '')
-        const templatePath = resolve(`./runtime/app/components/Templates/Community/${componentName}`)
-        // readFile, we need to modify it
+        const newPath = join(dir, componentName || '')
+        const templatePath = join(communityTemplatesDir, componentName || '')
         const template = (await readFile(templatePath, 'utf-8')).replace('{{ title }}', `{{ title }} - Ejected!`)
-        // copy the file over
         await writeFile(newPath, template, { encoding: 'utf-8' })
         await updateTemplates({ filter: t => t.filename.includes('nuxt-og-image/components.mjs') })
         const nitro = await useNitro
@@ -69,7 +68,7 @@ export function setupDevToolsUI(options: ModuleOptions, resolve: Resolver['resol
     })
 
     nuxt.hook('builder:watch', (e, path) => {
-      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
+      path = relative(nuxt.options.srcDir, join(nuxt.options.srcDir, path))
       // needs to be for a page change
       if ((e === 'change' || e.includes('link')) && (path.startsWith('pages') || path.startsWith('content'))) {
         rpc.broadcast.refreshRouteData(path) // client needs to figure it if it's for the page we're on


### PR DESCRIPTION
### 🔗 Linked issue

Related to #435

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The eject modal in devtools was showing empty (no directory options) because `componentDirs` was initialized as a one-time snapshot at setup time before async data loaded. Added a reactive computed + watcher so the radio options populate when `globalDebug` data becomes available.

The eject RPC handler used `resolve('./runtime/...')` which resolved relative to the user's CWD instead of the module directory. Fixed by pre-computing the community templates directory at setup time using the module resolver, and using `join()` for path construction. Also added `{ recursive: true }` to `mkdirSync`.