### PR TITLE
chore(test): update takumi wasm import for new package structure

### DIFF
--- a/test/e2e-not-nuxt/cloudflare-takumi.test.ts
+++ b/test/e2e-not-nuxt/cloudflare-takumi.test.ts
@@ -155,10 +155,8 @@ describe('cloudflare-takumi', () => {
     let fontSubsets: Uint8Array[]
 
     beforeAll(async () => {
-      const wasmBytes = await fs.readFile(join(wasmPkgDir, 'takumi_wasm_bg.wasm'))
-      const wasmJs = await import(join(wasmPkgDir, 'takumi_wasm.js'))
-      await wasmJs.default({ module_or_path: await WebAssembly.compile(wasmBytes) })
-      Renderer = wasmJs.Renderer
+      const takumi = await import('@takumi-rs/wasm/bundlers/node')
+      Renderer = takumi.Renderer
 
       const fontsDir = resolve(fixtureDir, '.output/public/_fonts')
       const woff2Files = await globby('*.woff2', { cwd: fontsDir })

--- a/test/e2e-not-nuxt/cloudflare-takumi.test.ts
+++ b/test/e2e-not-nuxt/cloudflare-takumi.test.ts
@@ -155,7 +155,7 @@ describe('cloudflare-takumi', () => {
     let fontSubsets: Uint8Array[]
 
     beforeAll(async () => {
-      const takumi = await import('@takumi-rs/wasm/bundlers/node')
+      const takumi = await import('@takumi-rs/wasm/node')
       Renderer = takumi.Renderer
 
       const fontsDir = resolve(fixtureDir, '.output/public/_fonts')

--- a/test/e2e-not-nuxt/cloudflare-takumi.test.ts
+++ b/test/e2e-not-nuxt/cloudflare-takumi.test.ts
@@ -155,7 +155,9 @@ describe('cloudflare-takumi', () => {
     let fontSubsets: Uint8Array[]
 
     beforeAll(async () => {
-      const takumi = await import('@takumi-rs/wasm/node')
+      const takumi = await import('@takumi-rs/wasm')
+      const wasmBytes = await fs.readFile(join(wasmPkgDir, 'takumi_wasm_bg.wasm'))
+      takumi.initSync({ module: wasmBytes })
       Renderer = takumi.Renderer
 
       const fontsDir = resolve(fixtureDir, '.output/public/_fonts')


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@takumi-rs/wasm` no longer ships `pkg/takumi_wasm.js` after the v1 restructure. The `font subset glyph fallback` test was importing that removed file, causing CI to fail on every run. Now uses `@takumi-rs/wasm/bundlers/node` which handles WASM initialization automatically and exports the same `Renderer` class.