### PR TITLE
fix: base64-encode non-ASCII values in URL path params

### DIFF
--- a/src/runtime/shared/urlEncoding.ts
+++ b/src/runtime/shared/urlEncoding.ts
@@ -235,6 +235,21 @@ export function encodeOgImageParams(options: Record<string, any>, defaults?: Rec
   return parts.join(',')
 }
 
+const RE_NUMERIC = /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/
+
+/**
+ * Parse a string as a number only if it's actually numeric.
+ * Avoids false positives like Number('+') → 0 or Number('') → 0.
+ */
+function tryParseNumber(value: string): string | number {
+  if (RE_NUMERIC.test(value)) {
+    const num = Number(value)
+    if (!Number.isNaN(num))
+      return num
+  }
+  return value
+}
+
 /**
  * Decode a simple string value, handling ~ prefix for b64-encoded non-ASCII
  * and ~~ escape for literal values starting with ~.
@@ -314,8 +329,7 @@ export function decodeOgImageParams(encoded: string): Record<string, any> {
         options[paramName] = false
       }
       else if (value !== '') {
-        const num = Number(value)
-        options[paramName] = Number.isNaN(num) ? value : num
+        options[paramName] = tryParseNumber(value)
       }
     }
     else {
@@ -330,8 +344,7 @@ export function decodeOgImageParams(encoded: string): Record<string, any> {
         options.props[paramName] = false
       }
       else if (value !== '') {
-        const num = Number(value)
-        options.props[paramName] = Number.isNaN(num) ? value : num
+        options.props[paramName] = tryParseNumber(value)
       }
     }
   }

--- a/test/unit/urlEncoding.test.ts
+++ b/test/unit/urlEncoding.test.ts
@@ -729,13 +729,8 @@ describe('urlEncoding', () => {
     })
 
     // Empty-ish values
-    // Space-only value encodes as "+", which the decoder coerces to Number(0).
-    // This is a preexisting quirk in the number coercion logic, not related to the b64 change.
-    it('space-only value is coerced to 0 by decoder (preexisting)', () => {
-      const encoded = encodeOgImageParams({ props: { title: ' ' } })
-      expect(encoded).toBe('title_+')
-      const decoded = decodeOgImageParams(encoded)
-      expect(decoded).toEqual({ props: { title: 0 } })
+    it('round-trips value that is just a space', () => {
+      roundtrip({ title: ' ' })
     })
 
     it('round-trips value that is just +', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #513

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

h3 v1.15.7+ decodes percent-encoded `req.url`, so non-ASCII characters in URL path params (accented letters, CJK, emojis) cause 400 errors when the dev proxy forwards the request.

Non-ASCII string values now use base64 encoding with a `~` prefix marker instead of `encodeURIComponent`. The b64 output is pure ASCII so h3's decoding has nothing to mangle. ASCII values starting with `~` are escaped as `~~`, and invalid b64 after `~` gracefully falls back to URL decoding.

This is h3-version-agnostic: works with both current h3 and after h3js/h3#1355 lands. Includes 34 new unit tests covering accented chars, CJK, emoji, edge cases, and backwards compat.