### PR TITLE
fix: support non-latin fonts with Takumi renderer

### DIFF
--- a/src/build/fonts.ts
+++ b/src/build/fonts.ts
@@ -23,6 +23,8 @@ export interface ParsedFont {
   style: string
   satoriSrc?: string
   unicodeRange?: string
+  /** Subset name from @nuxt/fonts CSS comment (e.g. 'latin', 'devanagari') */
+  subset?: string
   /** Absolute filesystem path for direct file reads (e.g. bundled fallback fonts). */
   absolutePath?: string
 }
@@ -56,6 +58,16 @@ export interface FontRequirementsState {
 /** Dedup key for a font face: family + weight + style + unicode range. */
 export function fontKey(f: { family: string, weight: number, style: string, unicodeRange?: string }): string {
   return `${f.family}-${f.weight}-${f.style}-${f.unicodeRange || 'default'}`
+}
+
+/** Collect unique non-null subset names from parsed fonts. */
+export function extractSubsetNames(fonts: ParsedFont[]): string[] {
+  const subsets = new Set<string>()
+  for (const f of fonts) {
+    if (f.subset)
+      subsets.add(f.subset)
+  }
+  return [...subsets]
 }
 
 /** Check if a font matches the detected weight/style/family requirements. */
@@ -271,6 +283,7 @@ export async function parseFontsFromTemplate(
       style: font.style,
       satoriSrc,
       unicodeRange: font.unicodeRange || defaultUnicodeRange,
+      subset: font.subset,
     }
   })
 

--- a/test/e2e/multi-font-families.test.ts
+++ b/test/e2e/multi-font-families.test.ts
@@ -94,6 +94,14 @@ describe('multi-font-families', () => {
     expect(serifBold.byteLength).toBeGreaterThan(1000)
   })
 
+  it('downloads static font files for Devanagari (non-Latin subset)', async () => {
+    // Verify fontless downloaded static WOFF for Noto Sans Devanagari under /_og-satori-fonts/
+    // This is the regression fix: Takumi's WOFF2 decompressor can't handle subsetted WOFF2
+    // files from Google Fonts CDN, so the fontless pipeline must provide static alternatives
+    const font400: ArrayBuffer = await $fetch('/_og-satori-fonts/Noto_Sans_Devanagari-400-normal.woff', { responseType: 'arrayBuffer' })
+    expect(font400.byteLength).toBeGreaterThan(1000)
+  })
+
   it('renders Devanagari text with takumi font fallback', async () => {
     const html = await $fetch('/devanagari') as string
     expect(html).toContain('og:image')


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Takumi's WOFF2 decompressor can't render Devanagari glyphs from Google Fonts CDN subsetted WOFF2 files. The fontless static font pipeline (previously Satori-only) is now extended to also serve Takumi, giving it static WOFF files instead of broken WOFF2 subsets.

Additionally, font subsets are now auto-detected from `@nuxt/fonts` CSS comments so fontless downloads non-Latin subsets (devanagari, cyrillic, etc.) instead of defaulting to `latin`-only via `fontSubsets` config.

**Changes across 5 files:**
- `src/build/fonts.ts` — Added `subset` field to `ParsedFont`, propagated from `@nuxt/fonts` CSS, added `extractSubsetNames()` helper
- `src/build/fontless.ts` — Extended `resolveOgImageFonts` to accept `hasTakumiRenderer`, auto-detect subsets, and include Takumi in all fontless guards
- `src/module.ts` — Wired `hasTakumiRenderer()` into font processing gates (dev-mode, vite:compiled, nitro:build:public-assets)
- `src/runtime/server/og-image/fonts.ts` — Added `preferStatic` option that prefers static fonts but falls through to WOFF2 when unavailable
- `src/runtime/server/og-image/takumi/renderer.ts` — Uses `preferStatic: true` so Takumi gets static fonts when available