### PR TITLE
feat: runtime unicode-range font filtering

### DIFF
--- a/src/build/fonts.ts
+++ b/src/build/fonts.ts
@@ -191,7 +191,6 @@ export async function parseFontsFromTemplate(
   nuxt: Nuxt,
   options: {
     convertedWoff2Files: Map<string, string>
-    fontSubsets?: string[]
   },
 ): Promise<ParsedFont[]> {
   // Cache on nuxt instance keyed by convertedWoff2Files state
@@ -207,10 +206,12 @@ export async function parseFontsFromTemplate(
     return []
   }
   const contents = await nuxtFontsTemplate.getContents({} as any)
-  const configuredSubsets = options.fontSubsets || ['latin']
 
-  // Parse @font-face rules with subset filtering (handles Google Fonts /* latin */ comments)
-  const allFonts = await extractFontFacesWithSubsets(contents, configuredSubsets)
+  // Include all @nuxt/fonts subsets — these are user-configured fonts and shouldn't be
+  // filtered. Non-Latin subsets (devanagari, cyrillic, etc.) need to be available for
+  // renderers like Takumi that support them natively. The fontSubsets config only controls
+  // fontless downloads (Satori fallback path) to limit download size.
+  const allFonts = await extractFontFacesWithSubsets(contents)
 
   // Dedupe: for each (family, weight, style, unicodeRange), prefer WOFF over WOFF2
   const fontMap = new Map<string, typeof allFonts[0]>()

--- a/src/module.ts
+++ b/src/module.ts
@@ -170,13 +170,14 @@ export interface ModuleOptions {
    */
   cacheQueryParams?: boolean
   /**
-   * Font subsets to include for OG image rendering.
+   * Font subsets to download when resolving missing font families via fontless.
    *
-   * By default, unicode-range from @font-face declarations is used automatically.
-   * Set this to override subset filtering if fonts aren't loading correctly.
+   * Fonts from @nuxt/fonts are always included with all their subsets (devanagari,
+   * cyrillic, etc.). This option only controls which subsets fontless downloads when
+   * supplementing missing families for the Satori renderer.
    *
    * @default ['latin']
-   * @example ['latin', 'latin-ext', 'cyrillic']
+   * @example ['latin', 'latin-ext', 'devanagari']
    */
   fontSubsets?: string[]
   /**
@@ -1137,7 +1138,7 @@ export const resolve = (import.meta.dev || import.meta.prerender) ? devResolve :
     // All available fonts (unfiltered) for devtools Fonts tab
     nuxt.options.nitro.virtual['#og-image/fonts-available'] = async () => {
       const fonts = hasNuxtFonts
-        ? await parseFontsFromTemplate(nuxt, { convertedWoff2Files, fontSubsets: config.fontSubsets })
+        ? await parseFontsFromTemplate(nuxt, { convertedWoff2Files })
         : []
       return `export default ${JSON.stringify(fonts)}`
     }

--- a/src/runtime/server/og-image/satori/renderer.ts
+++ b/src/runtime/server/og-image/satori/renderer.ts
@@ -6,7 +6,7 @@ import compatibility from '#og-image/compatibility'
 import resolvedFonts from '#og-image/fonts'
 import { defu } from 'defu'
 import { useOgImageRuntimeConfig } from '../../utils'
-import { loadAllFonts, loadAllFontsDebug } from '../fonts'
+import { extractCodepointsFromVNodes, loadAllFonts, loadAllFontsDebug } from '../fonts'
 import { useResvg, useSatori, useSharp } from './instances'
 import { createVNodes } from './vnodes'
 
@@ -37,11 +37,12 @@ export async function createSvg(event: OgImageRenderEventContext): Promise<{ svg
   const fontFamilyOverride = (options.props as Record<string, any>)?.fontFamily
   // Always include the default font (first resolved, e.g. Lobster) so the wrapper div renders correctly
   const defaultFont = (resolvedFonts as FontConfig[])[0]?.family
-  const [satori, vnodes, fonts] = await Promise.all([
+  const [satori, vnodes] = await Promise.all([
     useSatori(),
     createVNodes(event),
-    loadAllFonts(event.e, { supportsWoff2: false, component: options.component, fontFamilyOverride: fontFamilyOverride || defaultFont }),
   ])
+  const codepoints = extractCodepointsFromVNodes(vnodes)
+  const fonts = await loadAllFonts(event.e, { supportsWoff2: false, component: options.component, fontFamilyOverride: fontFamilyOverride || defaultFont, codepoints })
 
   await event._nitro.hooks.callHook('nuxt-og-image:satori:vnodes', vnodes, event)
   // Remap to satori's font format (requires `name` instead of `family`).

--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -3,7 +3,7 @@ import resolvedFonts from '#og-image/fonts'
 import { useNitroOrigin } from '#site-config/server/composables/useNitroOrigin'
 import { defu } from 'defu'
 import { withBase } from 'ufo'
-import { loadAllFonts } from '../fonts'
+import { extractCodepointsFromTakumiNodes, loadAllFonts } from '../fonts'
 import { resolveColorMix } from '../utils/css'
 import { linearGradientToSvg, radialGradientToSvg } from '../utils/gradient-svg'
 import { detectImageExt } from '../utils/image-detector'
@@ -197,7 +197,8 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
   const fontFamilyOverride = (options.props as Record<string, any>)?.fontFamily
   const defaultFont = (resolvedFonts as FontConfig[])[0]?.family
   const nodes = await createTakumiNodes(event)
-  const fonts = await loadAllFonts(event.e, { supportsWoff2: true, component: options.component, fontFamilyOverride: fontFamilyOverride || defaultFont })
+  const codepoints = extractCodepointsFromTakumiNodes(nodes)
+  const fonts = await loadAllFonts(event.e, { supportsWoff2: true, component: options.component, fontFamilyOverride: fontFamilyOverride || defaultFont, codepoints })
 
   await event._nitro.hooks.callHook('nuxt-og-image:takumi:nodes' as any, nodes, event)
   sanitizeTakumiStyles(nodes)

--- a/src/runtime/server/og-image/unicode-range.ts
+++ b/src/runtime/server/og-image/unicode-range.ts
@@ -1,0 +1,74 @@
+import type { VNode } from '../../types'
+
+/** Parse a CSS unicode-range string (e.g. "U+0900-097F, U+0980-09FF") into codepoint ranges */
+export function parseUnicodeRange(range: string): [number, number][] | null {
+  const parts = range.split(',').map(s => s.trim()).filter(Boolean)
+  const result: [number, number][] = []
+  for (const part of parts) {
+    const match = part.match(/^U\+([0-9A-Fa-f]+)(?:-([0-9A-Fa-f]+))?$/)
+    if (!match)
+      return null
+    const start = Number.parseInt(match[1]!, 16)
+    const end = match[2] ? Number.parseInt(match[2], 16) : start
+    result.push([start, end])
+  }
+  return result.length > 0 ? result : null
+}
+
+/** Test whether any codepoint in the set falls within the given ranges */
+export function codepointsIntersectRanges(codepoints: Set<number>, ranges: [number, number][]): boolean {
+  for (const cp of codepoints) {
+    for (const [start, end] of ranges) {
+      if (cp >= start && cp <= end)
+        return true
+    }
+  }
+  return false
+}
+
+/** Extract all codepoints from text content in a satori VNode tree */
+export function extractCodepointsFromVNodes(node: VNode): Set<number> {
+  const codepoints = new Set<number>()
+  const walk = (n: VNode) => {
+    const { children } = n.props
+    if (typeof children === 'string') {
+      for (const ch of children) {
+        codepoints.add(ch.codePointAt(0)!)
+      }
+    }
+    else if (Array.isArray(children)) {
+      for (const child of children) {
+        if (child == null)
+          continue
+        if (typeof child === 'string') {
+          for (const ch of child) {
+            codepoints.add(ch.codePointAt(0)!)
+          }
+        }
+        else {
+          walk(child)
+        }
+      }
+    }
+  }
+  walk(node)
+  return codepoints
+}
+
+/** Extract all codepoints from text content in a takumi node tree */
+export function extractCodepointsFromTakumiNodes(node: { text?: string, children?: any[] }): Set<number> {
+  const codepoints = new Set<number>()
+  const walk = (n: { text?: string, children?: any[] }) => {
+    if (typeof n.text === 'string') {
+      for (const ch of n.text) {
+        codepoints.add(ch.codePointAt(0)!)
+      }
+    }
+    if (Array.isArray(n.children)) {
+      for (const child of n.children)
+        walk(child)
+    }
+  }
+  walk(node)
+  return codepoints
+}


### PR DESCRIPTION
### 🔗 Linked issue

Related to #435

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Build-time subset filtering dropped all non-Latin font subsets, breaking rendering for scripts like Devanagari and Cyrillic. This removes that filtering so all `@nuxt/fonts` subsets are preserved, then adds runtime unicode-range filtering that extracts codepoints from the template's actual text and skips font subsets that don't match — keeping load times lean without breaking non-Latin support.

The `fontSubsets` config now only controls fontless downloads (Satori fallback path) rather than gating which `@nuxt/fonts` subsets are available.