### PR TITLE
fix: fallback to internal handler when font origin is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
 
+## v6.3.7...main
+
+[compare changes](https://github.com/nuxt-modules/og-image/compare/v6.3.7...main)
+
+### 🩹 Fixes
+
+- Resolve :style object literal bindings to inline CSS ([#562](https://github.com/nuxt-modules/og-image/pull/562))
+- Misc cache improvements ([#564](https://github.com/nuxt-modules/og-image/pull/564))
+
+### 🏡 Chore
+
+- Takumi v1 ([cdf161b3](https://github.com/nuxt-modules/og-image/commit/cdf161b3))
+- **test:** Update takumi wasm import for new package structure ([#565](https://github.com/nuxt-modules/og-image/pull/565))
+
+### ❤️ Contributors
+
+- Harlan Wilton ([@harlan-zw](https://github.com/harlan-zw))
+
 ## v6.3.6...main
 
 [compare changes](https://github.com/nuxt-modules/og-image/compare/v6.3.6...main)

--- a/src/runtime/server/og-image/bindings/font-assets/node.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/node.ts
@@ -9,9 +9,15 @@ export async function resolve(event: H3Event, font: FontConfig) {
   const { app } = useRuntimeConfig()
   const fullPath = withBase(path, app.baseURL)
   const origin = getNitroOrigin(event)
-  const res = await fetch(new URL(fullPath, origin).href)
-  if (res.ok) {
+  const res = await fetch(new URL(fullPath, origin).href).catch(() => null)
+  if (res?.ok) {
     return Buffer.from(await res.arrayBuffer())
   }
-  throw new Error(`[Nuxt OG Image] Failed to resolve font: ${path}`)
+  // Fallback to Nitro's internal handler when origin is unreachable
+  // (behind a proxy, serverless, or server not fully started)
+  // @ts-expect-error excessive stack depth from Nuxt typed routes
+  const arrayBuffer = await event.$fetch(fullPath, {
+    responseType: 'arrayBuffer',
+  }) as ArrayBuffer
+  return Buffer.from(arrayBuffer)
 }

--- a/src/runtime/server/og-image/bindings/font-assets/node.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/node.ts
@@ -15,7 +15,6 @@ export async function resolve(event: H3Event, font: FontConfig) {
   }
   // Fallback to Nitro's internal handler when origin is unreachable
   // (behind a proxy, serverless, or server not fully started)
-  // @ts-expect-error excessive stack depth from Nuxt typed routes
   const arrayBuffer = await event.$fetch(fullPath, {
     responseType: 'arrayBuffer',
   }) as ArrayBuffer


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When the server is behind a proxy, running in serverless mode, or not fully started, fetching fonts via the origin URL can fail silently. This adds a fallback using `event.$fetch` to resolve fonts through Nitro's internal handler, preventing font loading failures in these environments.

Also includes CHANGELOG updates for v6.3.7.