### PR TITLE
fix(devtools): use actual content width for preview scaling

### DIFF
--- a/client/components/IFrameLoader.vue
+++ b/client/components/IFrameLoader.vue
@@ -54,11 +54,15 @@ onMounted(() => {
   })
 })
 
-// Recalculate scale when container resizes
+// Recalculate scale when container resizes or configured width changes
 useResizeObserver(container, () => {
   if (src.value)
     setSource()
 })
+watch(() => toValue(options.value.width), () => {
+  if (src.value)
+    setSource()
+}, { flush: 'post' })
 </script>
 
 <template>

--- a/client/components/ImageLoader.vue
+++ b/client/components/ImageLoader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, watch } from '#imports'
+import { onBeforeUnmount, ref, toValue, watch } from '#imports'
+import { options } from '../util/logic'
 
 const props = defineProps<{
   src: string
@@ -60,7 +61,7 @@ function onError() {
     <img
       v-show="!isLoading && !error"
       :src="src"
-      :style="{ aspectRatio, maxWidth: maxWidth ? `${maxWidth}px` : undefined }"
+      :style="{ aspectRatio, maxWidth: `${toValue(options.width) || 1200}px` }"
       @load="onLoad"
       @error="onError"
     >


### PR DESCRIPTION
### 🔗 Linked issue

Related to #505

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The devtools preview container had a hardcoded `max-width: 1200px` in both `IFrameLoader` and `ImageLoader`, so when users configure OG images with custom dimensions larger than 1200px (e.g. 1920×1080), the outer container didn't scale to match. Now derives `max-width` from the actual configured width in `options`.