### PR TITLE
fix: prevent crash when defineOgImage runs client-side during layout transitions

### DIFF
--- a/src/runtime/app/composables/_defineOgImageRaw.ts
+++ b/src/runtime/app/composables/_defineOgImageRaw.ts
@@ -1,7 +1,7 @@
 import type { DefineOgImageInput, OgImageOptions, OgImagePrebuilt } from '../../types'
 import { appendHeader } from 'h3'
 import { createError, useError, useNuxtApp, useRequestEvent, useRoute, useState } from 'nuxt/app'
-import { ref, toValue } from 'vue'
+import { toValue } from 'vue'
 import { createOgImageMeta, getOgImagePath, setHeadOgImagePrebuilt, useOgImageRuntimeConfig } from '../utils'
 
 const RE_COMMA = /,/g


### PR DESCRIPTION
### 🔗 Linked issue

Closes #501

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`defineOgImage()` crashed when navigating between pages that use different layouts, each calling `defineOgImage` in their setup. The dev validation used `nuxtApp.payload.path === basePath` to detect client-only usage, but `payload.path` updates on every client navigation, so the guard never excluded layout transitions. The validation then threw because the SSR state for the new path was never set (it was a client navigation, not SSR).

Replaced the broken `payload.path` heuristic with `nuxtApp.isHydrating`, which correctly limits the dev validation to initial hydration where the server/client mismatch check is actually meaningful. After hydration, all client-side calls simply no-op.