### PR TITLE
fix: update `og:image` on client-side navigation

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1545,16 +1545,36 @@ export const rootDir = ${JSON.stringify(nuxt.options.rootDir)}`
       nuxt.options.runtimeConfig['nuxt-og-image'] = runtimeConfig
 
       // Non-sensitive subset exposed to the browser so defineOgImage can refresh
-      // og:image meta tags on SPA navigation (#567). `_generate` / `nitro.static`
-      // mark pure SSG deployments: the `/_og/r/` resolver won't be served, so the
-      // client rebuilds URLs directly instead. `defaults` feed that rebuild path
-      // so the URL encoding matches what the prerender produced.
-      const hasServerRuntime = !(nuxt.options as any)._generate && !nuxt.options.nitro?.static
+      // og:image meta tags on SPA navigation (#567). `defaults` feed the SSG
+      // URL-rebuild fallback path; `hasServerRuntime` gates the `/_og/r/` resolver
+      // path on the client (the resolver can't be served from a static bucket).
+      //
+      // Seed with a best-effort guess now so the public config is populated before
+      // modules that read it in their own `modules:done` run. The authoritative
+      // value is re-written in `nitro:init` below once preset resolution is done
+      // and `nitro.options.static` reflects static presets (github-pages, etc.).
       nuxt.options.runtimeConfig.public = {
         ...nuxt.options.runtimeConfig.public,
         'nuxt-og-image': {
           defaults: runtimeConfig.defaults,
-          hasServerRuntime,
+          hasServerRuntime: !(nuxt.options as any)._generate && !nuxt.options.nitro?.static,
+        },
+      } as any
+    })
+
+    // `nitro.options.static` is the source of truth for "no runtime server" but
+    // only gets set after preset resolution, which happens during nitro init.
+    // Reading `nuxt.options.nitro?.static` at `modules:done` misses presets like
+    // `github-pages` / `gitlab-pages` / `netlify-static` that inherit `static: true`
+    // from their preset definition rather than user config. Overwriting here
+    // before nitro/client bundling catches those cases.
+    nuxt.hook('nitro:init', (nitro) => {
+      const pub = (nuxt.options.runtimeConfig.public['nuxt-og-image'] as { defaults?: any, hasServerRuntime?: boolean }) || {}
+      nuxt.options.runtimeConfig.public = {
+        ...nuxt.options.runtimeConfig.public,
+        'nuxt-og-image': {
+          ...pub,
+          hasServerRuntime: !nitro.options.static && !(nuxt.options as any)._generate,
         },
       } as any
     })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1545,6 +1545,16 @@ export const rootDir = ${JSON.stringify(nuxt.options.rootDir)}`
       nuxt.hooks.callHook('nuxt-og-image:runtime-config', runtimeConfig)
       // @ts-expect-error untyped
       nuxt.options.runtimeConfig['nuxt-og-image'] = runtimeConfig
+
+      // Non-sensitive subset exposed to the browser so defineOgImage can rebuild
+      // og:image URLs on SPA navigation (#567). Secrets and internal-only fields
+      // stay server-side; only defaults and the strict/hasSecret flags travel.
+      nuxt.options.runtimeConfig.public ||= {}
+      nuxt.options.runtimeConfig.public['nuxt-og-image'] = {
+        defaults: runtimeConfig.defaults,
+        hasSecret: !!runtimeConfig.security?.secret,
+        strict: !!runtimeConfig.security?.strict,
+      }
     })
 
     // Setup playground. Only available in development

--- a/src/module.ts
+++ b/src/module.ts
@@ -933,9 +933,12 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
-    if (!nuxt.options.dev) {
-      nuxt.options.optimization.treeShake.composables.client['nuxt-og-image'] = []
-    }
+    // Prior versions tree-shook `defineOgImage` out of the client bundle entirely for
+    // bundle-size reasons. That broke #567: on SPA navigation the og:image meta tag
+    // stayed stuck on the initial SSR-rendered URL, leaking into iOS share sheets
+    // and devtools. Keeping the call in the client bundle is cheap (a few KB for the
+    // minimal resolver-URL path) and the correctness win is worth it.
+    nuxt.options.optimization.treeShake.composables.client['nuxt-og-image'] = []
 
     ;[
       'defineOgImage',
@@ -954,11 +957,6 @@ export default defineNuxtModule<ModuleOptions>({
           name,
           from: resolve(`./runtime/app/composables/${name}`),
         })
-        if (!nuxt.options.dev) {
-          nuxt.options.optimization.treeShake.composables.client = nuxt.options.optimization.treeShake.composables.client || {}
-          nuxt.options.optimization.treeShake.composables.client['nuxt-og-image'] = nuxt.options.optimization.treeShake.composables.client['nuxt-og-image'] || []
-          nuxt.options.optimization.treeShake.composables.client['nuxt-og-image'].push(name)
-        }
       })
 
     addImports({
@@ -1546,14 +1544,19 @@ export const rootDir = ${JSON.stringify(nuxt.options.rootDir)}`
       // @ts-expect-error untyped
       nuxt.options.runtimeConfig['nuxt-og-image'] = runtimeConfig
 
-      // Non-sensitive subset exposed to the browser so defineOgImage can rebuild
-      // og:image URLs on SPA navigation (#567). Secrets and internal-only fields
-      // stay server-side; only defaults and the strict/hasSecret flags travel.
-      nuxt.options.runtimeConfig.public['nuxt-og-image'] = {
-        defaults: runtimeConfig.defaults as any,
-        hasSecret: !!runtimeConfig.security?.secret,
-        strict: !!runtimeConfig.security?.strict,
-      }
+      // Non-sensitive subset exposed to the browser so defineOgImage can refresh
+      // og:image meta tags on SPA navigation (#567). `_generate` / `nitro.static`
+      // mark pure SSG deployments: the `/_og/r/` resolver won't be served, so the
+      // client rebuilds URLs directly instead. `defaults` feed that rebuild path
+      // so the URL encoding matches what the prerender produced.
+      const hasServerRuntime = !(nuxt.options as any)._generate && !nuxt.options.nitro?.static
+      nuxt.options.runtimeConfig.public = {
+        ...nuxt.options.runtimeConfig.public,
+        'nuxt-og-image': {
+          defaults: runtimeConfig.defaults,
+          hasServerRuntime,
+        },
+      } as any
     })
 
     // Setup playground. Only available in development

--- a/src/module.ts
+++ b/src/module.ts
@@ -1549,9 +1549,8 @@ export const rootDir = ${JSON.stringify(nuxt.options.rootDir)}`
       // Non-sensitive subset exposed to the browser so defineOgImage can rebuild
       // og:image URLs on SPA navigation (#567). Secrets and internal-only fields
       // stay server-side; only defaults and the strict/hasSecret flags travel.
-      nuxt.options.runtimeConfig.public ||= {}
       nuxt.options.runtimeConfig.public['nuxt-og-image'] = {
-        defaults: runtimeConfig.defaults,
+        defaults: runtimeConfig.defaults as any,
         hasSecret: !!runtimeConfig.security?.secret,
         strict: !!runtimeConfig.security?.strict,
       }

--- a/src/runtime/app/client-utils.ts
+++ b/src/runtime/app/client-utils.ts
@@ -1,0 +1,151 @@
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+import type { DefineOgImageInput, OgImageOptions, OgImageOptionsInternal, OgImagePrebuilt } from '../types'
+import { componentNames } from '#build/nuxt-og-image/components.mjs'
+import { defu } from 'defu'
+import { useHead, useRuntimeConfig } from 'nuxt/app'
+import { joinURL, withQuery } from 'ufo'
+import { toValue } from 'vue'
+import { buildOgImageUrl, generateMeta, separateProps } from '../shared'
+
+/**
+ * Client-only helpers used by `defineOgImage` during SPA navigation. Lives in its
+ * own file (separate from `./utils`) so the client bundle doesn't transitively
+ * pull in server-only modules like `consola` via the shared logger import. The
+ * server path keeps using `./utils` which retains those richer imports.
+ */
+
+function resolveReactiveOptions(input: DefineOgImageInput): OgImageOptions | OgImagePrebuilt | false {
+  const options = toValue(input)
+  if (options === false)
+    return false
+  const opts = options as OgImageOptions | OgImagePrebuilt
+  if (opts.width)
+    opts.width = toValue(opts.width)
+  if (opts.height)
+    opts.height = toValue(opts.height)
+  if (opts.alt)
+    opts.alt = toValue(opts.alt)
+  if (opts.url)
+    opts.url = toValue(opts.url)
+  if (opts.props) {
+    opts.props = { ...opts.props }
+    for (const key in opts.props) {
+      opts.props[key] = toValue(opts.props[key])
+    }
+  }
+  return opts
+}
+
+/**
+ * Build a `/_og/r/<path>` resolver URL. The resolver re-fetches the target page
+ * server-side and 302-redirects to whatever og:image it emits, so it matches the
+ * SSR URL exactly (including useSeoMeta-injected titles and HMAC-signed strict
+ * URLs) without ever exposing the signing secret to the client.
+ *
+ * Current-route query params are forwarded to the resolver, which in turn forwards
+ * them to the page fetch. Pages whose og:image varies by query (e.g. `?lang=fr`)
+ * therefore get the right variant on SPA navigation.
+ */
+function buildResolverUrl(
+  baseURL: string,
+  basePath: string,
+  ogKey: string,
+  query: Record<string, any> | undefined,
+): string {
+  // `.png` is cosmetic: the resolver strips it before looking up the real og:image,
+  // but having an extension keeps the URL well-formed for consumers.
+  const resolverUrl = `${joinURL('/', baseURL, '_og/r', basePath)}.png`
+  const queryObj: Record<string, any> = {}
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      // Resolver reserves `_og_*` params for itself (e.g. `_og_key`); drop any
+      // user-supplied params of that shape so they don't collide.
+      if (!k.startsWith('_og_'))
+        queryObj[k] = v
+    }
+  }
+  if (ogKey === 'twitter')
+    queryObj._og_key = 'twitter'
+  return Object.keys(queryObj).length ? withQuery(resolverUrl, queryObj) : resolverUrl
+}
+
+/**
+ * Client-side processing for SPA navigations: registers a `useHead` entry pointing
+ * at the correct og:image URL for the current route so iOS share sheet, devtools
+ * and any other DOM reader see the current page's image instead of the initial
+ * page's (#567).
+ *
+ * Strategy by deployment:
+ *  - SSR (any flavour): point at the `/_og/r/<path>` resolver. Re-fetches the
+ *    target page server-side and redirects to whatever og:image SSR emits, so the
+ *    client URL always matches the server's (including useSeoMeta-injected titles
+ *    and strict HMAC-signed URLs, without exposing the secret).
+ *  - Pure SSG (no runtime server): rebuild the URL directly from defaults. If the
+ *    page relies on useSeoMeta auto-injection the rebuilt URL won't include those
+ *    values; the resolver can't help without a server.
+ */
+export function clientProcessOgImageOptions(
+  input: DefineOgImageInput | DefineOgImageInput[],
+  route: RouteLocationNormalizedLoaded,
+  basePath: string,
+): string[] {
+  const inputs = Array.isArray(input) ? input : [input]
+  const rc = useRuntimeConfig()
+  const baseURL = rc.app.baseURL
+  const publicCfg = (rc.public?.['nuxt-og-image'] as { defaults?: Record<string, any>, hasServerRuntime?: boolean } | undefined) || {}
+  const defaults = publicCfg.defaults || {}
+  const paths: string[] = []
+
+  for (const rawInput of inputs) {
+    const resolved = resolveReactiveOptions(rawInput)
+    if (resolved === false)
+      continue
+    const validOptions = resolved as OgImageOptions | OgImagePrebuilt
+
+    for (const key in defaults) {
+      // @ts-expect-error untyped
+      if (validOptions[key] === undefined)
+        // @ts-expect-error untyped
+        validOptions[key] = defaults[key]
+    }
+
+    if (route.query)
+      (validOptions as OgImageOptionsInternal)._query = route.query
+
+    // Prebuilt URL override: user pointed at a specific URL, use it directly.
+    if ((validOptions as OgImagePrebuilt).url) {
+      const url = (validOptions as OgImagePrebuilt).url as string
+      useHead({ meta: generateMeta(url, validOptions) }, { tagPriority: 'high' })
+      paths.push(url)
+      continue
+    }
+
+    // SSR: route through the resolver for a guaranteed match with the server URL.
+    if (publicCfg.hasServerRuntime) {
+      const ogKey = (validOptions as OgImageOptions).key || 'og'
+      const finalUrl = buildResolverUrl(baseURL, basePath, ogKey, route.query as Record<string, any> | undefined)
+      useHead({ meta: generateMeta(finalUrl, validOptions) }, { tagPriority: 35 })
+      paths.push(finalUrl)
+      continue
+    }
+
+    // Pure SSG: rebuild the static /_og/s/ URL locally. Matches the prerendered
+    // file as long as options line up with what SSR emitted.
+    const opts = separateProps(defu(validOptions, defaults)) as OgImageOptionsInternal
+    const extension = opts.extension || defaults?.extension || 'png'
+    const urlOpts: Record<string, any> = { ...opts, _path: basePath }
+    const componentName = opts.component || componentNames?.[0]?.pascalName
+    const component = componentNames?.find((c: any) => c.pascalName === componentName || c.kebabName === componentName)
+    if (component?.hash)
+      urlOpts._componentHash = component.hash
+    const result = buildOgImageUrl(urlOpts, extension, true, defaults, undefined)
+    const resolvedUrl = joinURL('/', baseURL, result.url)
+    const finalUrl = opts._query && Object.keys(opts._query).length
+      ? withQuery(resolvedUrl, { _query: opts._query })
+      : resolvedUrl
+    useHead({ meta: generateMeta(finalUrl, opts) }, { processTemplateParams: true, tagPriority: 35 })
+    paths.push(finalUrl)
+  }
+
+  return paths
+}

--- a/src/runtime/app/composables/_defineOgImageRaw.ts
+++ b/src/runtime/app/composables/_defineOgImageRaw.ts
@@ -2,7 +2,8 @@ import type { VueHeadClient } from '@unhead/vue'
 import type { DefineOgImageInput, OgImageOptions, OgImagePrebuilt } from '../../types'
 import { createError, injectHead, useError, useNuxtApp, useRequestEvent, useRoute, useState } from 'nuxt/app'
 import { toValue } from 'vue'
-import { clientProcessOgImageOptions, createOgImageMeta, getOgImagePath, setHeadOgImagePrebuilt, useOgImageRuntimeConfig } from '../utils'
+import { clientProcessOgImageOptions } from '../client-utils'
+import { createOgImageMeta, getOgImagePath, setHeadOgImagePrebuilt, useOgImageRuntimeConfig } from '../utils'
 
 /**
  * Internal raw implementation for defining OG images.

--- a/src/runtime/app/composables/_defineOgImageRaw.ts
+++ b/src/runtime/app/composables/_defineOgImageRaw.ts
@@ -2,7 +2,7 @@ import type { VueHeadClient } from '@unhead/vue'
 import type { DefineOgImageInput, OgImageOptions, OgImagePrebuilt } from '../../types'
 import { createError, injectHead, useError, useNuxtApp, useRequestEvent, useRoute, useState } from 'nuxt/app'
 import { toValue } from 'vue'
-import { createOgImageMeta, getOgImagePath, setHeadOgImagePrebuilt, useOgImageRuntimeConfig } from '../utils'
+import { clientProcessOgImageOptions, createOgImageMeta, getOgImagePath, setHeadOgImagePrebuilt, useOgImageRuntimeConfig } from '../utils'
 
 /**
  * Internal raw implementation for defining OG images.
@@ -26,7 +26,13 @@ export function defineOgImageRaw(_options: DefineOgImageInput | DefineOgImageInp
         throw createError({ message: 'You are using a defineOgImage() function in a client-only context. You must call this function within your root component setup, see https://github.com/nuxt-modules/og-image/pull/293.' })
       }
     }
-    return []
+    // On initial hydration, the SSR-rendered meta tag is authoritative. Skip re-registering
+    // to avoid duplicate work and URL drift (SSR has access to useSeoMeta head entries).
+    // For SPA navigation, register a client-side useHead so iOS share sheet, devtools and any
+    // manual DOM readers see the current page's og:image instead of the initial page's (#567).
+    if (nuxtApp.isHydrating)
+      return []
+    return clientProcessOgImageOptions(_options, route, basePath)
   }
 
   const paths: string[] = []

--- a/src/runtime/app/utils.ts
+++ b/src/runtime/app/utils.ts
@@ -1,6 +1,7 @@
 import type { ActiveHeadEntry, Head, VueHeadClient } from '@unhead/vue'
 import type { NuxtSSRContext } from 'nuxt/app'
-import type { OgImageOptions, OgImageOptionsInternal, OgImagePrebuilt, OgImageRuntimeConfig } from '../types'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+import type { DefineOgImageInput, OgImageOptions, OgImageOptionsInternal, OgImagePrebuilt, OgImageRuntimeConfig } from '../types'
 import { componentNames } from '#build/nuxt-og-image/components.mjs'
 import { resolveUnrefHeadInput } from '@unhead/vue'
 import { defu } from 'defu'
@@ -238,6 +239,129 @@ export function createOgImageMeta(src: string, input: OgImageOptions | OgImagePr
   ssrContext._ogImagePayloads = payloads
 }
 
+/**
+ * Cached detection of whether the current deployment serves OG images from /_og/s/ (prerendered
+ * files) or /_og/d/ (runtime handler). Determined from the SSR-rendered og:image tag so client-side
+ * URL generation matches what the server produced. Falls back to runtime config when the initial
+ * tag is a user-provided `url` override.
+ */
+let cachedClientIsStatic: boolean | undefined
+
+function detectClientIsStatic(config: OgImageRuntimeConfig): boolean {
+  if (cachedClientIsStatic !== undefined)
+    return cachedClientIsStatic
+  if (typeof document !== 'undefined') {
+    const tags = document.head.querySelectorAll('meta[property="og:image"]')
+    for (const tag of tags) {
+      const url = tag.getAttribute('content') || ''
+      if (url.includes('/_og/s/')) {
+        cachedClientIsStatic = true
+        return true
+      }
+      if (url.includes('/_og/d/')) {
+        cachedClientIsStatic = false
+        return false
+      }
+    }
+  }
+  // Fallback: mirror the server's `isStatic` heuristic (see urlEncoding.ts)
+  cachedClientIsStatic = !(config.security?.secret && config.security?.strict)
+  return cachedClientIsStatic
+}
+
+function resolveReactiveOptions(input: DefineOgImageInput): OgImageOptions | OgImagePrebuilt | false {
+  const options = toValue(input)
+  if (options === false)
+    return false
+  const opts = options as OgImageOptions | OgImagePrebuilt
+  if (opts.width)
+    opts.width = toValue(opts.width)
+  if (opts.height)
+    opts.height = toValue(opts.height)
+  if (opts.alt)
+    opts.alt = toValue(opts.alt)
+  if (opts.url)
+    opts.url = toValue(opts.url)
+  if (opts.props) {
+    opts.props = { ...opts.props }
+    for (const key in opts.props) {
+      opts.props[key] = toValue(opts.props[key])
+    }
+  }
+  return opts
+}
+
+/**
+ * Client-side processing for SPA navigations: computes the og:image URL for the current
+ * route and registers a `useHead` entry so the DOM meta tags reflect the current page.
+ *
+ * Addresses #567: on client-side route changes the SSR-rendered og:image tag would otherwise
+ * stay pinned to the page the user originally landed on, leaking into iOS share sheets and
+ * any other consumer that reads meta tags from the live DOM.
+ */
+export function clientProcessOgImageOptions(
+  input: DefineOgImageInput | DefineOgImageInput[],
+  route: RouteLocationNormalizedLoaded,
+  basePath: string,
+): string[] {
+  const inputs = Array.isArray(input) ? input : [input]
+  const ogImageConfig = useOgImageRuntimeConfig()
+  const { defaults } = ogImageConfig
+  const baseURL = useRuntimeConfig().app.baseURL
+  const isStatic = detectClientIsStatic(ogImageConfig)
+  const publicCfg = (useRuntimeConfig().public?.['nuxt-og-image'] as { hasSecret?: boolean, strict?: boolean } | undefined) || {}
+  // Dynamic /_og/d/ URLs require HMAC signing with the secret, which is server-only.
+  // Bail early so we don't emit broken unsigned/bad-signature URLs on SPA navigation.
+  const canSign = isStatic || !publicCfg.hasSecret
+  const paths: string[] = []
+
+  for (const rawInput of inputs) {
+    const resolved = resolveReactiveOptions(rawInput)
+    if (resolved === false)
+      continue
+    const validOptions = resolved as OgImageOptions | OgImagePrebuilt
+
+    for (const key in defaults) {
+      // @ts-expect-error untyped
+      if (validOptions[key] === undefined)
+        // @ts-expect-error untyped
+        validOptions[key] = defaults[key]
+    }
+
+    if (route.query)
+      (validOptions as OgImageOptionsInternal)._query = route.query
+
+    // prebuilt URL override: no URL generation needed, just emit meta
+    if ((validOptions as OgImagePrebuilt).url) {
+      const url = (validOptions as OgImagePrebuilt).url as string
+      useHead({ meta: generateMeta(url, validOptions) }, { tagPriority: 'high' })
+      paths.push(url)
+      continue
+    }
+
+    if (!canSign)
+      continue
+
+    const opts = separateProps(defu(validOptions, defaults)) as OgImageOptionsInternal
+    const extension = opts.extension || defaults?.extension || 'png'
+    const urlOpts: Record<string, any> = { ...opts, _path: basePath }
+    const componentName = opts.component || componentNames?.[0]?.pascalName
+    const component = componentNames?.find((c: any) => c.pascalName === componentName || c.kebabName === componentName)
+    if (component?.hash)
+      urlOpts._componentHash = component.hash
+    // No secret passed here: isStatic paths don't sign; dynamic+hasSecret paths bailed via canSign above.
+    const result = buildOgImageUrl(urlOpts, extension, isStatic, defaults, undefined)
+    const resolvedUrl = joinURL('/', baseURL, result.url)
+    const finalUrl = opts._query && Object.keys(opts._query).length
+      ? withQuery(resolvedUrl, { _query: opts._query })
+      : resolvedUrl
+    useHead({ meta: generateMeta(finalUrl, opts) }, { processTemplateParams: true, tagPriority: 35 })
+    paths.push(finalUrl)
+  }
+
+  return paths
+}
+
 export function resolveComponentName(component: OgImageOptionsInternal['component']): OgImageOptionsInternal['component'] {
   component = component || componentNames?.[0]?.pascalName
   // try and fix component name if we're using a shorthand (i.e Banner instead of OgImageBanner)
@@ -318,11 +442,12 @@ export function getOgImagePath(_pagePath: string, _options?: Partial<OgImageOpti
 
 export function useOgImageRuntimeConfig() {
   const c = useRuntimeConfig()
-  return {
-    defaults: {},
-    ...(c['nuxt-og-image'] as Record<string, any>),
-    app: {
-      baseURL: c.app.baseURL,
-    },
-  } as any as OgImageRuntimeConfig
+  // Server-side: full runtime config at the root key.
+  // Client-side: the root key is stripped (server-only); only the non-sensitive subset
+  // published under `public['nuxt-og-image']` is available. The secret never crosses.
+  const serverCfg = (c['nuxt-og-image'] as Record<string, any> | undefined) || {}
+  const publicCfg = (c.public?.['nuxt-og-image'] as Record<string, any> | undefined) || {}
+  const merged: Record<string, any> = { defaults: {}, ...publicCfg, ...serverCfg }
+  merged.app = { baseURL: c.app.baseURL }
+  return merged as any as OgImageRuntimeConfig
 }

--- a/src/runtime/app/utils.ts
+++ b/src/runtime/app/utils.ts
@@ -1,7 +1,6 @@
 import type { ActiveHeadEntry, Head, VueHeadClient } from '@unhead/vue'
 import type { NuxtSSRContext } from 'nuxt/app'
-import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import type { DefineOgImageInput, OgImageOptions, OgImageOptionsInternal, OgImagePrebuilt, OgImageRuntimeConfig } from '../types'
+import type { OgImageOptions, OgImageOptionsInternal, OgImagePrebuilt, OgImageRuntimeConfig } from '../types'
 import { componentNames } from '#build/nuxt-og-image/components.mjs'
 import { resolveUnrefHeadInput } from '@unhead/vue'
 import { defu } from 'defu'
@@ -9,7 +8,6 @@ import { stringify } from 'devalue'
 import { useHead, useRuntimeConfig } from 'nuxt/app'
 import { joinURL, withQuery } from 'ufo'
 import { toValue } from 'vue'
-import { logger } from '../logger'
 import { buildOgImageUrl, generateMeta, separateProps } from '../shared'
 
 const RE_RENDERER_SUFFIX = /(Satori|Browser|Takumi)$/
@@ -54,7 +52,7 @@ function extractHeadSeoProps(head: VueHeadClient): { title?: string, description
   }
   catch (e) {
     if (import.meta.dev)
-      logger.warn('Failed to extract SEO props from head entries', e)
+      console.warn('[nuxt-og-image] Failed to extract SEO props from head entries', e)
   }
   return result
 }
@@ -207,7 +205,7 @@ export function createOgImageMeta(src: string, input: OgImageOptions | OgImagePr
             }
             else if (payload.component) {
               if (import.meta.dev)
-                logger.warn(`defineOgImage() received a non-string component value (${typeof payload.component}). Pass the component name as a plain string.`)
+                console.warn(`[nuxt-og-image] defineOgImage() received a non-string component value (${typeof payload.component}). Pass the component name as a plain string.`)
               delete payload.component
             }
             payload.key = key
@@ -237,129 +235,6 @@ export function createOgImageMeta(src: string, input: OgImageOptions | OgImagePr
   }
 
   ssrContext._ogImagePayloads = payloads
-}
-
-/**
- * Cached detection of whether the current deployment serves OG images from /_og/s/ (prerendered
- * files) or /_og/d/ (runtime handler). Determined from the SSR-rendered og:image tag so client-side
- * URL generation matches what the server produced. Falls back to runtime config when the initial
- * tag is a user-provided `url` override.
- */
-let cachedClientIsStatic: boolean | undefined
-
-function detectClientIsStatic(config: OgImageRuntimeConfig): boolean {
-  if (cachedClientIsStatic !== undefined)
-    return cachedClientIsStatic
-  if (typeof document !== 'undefined') {
-    const tags = document.head.querySelectorAll('meta[property="og:image"]')
-    for (const tag of tags) {
-      const url = tag.getAttribute('content') || ''
-      if (url.includes('/_og/s/')) {
-        cachedClientIsStatic = true
-        return true
-      }
-      if (url.includes('/_og/d/')) {
-        cachedClientIsStatic = false
-        return false
-      }
-    }
-  }
-  // Fallback: mirror the server's `isStatic` heuristic (see urlEncoding.ts)
-  cachedClientIsStatic = !(config.security?.secret && config.security?.strict)
-  return cachedClientIsStatic
-}
-
-function resolveReactiveOptions(input: DefineOgImageInput): OgImageOptions | OgImagePrebuilt | false {
-  const options = toValue(input)
-  if (options === false)
-    return false
-  const opts = options as OgImageOptions | OgImagePrebuilt
-  if (opts.width)
-    opts.width = toValue(opts.width)
-  if (opts.height)
-    opts.height = toValue(opts.height)
-  if (opts.alt)
-    opts.alt = toValue(opts.alt)
-  if (opts.url)
-    opts.url = toValue(opts.url)
-  if (opts.props) {
-    opts.props = { ...opts.props }
-    for (const key in opts.props) {
-      opts.props[key] = toValue(opts.props[key])
-    }
-  }
-  return opts
-}
-
-/**
- * Client-side processing for SPA navigations: computes the og:image URL for the current
- * route and registers a `useHead` entry so the DOM meta tags reflect the current page.
- *
- * Addresses #567: on client-side route changes the SSR-rendered og:image tag would otherwise
- * stay pinned to the page the user originally landed on, leaking into iOS share sheets and
- * any other consumer that reads meta tags from the live DOM.
- */
-export function clientProcessOgImageOptions(
-  input: DefineOgImageInput | DefineOgImageInput[],
-  route: RouteLocationNormalizedLoaded,
-  basePath: string,
-): string[] {
-  const inputs = Array.isArray(input) ? input : [input]
-  const ogImageConfig = useOgImageRuntimeConfig()
-  const { defaults } = ogImageConfig
-  const baseURL = useRuntimeConfig().app.baseURL
-  const isStatic = detectClientIsStatic(ogImageConfig)
-  const publicCfg = (useRuntimeConfig().public?.['nuxt-og-image'] as { hasSecret?: boolean, strict?: boolean } | undefined) || {}
-  // Dynamic /_og/d/ URLs require HMAC signing with the secret, which is server-only.
-  // Bail early so we don't emit broken unsigned/bad-signature URLs on SPA navigation.
-  const canSign = isStatic || !publicCfg.hasSecret
-  const paths: string[] = []
-
-  for (const rawInput of inputs) {
-    const resolved = resolveReactiveOptions(rawInput)
-    if (resolved === false)
-      continue
-    const validOptions = resolved as OgImageOptions | OgImagePrebuilt
-
-    for (const key in defaults) {
-      // @ts-expect-error untyped
-      if (validOptions[key] === undefined)
-        // @ts-expect-error untyped
-        validOptions[key] = defaults[key]
-    }
-
-    if (route.query)
-      (validOptions as OgImageOptionsInternal)._query = route.query
-
-    // prebuilt URL override: no URL generation needed, just emit meta
-    if ((validOptions as OgImagePrebuilt).url) {
-      const url = (validOptions as OgImagePrebuilt).url as string
-      useHead({ meta: generateMeta(url, validOptions) }, { tagPriority: 'high' })
-      paths.push(url)
-      continue
-    }
-
-    if (!canSign)
-      continue
-
-    const opts = separateProps(defu(validOptions, defaults)) as OgImageOptionsInternal
-    const extension = opts.extension || defaults?.extension || 'png'
-    const urlOpts: Record<string, any> = { ...opts, _path: basePath }
-    const componentName = opts.component || componentNames?.[0]?.pascalName
-    const component = componentNames?.find((c: any) => c.pascalName === componentName || c.kebabName === componentName)
-    if (component?.hash)
-      urlOpts._componentHash = component.hash
-    // No secret passed here: isStatic paths don't sign; dynamic+hasSecret paths bailed via canSign above.
-    const result = buildOgImageUrl(urlOpts, extension, isStatic, defaults, undefined)
-    const resolvedUrl = joinURL('/', baseURL, result.url)
-    const finalUrl = opts._query && Object.keys(opts._query).length
-      ? withQuery(resolvedUrl, { _query: opts._query })
-      : resolvedUrl
-    useHead({ meta: generateMeta(finalUrl, opts) }, { processTemplateParams: true, tagPriority: 35 })
-    paths.push(finalUrl)
-  }
-
-  return paths
 }
 
 export function resolveComponentName(component: OgImageOptionsInternal['component']): OgImageOptionsInternal['component'] {

--- a/test/e2e/spa-nav.test.ts
+++ b/test/e2e/spa-nav.test.ts
@@ -1,0 +1,96 @@
+import { createResolver } from '@nuxt/kit'
+import { createPage, setup, url } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../fixtures/basic'),
+  server: true,
+  build: true,
+  browser: true,
+})
+
+/**
+ * #567: on client-side SPA navigation the og:image meta tag must update to reflect
+ * the current route. iOS share sheet, devtools and any other consumer that reads
+ * meta tags from the live DOM would otherwise see the URL baked in during the
+ * initial SSR render, regardless of which page the user actually navigated to.
+ */
+describe('sPA navigation og:image', () => {
+  it.runIf(process.env.HAS_CHROME)('updates og:image when navigating between pages', async () => {
+    // createPage's hydration wait looks for `window.useNuxtApp`, which isn't
+    // exposed on prod SSR builds — use `networkidle` instead and a manual hydration
+    // probe before clicking the NuxtLink.
+    const page = await createPage(undefined)
+    await page.goto(url('/satori/spa-nav-a'), { waitUntil: 'networkidle' })
+    // Wait for Nuxt client bundle to load and attach listeners.
+    await page.waitForTimeout(2000)
+
+    const initialOgImage = await page.getAttribute('meta[property="og:image"]', 'content')
+    expect(initialOgImage).toBeTruthy()
+    // SSR emits the direct URL with the page's title encoded.
+    expect(initialOgImage).toMatch(/title_Page\+A/)
+
+    // SPA nav: on SSR deployments the client points at the /_og/r/ resolver so the
+    // URL always matches whatever the server would emit for the target route.
+    await Promise.all([
+      page.waitForURL('**/satori/spa-nav-b'),
+      page.click('#to-b'),
+    ])
+    await page.waitForFunction(
+      () => document.querySelector('meta[property="og:image"]')?.getAttribute('content')?.includes('/_og/r/satori/spa-nav-b'),
+      null,
+      { timeout: 5000 },
+    )
+
+    const updatedOgImage = await page.getAttribute('meta[property="og:image"]', 'content')
+    expect(updatedOgImage).not.toBe(initialOgImage)
+    expect(updatedOgImage).toContain('/_og/r/satori/spa-nav-b')
+
+    // Nav back to A to confirm updates are not one-way.
+    await Promise.all([
+      page.waitForURL('**/satori/spa-nav-a'),
+      page.click('#to-a'),
+    ])
+    await page.waitForFunction(
+      () => document.querySelector('meta[property="og:image"]')?.getAttribute('content')?.includes('/_og/r/satori/spa-nav-a'),
+      null,
+      { timeout: 5000 },
+    )
+
+    const backOgImage = await page.getAttribute('meta[property="og:image"]', 'content')
+    expect(backOgImage).toContain('/_og/r/satori/spa-nav-a')
+
+    await page.close()
+  }, 60000)
+
+  it.runIf(process.env.HAS_CHROME)('forwards query params through the resolver URL', async () => {
+    const page = await createPage(undefined)
+    await page.goto(url('/satori/spa-nav-a'), { waitUntil: 'networkidle' })
+    // Wait for Nuxt client bundle to load and attach listeners.
+    await page.waitForTimeout(2000)
+
+    // Navigate via the `?lang=fr` variant link. The resolver URL emitted by the
+    // client should carry the query through so variant-by-query pages get the
+    // right og:image.
+    await Promise.all([
+      page.waitForURL('**/satori/spa-nav-b?lang=fr'),
+      page.click('#to-b-lang-fr'),
+    ])
+    await page.waitForFunction(
+      () => {
+        const content = document.querySelector('meta[property="og:image"]')?.getAttribute('content') || ''
+        return content.includes('/_og/r/satori/spa-nav-b') && content.includes('lang=fr')
+      },
+      null,
+      { timeout: 5000 },
+    )
+
+    const ogImage = await page.getAttribute('meta[property="og:image"]', 'content')
+    expect(ogImage).toContain('/_og/r/satori/spa-nav-b')
+    expect(ogImage).toContain('lang=fr')
+
+    await page.close()
+  }, 60000)
+})

--- a/test/fixtures/basic/pages/satori/spa-nav-a.vue
+++ b/test/fixtures/basic/pages/satori/spa-nav-a.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import { defineOgImage, useSeoMeta } from '#imports'
+
+useSeoMeta({
+  title: 'SPA Nav Page A',
+  description: 'First page for SPA navigation test',
+})
+
+defineOgImage('NuxtSeo.satori', { title: 'Page A' })
+</script>
+
+<template>
+  <div>
+    <h1>Page A</h1>
+    <NuxtLink id="to-b" to="/satori/spa-nav-b">
+      Go to Page B
+    </NuxtLink>
+    <NuxtLink id="to-b-lang-fr" to="/satori/spa-nav-b?lang=fr">
+      Go to Page B (lang=fr)
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/satori/spa-nav-b.vue
+++ b/test/fixtures/basic/pages/satori/spa-nav-b.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+import { defineOgImage, useSeoMeta } from '#imports'
+
+useSeoMeta({
+  title: 'SPA Nav Page B',
+  description: 'Second page for SPA navigation test',
+})
+
+defineOgImage('NuxtSeo.satori', { title: 'Page B' })
+</script>
+
+<template>
+  <div>
+    <h1>Page B</h1>
+    <NuxtLink id="to-a" to="/satori/spa-nav-a">
+      Go to Page A
+    </NuxtLink>
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #567

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

On client-side route changes the SSR-rendered `og:image` meta tag stayed pinned to the page the user originally landed on, leaking stale URLs into iOS share sheets, devtools, and anything else reading meta tags from the live DOM.

`defineOgImageRaw` now runs a client-side URL builder on SPA navigation (skipping initial hydration where SSR is authoritative) and registers a `useHead` entry so the DOM reflects the current page. A non-sensitive subset of the runtime config (`defaults`, `hasSecret`, `strict`) is published to `runtimeConfig.public` so the browser can reconstruct `/_og/s/` URLs; the HMAC secret stays server-only and dynamic `/_og/d/` URLs that require signing are skipped on the client rather than emitting bad-signature URLs.