### PR TITLE
fix(tw4): use safe module resolution to prevent throws for unresolvable plugins

### DIFF
--- a/src/build/css/providers/tw4.ts
+++ b/src/build/css/providers/tw4.ts
@@ -47,7 +47,14 @@ async function loadTw4Deps() {
  */
 export function createModuleLoader(baseDir: string) {
   return async (id: string, base: string) => {
-    const resolved = resolveModulePath(id, { from: base || baseDir, try: true })
+    // Use suffixes + extensions to handle packages without an `exports` map
+    // (e.g. daisyui/theme resolves to daisyui/theme/index.js)
+    const resolved = resolveModulePath(id, {
+      from: base || baseDir,
+      try: true,
+      suffixes: ['', '/index'],
+      extensions: ['.js', '.mjs', '.cjs'],
+    })
     if (resolved) {
       const module = await import(pathToFileURL(resolved).href).then(m => m.default || m)
       return { path: resolved, base: dirname(resolved), module }
@@ -85,7 +92,13 @@ export function createStylesheetLoader(baseDir: string) {
       return { path: resolved, base: dirname(resolved), content }
     }
     // Handle node_modules imports (e.g., @nuxt/ui)
-    const resolved = resolveModulePath(id, { from: base || baseDir, conditions: ['style'], try: true })
+    const resolved = resolveModulePath(id, {
+      from: base || baseDir,
+      conditions: ['style'],
+      try: true,
+      suffixes: ['', '/index'],
+      extensions: ['.css', '.js', '.mjs'],
+    })
     if (resolved) {
       const content = await readFile(resolved, 'utf-8').catch(() => '')
       return { path: resolved, base: dirname(resolved), content }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #518

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Packages like `daisyui` have `"type": "module"` but no `exports` field in their `package.json`. When TW4's `compile()` calls our `loadModule` callback with `daisyui/theme`, `exsolve`'s strict ESM resolution can't resolve the subpath because it doesn't try directory index files or extensions without explicit options.

The fix adds `suffixes: ['', '/index']` and `extensions: ['.js', '.mjs', '.cjs']` to `resolveModulePath` calls, mirroring how Vite's resolver handles these packages. Also uses `try: true` so unresolvable modules fall through to the existing fallback logic instead of throwing an unhandled rejection.