### PR TITLE
fix: gate cache purge behind dev-only mode

### DIFF
--- a/src/runtime/server/util/cache.ts
+++ b/src/runtime/server/util/cache.ts
@@ -34,7 +34,7 @@ export async function useOgImageBufferCache(ctx: OgImageRenderEventContext, opti
         value: null,
         expiresAt: Date.now(),
       })) as any
-      if (typeof getQuery(ctx.e).purge !== 'undefined') {
+      if (import.meta.dev && typeof getQuery(ctx.e).purge !== 'undefined') {
         await cache.removeItem(key).catch(() => {
         })
       }


### PR DESCRIPTION
### 🔗 Linked issue

Related to GHSA-c7xp-q6q8-hg76

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `?purge` query parameter on OG image endpoints allowed any external user to invalidate the cache in production. An attacker could repeatedly hit endpoints with `?purge` to force constant re-renders, enabling a cache thrashing DoS attack.

This gates the purge functionality behind `import.meta.dev` so it only works during development, where it is useful for debugging. In production builds, the condition is tree-shaken away entirely.