### PR TITLE
fix: add missing option keys to URL encoding and prop separation

### DIFF
--- a/src/runtime/shared.ts
+++ b/src/runtime/shared.ts
@@ -70,7 +70,9 @@ function filterIsOgImageOption(key: string) {
     'resvg',
     'sharp',
     'screenshot',
+    'takumi',
     'cacheMaxAgeSeconds',
+    'cacheKey',
     'key',
   ]
   return keys.includes(key as keyof OgImageOptionsInternal)

--- a/src/runtime/shared/urlEncoding.ts
+++ b/src/runtime/shared/urlEncoding.ts
@@ -55,26 +55,30 @@ const KNOWN_PARAMS = new Set([
   'width',
   'height',
   'component',
+  'renderer',
   'emojis',
   'key',
   'alt',
   'url',
   'cacheMaxAgeSeconds',
+  'cacheKey',
   'extension',
   'html',
   'satori',
   'resvg',
   'sharp',
   'screenshot',
+  'takumi',
   'fonts',
   '_query',
+  '_hash',
   'socialPreview',
   'props',
   '_path',
 ])
 
 // Params that need base64 encoding (complex objects, or values with slashes)
-const COMPLEX_PARAMS = new Set(['satori', 'resvg', 'sharp', 'screenshot', 'fonts', '_query', '_path'])
+const COMPLEX_PARAMS = new Set(['satori', 'resvg', 'sharp', 'screenshot', 'takumi', 'fonts', '_query', '_path'])
 
 // URL-safe base64 encode/decode helpers (works in both browser and Node, handles Unicode)
 // Uses ~ instead of / and - instead of + to avoid breaking URL path segments


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #511

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`takumi`, `renderer`, `cacheKey`, and `_hash` were not in `KNOWN_PARAMS` (URL decoding) or `filterIsOgImageOption` (prop separation), so they leaked into component props instead of being treated as OG image configuration. On Cloudflare Pages with `takumi: wasm`, this caused the renderer config to be passed as component props, making the component fall back to default values.

Adds these keys to `KNOWN_PARAMS`, `COMPLEX_PARAMS` (for `takumi`'s object value), and `filterIsOgImageOption`. Works locally with `node-dev` because that mode doesn't encode/decode options through the URL path.