### PR TITLE
feat: add `/_og/r/<path>` resolver endpoint

### DIFF
--- a/docs/content/3.guides/4.resolve-og-images.md
+++ b/docs/content/3.guides/4.resolve-og-images.md
@@ -1,103 +1,31 @@
 ---
-title: Reuse OG Images On Listing Pages
-description: Point to another page's OG image without knowing its generated URL.
+title: Embedding OG Images
+description: Render another page's OG image in an <img> tag without reconstructing its URL.
 ---
 
-## Introduction
+The generated URL for an OG image depends on the options passed to `defineOgImage()`{lang="ts"}, including the component hash and any props. These URLs change when you edit a template, so hardcoding them in a blog index or listing page breaks on every deploy.
 
-A common need is to show the OG image of one page inside a different page, for example
-rendering each article's social card on a blog index or resources listing.
+The `/_og/r/` endpoint solves this. Point it at any page path and it fetches the page, reads the `og:image` meta tag, and redirects (302) to the current image URL.
 
-The generated image URL for any page depends on the options passed to `defineOgImage()`{lang="ts"}
-on that page, including the component hash and any props. Hardcoding those URLs is
-fragile because they change when templates or props change.
-
-The resolver endpoint `/_og/r/<path>`{lang="html"} gives you a stable URL you can drop into an
-`<img>`{lang="html"} tag. It fetches the target page, reads the `og:image` meta tag, then
-redirects (302) to the actual image URL.
-
-## Usage
-
-Given a page `/blog/hello-world` that declares its own OG image, point any listing
-view at the resolver:
-
-```vue
+```vue [pages/blog/index.vue]
 <template>
   <article v-for="post in posts" :key="post.path">
-    <img :src="`/_og/r${post.path}`" :alt="post.title">
-    <h3>{{ post.title }}</h3>
+    <NuxtLink :to="post.path">
+      <img :src="`/_og/r${post.path}`" :alt="post.title">
+      <h3>{{ post.title }}</h3>
+    </NuxtLink>
   </article>
 </template>
 ```
 
-Browsers follow the 302 transparently, so the image renders exactly as it would on
-the original page.
+Browsers follow the 302 transparently, so the image renders exactly as it would on the original page.
 
-### Twitter image variant
+## Using The Current Page's URL
 
-Pass `?_og_key=twitter` to redirect to the `twitter:image` meta tag instead:
-
-```html
-<img src="/_og/r/blog/hello-world?_og_key=twitter">
-```
-
-### Dynamic page query
-
-Any non-`_og_*` query parameter is forwarded to the target page, which lets dynamic
-routes render the correct image:
-
-```html
-<img src="/_og/r/products?id=42">
-<!-- fetches /products?id=42, then redirects to its og:image -->
-```
-
-### Trailing image extension
-
-The path accepts an optional `.png`, `.jpg`, `.jpeg`, `.webp`, or `.svg` suffix
-for tools that expect an image extension. The extension is cosmetic; the actual
-redirect target uses whatever the page declared:
-
-```html
-<img src="/_og/r/blog/hello-world.png">
-```
-
-## Caching
-
-The route is registered with a stale-while-revalidate rule using your module's
-`cacheMaxAgeSeconds`, so each resolution costs one HTML fetch on cold cache and
-is served from the Nitro cache otherwise.
-
-## Security
-
-The resolver respects the same security settings as the image handlers:
-
-- `security.restrictRuntimeImagesToOrigin` blocks requests from unknown hosts.
-- `security.maxQueryParamSize` limits the forwarded query string length.
-- Internal routes (`/_*`) are rejected.
-- Protocol-relative and absolute URLs are rejected.
-- The target path is capped at 2048 characters.
-
-See the [security guide](/docs/og-image/guides/security) for how to configure
-these options.
-
-### Trust Boundary
-
-The 302 target is whatever the page's own `og:image` meta tag declares. The
-resolver's trust boundary is therefore the set of pages on your site that call
-`defineOgImage()`{lang="ts"} (or set `og:image` via `useSeoMeta()`{lang="ts"}).
-If a page declares an external image URL, the resolver will redirect to it.
-Treat the resolver like any meta-tag reader, it reflects what the page declares,
-it does not validate the destination.
-
-## When Not To Use This
-
-### On The Same Page As The Image
-
-`defineOgImage()`{lang="ts"} returns the resolved image URLs for the current page,
-so you don't need the resolver at all, capture the return value:
+If you're showing the OG image on the same page that declares it, skip the resolver entirely. `defineOgImage()`{lang="ts"} returns the generated URLs:
 
 ```vue
-<script setup lang="ts">
+<script lang="ts" setup>
 const [ogImageUrl] = defineOgImage('NuxtSeo', { title: 'Hello' })
 </script>
 
@@ -106,11 +34,60 @@ const [ogImageUrl] = defineOgImage('NuxtSeo', { title: 'Hello' })
 </template>
 ```
 
-The return type is `string[]`{lang="ts"}, with one URL per variant when you pass
-multiple options (see the [`defineOgImage()`{lang="ts"} API](/docs/og-image/api/define-og-image)).
+The return type is `string[]`{lang="ts"} with one URL per variant. See [`defineOgImage()`{lang="ts"}](/docs/og-image/api/define-og-image) for details.
 
-### For Fully Static Sites
+## Selecting `twitter:image`
 
-Prefer linking the baked static URL if you already know it, since the resolver
-still performs one HTTP redirect. The resolver is most useful when the target
-page's image URL isn't known at build time or varies across deploys.
+By default the resolver follows `og:image`. Pass `_og_key=twitter`{lang="html"} to follow `twitter:image` instead:
+
+```html
+<img src="/_og/r/blog/hello-world?_og_key=twitter">
+```
+
+## Dynamic Pages
+
+Query parameters on the resolver URL (other than `_og_*`) are forwarded to the target page fetch, so dynamic routes render against the right props:
+
+```html
+<img src="/_og/r/products?id=42">
+```
+
+This fetches `/products?id=42`, then redirects to whatever `og:image` that page produced.
+
+## Image Extension Suffix
+
+Some tools refuse to treat a URL as an image unless it ends in an image extension. The resolver strips a trailing `.png`, `.jpg`, `.jpeg`, `.webp`, or `.svg` before resolving:
+
+```html
+<img src="/_og/r/blog/hello-world.png">
+```
+
+The extension is cosmetic. The redirect target is whatever the page declares.
+
+## Caching
+
+The resolver is registered with a stale-while-revalidate route rule using your module's `cacheMaxAgeSeconds`. The first request for a given path fetches the page HTML; subsequent requests are served from Nitro's cache until the TTL expires.
+
+To override the default, set your own rule:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  routeRules: {
+    '/_og/r/**': { swr: 60 * 60 } // 1 hour
+  }
+})
+```
+
+## Security
+
+The resolver respects the same settings as the image handlers. See the [security guide](/docs/og-image/guides/security) for configuration.
+
+| Protection | Behaviour |
+|------------|-----------|
+| `security.restrictRuntimeImagesToOrigin` | Blocks requests from unknown hosts |
+| `security.maxQueryParamSize` | Caps the forwarded query string |
+| Internal route guard | Rejects paths starting with `/_` |
+| Scheme and protocol-relative guard | Rejects `//evil.com` and `http://` paths |
+| Path length cap | Rejects paths over 2048 characters |
+
+The redirect target is whatever the page's own `og:image` declares. The resolver does not validate the destination, so its trust boundary is the set of pages on your site that call `defineOgImage()`{lang="ts"} or set `og:image` via `useSeoMeta()`{lang="ts"}.

--- a/docs/content/3.guides/4.resolve-og-images.md
+++ b/docs/content/3.guides/4.resolve-og-images.md
@@ -82,7 +82,26 @@ these options.
 
 ## When Not To Use This
 
-- **On the same page as the image**: `defineOgImage()`{lang="ts"} already emits the meta
-  tag, so read `og:image` directly if you need the URL on the current page.
-- **For fully static sites with no dynamic rendering**: Prefer linking the baked
-  static URL if you know it, since the resolver still performs a redirect.
+### On The Same Page As The Image
+
+`defineOgImage()`{lang="ts"} returns the resolved image URLs for the current page,
+so you don't need the resolver at all, capture the return value:
+
+```vue
+<script setup lang="ts">
+const [ogImageUrl] = defineOgImage('NuxtSeo', { title: 'Hello' })
+</script>
+
+<template>
+  <img :src="ogImageUrl" alt="Preview">
+</template>
+```
+
+The return type is `string[]`{lang="ts"}, with one URL per variant when you pass
+multiple options (see the [`defineOgImage()`{lang="ts"} API](/docs/og-image/api/define-og-image)).
+
+### For Fully Static Sites
+
+Prefer linking the baked static URL if you already know it, since the resolver
+still performs one HTTP redirect. The resolver is most useful when the target
+page's image URL isn't known at build time or varies across deploys.

--- a/docs/content/3.guides/4.resolve-og-images.md
+++ b/docs/content/3.guides/4.resolve-og-images.md
@@ -80,6 +80,15 @@ The resolver respects the same security settings as the image handlers:
 See the [security guide](/docs/og-image/guides/security) for how to configure
 these options.
 
+### Trust Boundary
+
+The 302 target is whatever the page's own `og:image` meta tag declares. The
+resolver's trust boundary is therefore the set of pages on your site that call
+`defineOgImage()`{lang="ts"} (or set `og:image` via `useSeoMeta()`{lang="ts"}).
+If a page declares an external image URL, the resolver will redirect to it.
+Treat the resolver like any meta-tag reader, it reflects what the page declares,
+it does not validate the destination.
+
 ## When Not To Use This
 
 ### On The Same Page As The Image

--- a/docs/content/3.guides/4.resolve-og-images.md
+++ b/docs/content/3.guides/4.resolve-og-images.md
@@ -1,0 +1,88 @@
+---
+title: Reuse OG Images On Listing Pages
+description: Point to another page's OG image without knowing its generated URL.
+---
+
+## Introduction
+
+A common need is to show the OG image of one page inside a different page, for example
+rendering each article's social card on a blog index or resources listing.
+
+The generated image URL for any page depends on the options passed to `defineOgImage()`{lang="ts"}
+on that page, including the component hash and any props. Hardcoding those URLs is
+fragile because they change when templates or props change.
+
+The resolver endpoint `/_og/r/<path>`{lang="html"} gives you a stable URL you can drop into an
+`<img>`{lang="html"} tag. It fetches the target page, reads the `og:image` meta tag, then
+redirects (302) to the actual image URL.
+
+## Usage
+
+Given a page `/blog/hello-world` that declares its own OG image, point any listing
+view at the resolver:
+
+```vue
+<template>
+  <article v-for="post in posts" :key="post.path">
+    <img :src="`/_og/r${post.path}`" :alt="post.title">
+    <h3>{{ post.title }}</h3>
+  </article>
+</template>
+```
+
+Browsers follow the 302 transparently, so the image renders exactly as it would on
+the original page.
+
+### Twitter image variant
+
+Pass `?_og_key=twitter` to redirect to the `twitter:image` meta tag instead:
+
+```html
+<img src="/_og/r/blog/hello-world?_og_key=twitter">
+```
+
+### Dynamic page query
+
+Any non-`_og_*` query parameter is forwarded to the target page, which lets dynamic
+routes render the correct image:
+
+```html
+<img src="/_og/r/products?id=42">
+<!-- fetches /products?id=42, then redirects to its og:image -->
+```
+
+### Trailing image extension
+
+The path accepts an optional `.png`, `.jpg`, `.jpeg`, `.webp`, or `.svg` suffix
+for tools that expect an image extension. The extension is cosmetic; the actual
+redirect target uses whatever the page declared:
+
+```html
+<img src="/_og/r/blog/hello-world.png">
+```
+
+## Caching
+
+The route is registered with a stale-while-revalidate rule using your module's
+`cacheMaxAgeSeconds`, so each resolution costs one HTML fetch on cold cache and
+is served from the Nitro cache otherwise.
+
+## Security
+
+The resolver respects the same security settings as the image handlers:
+
+- `security.restrictRuntimeImagesToOrigin` blocks requests from unknown hosts.
+- `security.maxQueryParamSize` limits the forwarded query string length.
+- Internal routes (`/_*`) are rejected.
+- Protocol-relative and absolute URLs are rejected.
+- The target path is capped at 2048 characters.
+
+See the [security guide](/docs/og-image/guides/security) for how to configure
+these options.
+
+## When Not To Use This
+
+- **On the same page as the image**: `defineOgImage()`{lang="ts"} already emits the meta
+  tag, so read `og:image` directly if you need the URL on the current page.
+- **For fully static sites with no dynamic rendering**: Prefer linking the baked
+  static URL if you know it, since the resolver still performs a redirect.

--- a/docs/content/4.api/0.define-og-image.md
+++ b/docs/content/4.api/0.define-og-image.md
@@ -288,11 +288,9 @@ const urls = defineOgImage('NuxtSeo', { title: 'My Page' }, [
 
 See the [WhatsApp guide](/docs/og-image/guides/whatsapp) for more details.
 
-## Reusing OG Images On Other Pages
+## Embedding On Other Pages
 
-If you need the final OG image URL of another page (for example rendering article
-cards on a blog index), point at the `/_og/r/<path>`{lang="html"} resolver endpoint instead of
-trying to reconstruct URLs yourself. See the [resolve OG images guide](/docs/og-image/guides/resolve-og-images).
+To render another page's OG image on a listing or index, use the `/_og/r/`{lang="html"} endpoint rather than reconstructing the URL. See [Embedding OG Images](/docs/og-image/guides/resolve-og-images).
 
 ## Keeping URLs Short
 

--- a/docs/content/4.api/0.define-og-image.md
+++ b/docs/content/4.api/0.define-og-image.md
@@ -288,6 +288,12 @@ const urls = defineOgImage('NuxtSeo', { title: 'My Page' }, [
 
 See the [WhatsApp guide](/docs/og-image/guides/whatsapp) for more details.
 
+## Reusing OG Images On Other Pages
+
+If you need the final OG image URL of another page (for example rendering article
+cards on a blog index), point at the `/_og/r/<path>`{lang="html"} resolver endpoint instead of
+trying to reconstruct URLs yourself. See the [resolve OG images guide](/docs/og-image/guides/resolve-og-images).
+
 ## Keeping URLs Short
 
 Runtime OG image URLs encode all props in the path. To keep URLs short, pass minimal props (like a slug) and fetch data inside the component. See the [Performance](/docs/og-image/guides/performance) guide for full strategies.

--- a/src/build/prerender.ts
+++ b/src/build/prerender.ts
@@ -24,10 +24,15 @@ export function setupPrerenderHandler(options: ModuleOptions, resolve: Resolver,
       // Dynamic OG URLs are runtime-only. Prevent nitro's crawler from picking
       // them up via HTML meta extraction and writing them to disk as filenames,
       // which would hit the filesystem 255-byte limit for long signed URLs.
+      // The resolver endpoint is excluded for the same reason and because each
+      // resolution triggers a cross-page HTML fetch that may race with the
+      // prerender graph.
       nitroConfig.prerender = nitroConfig.prerender || {}
       nitroConfig.prerender.ignore = nitroConfig.prerender.ignore || []
-      if (Array.isArray(nitroConfig.prerender.ignore))
+      if (Array.isArray(nitroConfig.prerender.ignore)) {
         nitroConfig.prerender.ignore.push('/_og/d/')
+        nitroConfig.prerender.ignore.push('/_og/r/')
+      }
     })
 
     // Track hash-mode OG URLs whose source page isn't in the prerender graph.

--- a/src/module.ts
+++ b/src/module.ts
@@ -877,6 +877,15 @@ export default defineNuxtModule<ModuleOptions>({
       route: '/_og/s/**',
       handler: resolve(`${basePath}/image`),
     })
+    // Resolver endpoint: /_og/r/<path> 302 redirects to the resolved og:image
+    // for the given page by fetching its HTML and reading the meta tag.
+    // Always uses the generated runtime handler (not zero-runtime) since it
+    // only needs HTML parsing, no image rendering.
+    addServerHandler({
+      lazy: true,
+      route: '/_og/r/**',
+      handler: resolve('./runtime/server/routes/resolve'),
+    })
 
     // Add cache route rules for OG image endpoints so platforms like Vercel
     // get durable caching (survives deployments) without manual config.
@@ -905,6 +914,19 @@ export default defineNuxtModule<ModuleOptions>({
           nuxt.options.routeRules['/_og/s/**'] || {},
           { headers: { 'cache-control': 'public, max-age=31536000, immutable' } },
         )
+      }
+
+      // Resolver endpoint: SWR to cache the redirect resolution. Each resolution
+      // costs one HTML fetch; SWR lets background revalidation keep it warm.
+      if (config.runtimeCacheStorage !== false && !nuxt.options.test) {
+        const ogResolveRule = nuxt.options.routeRules['/_og/r/**']
+        if (!ogResolveRule?.swr && !ogResolveRule?.isr && !ogResolveRule?.cache && !ogResolveRule?.headers) {
+          const ttl = config.cacheMaxAgeSeconds ?? config.defaults?.cacheMaxAgeSeconds ?? 60 * 60 * 24 * 3
+          nuxt.options.routeRules['/_og/r/**'] = defu(
+            nuxt.options.routeRules['/_og/r/**'] || {},
+            { swr: ttl },
+          )
+        }
       }
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -918,6 +918,9 @@ export default defineNuxtModule<ModuleOptions>({
 
       // Resolver endpoint: SWR to cache the redirect resolution. Each resolution
       // costs one HTML fetch; SWR lets background revalidation keep it warm.
+      // Skipped during tests for the same reason as /_og/d/**: Nitro's
+      // cachedEventHandler wrapper changes the execution context and can break
+      // font loading in the tests that assert image output.
       if (config.runtimeCacheStorage !== false && !nuxt.options.test) {
         const ogResolveRule = nuxt.options.routeRules['/_og/r/**']
         if (!ogResolveRule?.swr && !ogResolveRule?.isr && !ogResolveRule?.cache && !ogResolveRule?.headers) {

--- a/src/runtime/server/routes/resolve.ts
+++ b/src/runtime/server/routes/resolve.ts
@@ -56,9 +56,11 @@ export default defineEventHandler(async (event) => {
   const security = runtimeConfig.security
 
   // Origin restriction: mirror imageEventHandler — block runtime requests from
-  // unknown hosts so the resolver can't be abused as an open proxy. Loopback
-  // hosts are only trusted when URL signing is active (matches the main
-  // handler's policy).
+  // unknown hosts so the resolver can't be abused as an open proxy. The whole
+  // check is bypassed during prerender and dev (same as the main handler);
+  // at production runtime, loopback hosts are only trusted when URL signing
+  // is active, because without a secret the Host / X-Forwarded-Host headers
+  // are user-controlled and can't be trusted on their own.
   if (!import.meta.prerender && !import.meta.dev && security?.restrictRuntimeImagesToOrigin) {
     const requestHost = getRequestHost(event, { xForwardedHost: true })
     let requestHostname: string | undefined
@@ -114,10 +116,9 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Reject anything that looks like a protocol-relative or absolute URL sneaking
-  // past withLeadingSlash (e.g. `/_og/r//evil.com/x`). After withLeadingSlash
-  // collapses to a single leading `/`, a benign path starts with `/` followed
-  // by a non-slash character.
+  // Reject protocol-relative or scheme-prefixed paths (e.g. `/_og/r//evil.com/x`
+  // or `/_og/r/http://evil.com/x`). A safe same-origin path has exactly one
+  // leading slash followed by a non-slash character; a scheme contains `://`.
   if (targetPath.includes('://') || RE_DOUBLE_LEADING_SLASH.test(targetPath)) {
     throw createError({
       statusCode: 400,
@@ -135,7 +136,10 @@ export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   // Pull out resolver-controlled params (prefixed `_og_`) before forwarding the
   // rest to the page fetch, so they don't leak into the rendered page's query.
-  const metaKey = query._og_key === 'twitter' ? 'twitter:image' : 'og:image'
+  // `_og_key` selects which meta tag to redirect to; accepted case-insensitively
+  // so copy/paste from user code doesn't silently fall back to og:image.
+  const ogKey = typeof query._og_key === 'string' ? query._og_key.toLowerCase() : ''
+  const metaKey = ogKey === 'twitter' ? 'twitter:image' : 'og:image'
   const forwardQuery: Record<string, any> = {}
   for (const [k, v] of Object.entries(query)) {
     if (!k.startsWith('_og_'))

--- a/src/runtime/server/routes/resolve.ts
+++ b/src/runtime/server/routes/resolve.ts
@@ -1,0 +1,166 @@
+import type { H3Event } from 'h3'
+import { getSiteConfig } from '#site-config/server/composables/getSiteConfig'
+import { createError, defineEventHandler, getQuery, getRequestHost, sendRedirect } from 'h3'
+import { parseURL, withLeadingSlash, withQuery } from 'ufo'
+import { isInternalRoute } from '../../shared'
+import { useOgImageRuntimeConfig } from '../utils'
+
+// Matches a single <meta> tag and captures property/name and content attributes
+// regardless of attribute order. Case-insensitive; content may be single or
+// double quoted. Attribute values disallow the quote character to avoid
+// over-matching across tags.
+const RE_META_TAG = /<meta\b[^>]*>/gi
+const RE_META_KEY = /\b(?:property|name)\s*=\s*(?:"([^"]+)"|'([^']+)')/i
+const RE_META_CONTENT = /\bcontent\s*=\s*(?:"([^"]*)"|'([^']*)')/i
+
+// Cap the target path length to prevent amplification attacks where a tiny
+// request triggers an expensive upstream fetch or fills storage with cache
+// entries keyed by pathological URLs.
+const MAX_RESOLVE_PATH_LENGTH = 2048
+
+// Strips everything up to and including `/_og/r` so the handler works under
+// any baseURL. Preserves the subpath that follows.
+const RE_STRIP_PREFIX = /^.*?\/_og\/r/
+// Allow `/_og/r/blog/post.png` as an alias for `/_og/r/blog/post` so the URL
+// can be used in contexts expecting an image extension.
+const RE_IMAGE_EXT = /\.(?:png|jpe?g|webp|svg)$/i
+// Matches protocol-relative prefixes (`//evil.com/...`) after leading-slash
+// normalisation.
+const RE_DOUBLE_LEADING_SLASH = /^\/{2,}/
+
+function extractMeta(html: string, key: string): string | undefined {
+  for (const tagMatch of html.matchAll(RE_META_TAG)) {
+    const tag = tagMatch[0]
+    const keyMatch = tag.match(RE_META_KEY)
+    const keyValue = keyMatch?.[1] ?? keyMatch?.[2]
+    if (keyValue?.toLowerCase() !== key)
+      continue
+    const contentMatch = tag.match(RE_META_CONTENT)
+    const content = contentMatch?.[1] ?? contentMatch?.[2]
+    if (content)
+      return content
+  }
+  return undefined
+}
+
+function resolveTargetPath(event: H3Event): string {
+  const pathname = parseURL(event.path).pathname
+  const stripped = pathname.replace(RE_STRIP_PREFIX, '') || '/'
+  // The actual redirect target comes from the page's own og:image declaration,
+  // so the trailing image extension is purely cosmetic.
+  return stripped.replace(RE_IMAGE_EXT, '') || '/'
+}
+
+export default defineEventHandler(async (event) => {
+  const runtimeConfig = useOgImageRuntimeConfig()
+  const security = runtimeConfig.security
+
+  // Origin restriction: mirror imageEventHandler — block runtime requests from
+  // unknown hosts so the resolver can't be abused as an open proxy. Loopback
+  // hosts are only trusted when URL signing is active (matches the main
+  // handler's policy).
+  if (!import.meta.prerender && !import.meta.dev && security?.restrictRuntimeImagesToOrigin) {
+    const requestHost = getRequestHost(event, { xForwardedHost: true })
+    let requestHostname: string | undefined
+    if (requestHost) {
+      try {
+        requestHostname = new URL(`http://${requestHost}`).hostname
+      }
+      catch {
+        requestHostname = undefined
+      }
+    }
+    const isLoopback = !!security.secret && (
+      requestHostname === 'localhost'
+      || requestHostname === '127.0.0.1'
+      || requestHostname === '::1'
+    )
+    if (!isLoopback) {
+      const siteHost = new URL(getSiteConfig(event).url).host
+      const allowedHosts = [siteHost, ...security.restrictRuntimeImagesToOrigin.map((o) => {
+        try {
+          return new URL(o).host
+        }
+        catch {
+          return o
+        }
+      })]
+      if (!requestHost || !allowedHosts.includes(requestHost)) {
+        throw createError({
+          statusCode: 403,
+          statusMessage: '[Nuxt OG Image] Host not allowed.',
+        })
+      }
+    }
+  }
+
+  // Reject oversized query strings to reduce parsing / fetch amplification.
+  if (security?.maxQueryParamSize && !import.meta.prerender) {
+    const queryString = parseURL(event.path).search || ''
+    if (queryString.length > security.maxQueryParamSize) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `[Nuxt OG Image] Query string exceeds maximum allowed length of ${security.maxQueryParamSize} characters.`,
+      })
+    }
+  }
+
+  const targetPath = resolveTargetPath(event)
+
+  if (targetPath.length > MAX_RESOLVE_PATH_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `[Nuxt OG Image] Target path exceeds ${MAX_RESOLVE_PATH_LENGTH} characters.`,
+    })
+  }
+
+  // Reject anything that looks like a protocol-relative or absolute URL sneaking
+  // past withLeadingSlash (e.g. `/_og/r//evil.com/x`). After withLeadingSlash
+  // collapses to a single leading `/`, a benign path starts with `/` followed
+  // by a non-slash character.
+  if (targetPath.includes('://') || RE_DOUBLE_LEADING_SLASH.test(targetPath)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: '[Nuxt OG Image] Target path must be a same-origin path.',
+    })
+  }
+
+  if (isInternalRoute(targetPath)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: '[Nuxt OG Image] Cannot resolve og:image for internal route.',
+    })
+  }
+
+  const query = getQuery(event)
+  // Pull out resolver-controlled params (prefixed `_og_`) before forwarding the
+  // rest to the page fetch, so they don't leak into the rendered page's query.
+  const metaKey = query._og_key === 'twitter' ? 'twitter:image' : 'og:image'
+  const forwardQuery: Record<string, any> = {}
+  for (const [k, v] of Object.entries(query)) {
+    if (!k.startsWith('_og_'))
+      forwardQuery[k] = v
+  }
+
+  const fetchPath = withQuery(withLeadingSlash(targetPath), forwardQuery)
+
+  const html = await event.$fetch<string>(fetchPath, {
+    headers: { accept: 'text/html' },
+    responseType: 'text',
+  }).catch((err: unknown) => {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `[Nuxt OG Image] Failed to fetch ${fetchPath}: ${(err as Error)?.message || 'unknown error'}`,
+    })
+  })
+
+  const resolved = extractMeta(String(html), metaKey)
+  if (!resolved) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: `[Nuxt OG Image] No <meta property="${metaKey}"> found on ${fetchPath}.`,
+    })
+  }
+
+  return sendRedirect(event, resolved, 302)
+})

--- a/test/e2e/resolve-endpoint-security.test.ts
+++ b/test/e2e/resolve-endpoint-security.test.ts
@@ -1,0 +1,44 @@
+import { createResolver } from '@nuxt/kit'
+import { fetch, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+// Exercises the resolver under a non-root baseURL AND with security config
+// enabled, so the origin check / query-size cap / path-length cap code paths
+// are actually covered.
+await setup({
+  rootDir: resolve('../fixtures/basic'),
+  server: true,
+  build: true,
+  nuxtConfig: {
+    app: {
+      baseURL: '/prefix/',
+    },
+    ogImage: {
+      security: {
+        maxQueryParamSize: 32,
+      },
+    },
+  },
+})
+
+describe('/_og/r resolver (baseURL + security)', () => {
+  it('resolves under a non-root baseURL', async () => {
+    const res = await fetch('/prefix/_og/r/satori', { redirect: 'manual' })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBeTruthy()
+  }, 60000)
+
+  it('rejects query strings over maxQueryParamSize', async () => {
+    const longQuery = `?${'x'.repeat(64)}=1`
+    const res = await fetch(`/prefix/_og/r/satori${longQuery}`, { redirect: 'manual' })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects paths over the 2048-char cap', async () => {
+    const longPath = `/prefix/_og/r/${'a'.repeat(2100)}`
+    const res = await fetch(longPath, { redirect: 'manual' })
+    expect(res.status).toBe(400)
+  })
+})

--- a/test/e2e/resolve-endpoint.test.ts
+++ b/test/e2e/resolve-endpoint.test.ts
@@ -1,0 +1,73 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, fetch, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+import { extractOgImageUrl } from '../utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../fixtures/basic'),
+  server: true,
+  build: true,
+})
+
+describe('/_og/r resolver endpoint', () => {
+  it('302 redirects to the page\'s resolved og:image', async () => {
+    const pagePath = '/satori'
+    const pageHtml = await $fetch(pagePath) as string
+    const expected = extractOgImageUrl(pageHtml)
+    expect(expected).toBeTruthy()
+
+    const res = await fetch(`/_og/r${pagePath}`, { redirect: 'manual' })
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location')
+    expect(location).toBeTruthy()
+    const locationPath = location!.startsWith('http')
+      ? new URL(location!).pathname
+      : (location!.split('?')[0] ?? location!)
+    expect(locationPath).toBe(expected)
+  }, 60000)
+
+  it('strips trailing image extension alias', async () => {
+    const res = await fetch('/_og/r/satori.png', { redirect: 'manual' })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBeTruthy()
+  }, 60000)
+
+  // The core user-facing scenario from issue #571: a blog/listing page needs
+  // stable URLs pointing at the og:image of other pages so it can render
+  // image cards without knowing each page's encoded image URL.
+  it('resolves distinct og:image URLs for different pages (listing-page use case)', async () => {
+    const pages = ['/satori', '/satori/computed', '/satori/seo-meta-inject']
+    const results = await Promise.all(pages.map(async (p) => {
+      const res = await fetch(`/_og/r${p}`, { redirect: 'manual' })
+      return { page: p, status: res.status, location: res.headers.get('location') }
+    }))
+
+    for (const r of results) {
+      expect(r.status, `resolver for ${r.page}`).toBe(302)
+      expect(r.location, `location for ${r.page}`).toBeTruthy()
+    }
+    // Each page declares its own og:image via defineOgImage; the redirect
+    // targets must differ page-to-page (modulo query, strip it before compare).
+    const paths = results.map(r => (r.location!.split('?')[0] ?? r.location!))
+    expect(new Set(paths).size).toBe(pages.length)
+  }, 60000)
+
+  it('rejects resolving internal routes', async () => {
+    const res = await fetch('/_og/r/_og/d/foo.png', { redirect: 'manual' })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects protocol-relative paths (SSRF guard)', async () => {
+    const res = await fetch('/_og/r//evil.example.com/x', { redirect: 'manual' })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects paths containing a scheme', async () => {
+    // ufo normalises, so test by injecting via the URL encoded form
+    const res = await fetch('/_og/r/http%3A//evil.example.com/x', { redirect: 'manual' })
+    // Either rejected by the scheme guard (400) or fails to find a page (502/404).
+    expect([400, 404, 502]).toContain(res.status)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #571

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds a `/_og/r/<path>` endpoint that 302-redirects to another page's resolved `og:image`. It fetches the target page's HTML and extracts the meta tag, so listing views can embed per-post OG images without reconstructing their encoded URLs.

The handler respects existing security options (`restrictRuntimeImagesToOrigin`, `maxQueryParamSize`), rejects internal/cross-origin paths, caps the target path at 2048 chars, and is SWR-cached via the module's `cacheMaxAgeSeconds`. Includes an e2e suite covering the listing-page scenario and the SSRF/injection guards, plus a guide page.