### PR TITLE
fix: cap query string length, JSON values, and screenshot delay

### DIFF
--- a/src/runtime/server/og-image/context.ts
+++ b/src/runtime/server/og-image/context.ts
@@ -94,12 +94,25 @@ export async function resolveContext(e: H3Event): Promise<H3Error | OgImageRende
 
   // Also support query params for backwards compat and dynamic overrides
   const query = getQuery(e)
+
+  // Cap total query string size to prevent oversized payloads
+  const MAX_QUERY_LENGTH = 2048
+  const rawQuery = e.path.split('?')[1] || ''
+  if (rawQuery.length > MAX_QUERY_LENGTH) {
+    return createError({
+      statusCode: 400,
+      statusMessage: `[Nuxt OG Image] Query string exceeds maximum length of ${MAX_QUERY_LENGTH} characters.`,
+    })
+  }
+
   let queryParams: Record<string, any> = {}
   for (const k in query) {
     const v = String(query[k])
     if (!v)
       continue
     if (v.startsWith('{')) {
+      if (v.length > 4096)
+        continue // silently drop oversized JSON values
       try {
         queryParams[k] = JSON.parse(v)
       }
@@ -140,6 +153,10 @@ export async function resolveContext(e: H3Event): Promise<H3Error | OgImageRende
 
   // Normalise options and get renderer from component metadata
   const normalised = normaliseOptions(options)
+
+  // Cap screenshot.delay to prevent indefinite waits (max 10s)
+  if (normalised.options.screenshot?.delay != null)
+    normalised.options.screenshot.delay = Math.min(Math.max(0, Number(normalised.options.screenshot.delay) || 0), 10_000)
 
   // Auto-eject community templates in dev mode (skip devtools requests)
   if (normalised.component?.category === 'community')


### PR DESCRIPTION
### 🔗 Linked issue

Related to GHSA-c7xp-q6q8-hg76

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds input validation caps to the OG image context resolution endpoint to prevent abuse via oversized payloads and indefinite browser waits:

1. **Query string length cap (2048 chars)**: Rejects requests with query strings exceeding 2048 characters with a 400 error, preventing memory pressure from parsing massive query strings.
2. **JSON value size cap (4096 chars)**: Silently drops individual JSON query parameter values over 4096 characters before attempting `JSON.parse`, preventing CPU exhaustion from parsing deeply nested or very large JSON payloads.
3. **Screenshot delay cap (10s)**: Clamps `screenshot.delay` to a 0..10000ms range, preventing attackers from setting arbitrarily long delays that tie up browser renderer resources indefinitely.