### PR TITLE
fix: font tree shaking

### DIFF
--- a/src/build/css/css-classes.ts
+++ b/src/build/css/css-classes.ts
@@ -175,14 +175,17 @@ function extractFontFamilyFromClass(cls: string, familyClasses: Set<string>, fam
 
 function extractFontFamilyFromStyle(style: string, familyNames: Set<string>): void {
   for (const match of style.matchAll(INLINE_FONT_FAMILY_REGEX)) {
-    for (const name of extractCustomFontFamilies(match[1]!))
-      familyNames.add(name)
+    // Only take the primary (first) font — rest are CSS fallbacks
+    const primary = extractCustomFontFamilies(match[1]!)[0]
+    if (primary)
+      familyNames.add(primary)
   }
 }
 
 function extractFontFamilyFromJsStyle(content: string, familyNames: Set<string>): void {
   for (const match of content.matchAll(/fontFamily:\s*['"]([^'"]+)['"]/g)) {
-    for (const name of extractCustomFontFamilies(match[1]!))
-      familyNames.add(name)
+    const primary = extractCustomFontFamilies(match[1]!)[0]
+    if (primary)
+      familyNames.add(primary)
   }
 }

--- a/src/build/fonts.ts
+++ b/src/build/fonts.ts
@@ -87,10 +87,11 @@ export function resolveFontFamilies(
 
   const families = new Set<string>()
 
-  // Always include the default font family (font-sans) when filtering
-  const defaultVar = fontVars['font-sans']
-  if (defaultVar) {
-    for (const f of extractCustomFontFamilies(defaultVar))
+  // Always include the font-sans default — the wrapper div uses it as its font-family,
+  // so it must be in the requirements to ensure it gets resolved and loaded.
+  const sansValue = fontVars['font-sans']
+  if (sansValue) {
+    for (const f of extractCustomFontFamilies(sansValue))
       families.add(f)
   }
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -120,7 +120,7 @@ declare module '#og-image/font-requirements' {
     families: string[]
     hasDynamicBindings: boolean
   }
-  export const componentFontMap: Record<string, {
+  export function getComponentFontMap(): Record<string, {
     weights: number[]
     styles: Array<'normal' | 'italic'>
     families: string[]

--- a/test/fixtures/multi-font-families/nuxt.config.ts
+++ b/test/fixtures/multi-font-families/nuxt.config.ts
@@ -13,6 +13,10 @@ export default defineNuxtConfig({
     NuxtOgImage,
   ],
 
+  devServer: {
+    host: '::1',
+  },
+
   vite: {
     plugins: [tailwindcss()],
   },

--- a/test/unit/ipv6-font-fetch.test.ts
+++ b/test/unit/ipv6-font-fetch.test.ts
@@ -1,0 +1,101 @@
+import http from 'node:http'
+import { $fetch } from 'ofetch'
+import { describe, expect, it } from 'vitest'
+
+const FONT_DATA = Buffer.from('fake-font-data-ttf')
+
+function createServer(host: string): Promise<{ url: string, close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((_, res) => {
+      res.writeHead(200, { 'Content-Type': 'font/ttf' })
+      res.end(FONT_DATA)
+    })
+    server.listen(0, host, () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string')
+        return reject(new Error('unexpected address'))
+      const url = addr.family === 'IPv6'
+        ? `http://[${addr.address}]:${addr.port}`
+        : `http://${addr.address}:${addr.port}`
+      resolve({
+        url,
+        close: () => new Promise<void>(r => server.close(() => r())),
+      })
+    })
+  })
+}
+
+/**
+ * Replicates the IPv6 font fetching bug in dev-prerender.ts.
+ *
+ * Before the fix, when getNitroOrigin() returned an IPv6 origin like
+ * `http://[::1]:3000`, the $fetch call was skipped entirely because
+ * `origin.includes('::1')` was true. This caused a fallback to
+ * event.$fetch which can't reach public/ static files in dev
+ * (only Vite's HTTP middleware serves those, not Nitro internal routing).
+ *
+ * The fix removes the IPv6 guard — $fetch/undici handles [::1] URLs fine.
+ */
+describe('ipv6 font fetch', () => {
+  it('old code skipped $fetch entirely for IPv6 origins', () => {
+    const origin = 'http://[::1]:3000'
+
+    // Old guard: `!origin.includes('::1')` → false → skip $fetch
+    const oldGuard = !origin.includes('::1')
+    expect(oldGuard).toBe(false)
+
+    // This meant IPv6 users went straight to event.$fetch which can't
+    // serve public/ static files in dev mode (Vue Router warnings)
+  })
+
+  it('$fetch works with IPv6 [::1] origin', async () => {
+    let server: Awaited<ReturnType<typeof createServer>> | undefined
+    try {
+      server = await createServer('::1')
+    }
+    catch {
+      // IPv6 not available on this machine — skip
+      return
+    }
+
+    try {
+      const origin = server.url
+      expect(origin).toContain('[::1]')
+
+      // $fetch handles IPv6 bracket notation correctly
+      const data = await $fetch('/font.ttf', {
+        responseType: 'arrayBuffer',
+        baseURL: origin,
+      })
+      expect(Buffer.from(data)).toEqual(FONT_DATA)
+    }
+    finally {
+      await server.close()
+    }
+  })
+
+  it('native fetch works with IPv6 URL construction', async () => {
+    let server: Awaited<ReturnType<typeof createServer>> | undefined
+    try {
+      server = await createServer('::1')
+    }
+    catch {
+      return
+    }
+
+    try {
+      const origin = server.url
+      const fullPath = '/fonts/inter.ttf'
+      // URL constructor handles IPv6 bracket notation
+      const url = new URL(fullPath, origin).href
+      expect(url).toContain('[::1]')
+
+      const res = await fetch(url)
+      expect(res.ok).toBe(true)
+      expect(Buffer.from(await res.arrayBuffer())).toEqual(FONT_DATA)
+    }
+    finally {
+      await server.close()
+    }
+  })
+})

--- a/test/unit/tw4-font-vars.test.ts
+++ b/test/unit/tw4-font-vars.test.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { extractTw4Metadata } from '../../src/build/css/providers/tw4'
+
+describe('tw4 font vars extraction', () => {
+  it('extracts user-defined @theme font vars', async () => {
+    const cssPath = resolve(__dirname, '../fixtures/multi-font-families/assets/css/main.css')
+    const metadata = await extractTw4Metadata({ cssPath })
+    // User-defined @theme vars should be extracted despite TW4 tree-shaking
+    expect(metadata.fontVars['font-local-sans']).toContain('LocalSans')
+    expect(metadata.fontVars['font-local-serif']).toContain('LocalSerif')
+    expect(metadata.fontVars['font-display']).toContain('Lobster')
+    expect(metadata.fontVars['font-variable']).toContain('Nunito Sans')
+    expect(metadata.fontVars['font-serif']).toContain('Playfair Display')
+    expect(metadata.fontVars['font-mono']).toContain('JetBrains Mono')
+    // TW4 default
+    expect(metadata.fontVars['font-sans']).toBeDefined()
+  })
+})

--- a/types/virtual.d.ts
+++ b/types/virtual.d.ts
@@ -61,11 +61,12 @@ declare module '#og-image/font-requirements' {
     families: string[]
     hasDynamicBindings: boolean
   }
-  export const componentFontMap: Record<string, {
+  export function getComponentFontMap(): Record<string, {
     weights: number[]
     styles: Array<'normal' | 'italic'>
     families: string[]
     hasDynamicBindings: boolean
+    category?: 'app' | 'community' | 'pro'
   }>
   export const hasNuxtFonts: boolean
 }


### PR DESCRIPTION
### 🔗 Linked issue

Related to #435

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When no `@nuxt/fonts` module was installed, satori would crash with "No fonts are loaded" because the bundled Inter fallback fonts were being filtered out at runtime. Several issues combined to cause this:

1. **TW4 font vars tree-shaken** — `compiler.build([])` with no candidates caused TW4 to drop `--font-*` theme vars entirely, so `font-sans` was never emitted
2. **font-sans default missing from requirements** — `resolveFontFamilies` didn't include the font-sans family (used by the wrapper div), so Inter was never in the required families list
3. **Runtime override couldn't recover** — `loadAllFonts` tried to supplement missing fonts from `availableFonts` (empty without @nuxt/fonts) but never checked `resolvedFonts` where the bundled Inter lives
4. **Component font map stale in dev** — virtual modules are cached on first import before any OG components are transformed, so the component font map was always empty in dev mode

Also fixes CSS class extraction to only take the primary font family (not all CSS fallbacks), adds font debug info to the renderer debug endpoint, and ensures both satori and takumi renderers always pass the default font as `fontFamilyOverride`.