### PR TITLE
fix: @takumi-rs/* dep version missmatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
   "peerDependencies": {
     "@resvg/resvg-js": "^2.6.0",
     "@resvg/resvg-wasm": "^2.6.0",
-    "@takumi-rs/core": "^0.62.0",
-    "@takumi-rs/wasm": "^0.62.0",
+    "@takumi-rs/core": "^0.69.0",
+    "@takumi-rs/wasm": "^0.69.0",
     "@unhead/vue": "^2.0.5",
     "fontless": "^0.2.0",
     "playwright-core": "^1.50.0",


### PR DESCRIPTION
Lock file was `0.69.*`, while package.json uses `0.62.*`.

### 🔗 Linked issue

https://github.com/nuxt-modules/og-image/issues/488

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix packaging missmatch. This project works well with takumi-rs `0.69.*` (declared in lock file) but package.json uses `0.62`.
