### PR TITLE
fix: replacing .png inside the component params

### DIFF
--- a/src/runtime/server/og-image/context.ts
+++ b/src/runtime/server/og-image/context.ts
@@ -57,7 +57,7 @@ export async function resolveContext(e: H3Event): Promise<H3Error | OgImageRende
   // Parse encoded params from URL path (Cloudinary-style)
   // URL format: /_og/d/w_1200,title_Hello.png
   // Hash mode: /_og/d/o_<hash>.png (for long URLs)
-  const encodedSegment = (path.split('/').pop() as string).replace(`.${extension}`, '')
+  const encodedSegment = (path.split('/').pop() as string).replace(new RegExp(`\\.${extension}$`), '')
 
   // Check for hash mode (o_<hash>)
   const hashMatch = encodedSegment.match(/^o_([a-z0-9]+)$/i)

--- a/test/e2e/prop-with-extension.test.ts
+++ b/test/e2e/prop-with-extension.test.ts
@@ -1,0 +1,27 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+import { encodeOgImageParams } from '../../src/runtime/shared/urlEncoding'
+
+const { resolve } = createResolver(import.meta.url)
+
+describe.skipIf(!import.meta.env?.TEST_DEV)('prop values containing file extensions', async () => {
+  await setup({
+    rootDir: resolve('../fixtures/basic'),
+    dev: true,
+  })
+
+  // Regression: context.ts used String.replace(`.${extension}`, '') which replaces
+  // the FIRST occurrence. When a prop value contains the same extension as the
+  // output format AND there are other params after it, the extension inside the
+  // prop gets stripped instead of the trailing one.
+  it('preserves .html in prop value when output format is also .html', async () => {
+    const encoded = encodeOgImageParams({
+      component: 'PropTest.satori',
+      props: { logo: 'https://example.com/page.html', title: 'test' },
+      _path: '/satori',
+    })
+    const html = await $fetch(`/_og/d/${encoded}.html`) as string
+    expect(html).toContain('https://example.com/page.html')
+  }, 60000)
+})

--- a/test/fixtures/basic/components/OgImage/PropTest.satori.vue
+++ b/test/fixtures/basic/components/OgImage/PropTest.satori.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+  logo?: string
+}>(), {
+  logo: '',
+})
+</script>
+
+<template>
+  <div class="w-full h-full flex items-center justify-center bg-white">
+    <p class="text-2xl">
+      {{ logo }}
+    </p>
+  </div>
+</template>


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

context.ts uses String.replace() to strip the output format extension (.png, .html, etc.) from the URL path before parsing encoded params. String.replace() only replaces the first occurrence, so when a prop value contains the same extension as the output format (e.g. orgLogo=https://example.com/logo.png with a .png output), the extension inside the prop value gets stripped instead of the trailing one.

This results in broken prop values (e.g. logo.png becomes logo) and corrupted downstream params.

**Fix:** Replace String.replace() with a regex anchored to the end of the string ($), matching the approach already used in urlEncoding.ts's parseOgImageUrl().
