### PR TITLE
fix: remove auto SWR route rules; only set cache-control headers

### DIFF
--- a/docs/content/3.guides/11.performance.md
+++ b/docs/content/3.guides/11.performance.md
@@ -12,7 +12,7 @@ The module caches rendered images in [Nitro's default cache storage](https://nit
 - **First render**: 400-1500ms (Satori), 600-2500ms (Takumi), 1000-3500ms (Browser)
 - **Cached render**: 5-30ms
 
-Nitro's default storage is in-memory, which means the cache is **lost on server restart**. For production, point Nitro's `cache` storage at a persistent driver (for example [Redis](https://redis.io) or Cloudflare KV) via `nitro.storage.cache` — the module picks it up automatically. Or use the module-specific `runtimeCacheStorage` option if you want OG images on a separate mount. Append `?purge` to any OG image URL to manually invalidate its cache entry.
+Nitro's default storage is in-memory, which means the cache is **lost on server restart**. For production, point Nitro's `cache` storage at a persistent driver (for example [Redis](https://redis.io) or Cloudflare KV) via `nitro.storage.cache`; the module picks it up automatically. Or use the module-specific `runtimeCacheStorage` option if you want OG images on a separate mount. Append `?purge` to any OG image URL to manually invalidate its cache entry.
 
 ::callout{icon="i-heroicons-arrow-right" to="/docs/og-image/guides/runtime-cache"}
 See the [Runtime Cache guide](/docs/og-image/guides/runtime-cache) for storage drivers, cache keys, and TTL options.

--- a/docs/content/3.guides/11.performance.md
+++ b/docs/content/3.guides/11.performance.md
@@ -7,12 +7,12 @@ A first render takes 400-3500ms depending on renderer, but a cached render drops
 
 ## Caching
 
-The module enables in-memory caching by default with a 72-hour TTL and emits immutable `Cache-Control` headers so CDNs can serve cached copies without revalidation:
+The module caches rendered images in [Nitro's default cache storage](https://nitro.build/guide/cache) with a 72-hour TTL, and emits immutable `Cache-Control` headers so CDNs can serve cached copies without revalidation:
 
 - **First render**: 400-1500ms (Satori), 600-2500ms (Takumi), 1000-3500ms (Browser)
 - **Cached render**: 5-30ms
 
-The default memory cache is **lost on server restart**. For production, use a persistent storage driver like [Redis](https://redis.io) or Cloudflare KV. Append `?purge` to any OG image URL to manually invalidate its cache entry.
+Nitro's default storage is in-memory, which means the cache is **lost on server restart**. For production, configure a persistent driver (for example [Redis](https://redis.io) or Cloudflare KV) via `runtimeCacheStorage`. Append `?purge` to any OG image URL to manually invalidate its cache entry.
 
 ::callout{icon="i-heroicons-arrow-right" to="/docs/og-image/guides/runtime-cache"}
 See the [Runtime Cache guide](/docs/og-image/guides/runtime-cache) for storage drivers, cache keys, and TTL options.

--- a/docs/content/3.guides/11.performance.md
+++ b/docs/content/3.guides/11.performance.md
@@ -12,7 +12,7 @@ The module caches rendered images in [Nitro's default cache storage](https://nit
 - **First render**: 400-1500ms (Satori), 600-2500ms (Takumi), 1000-3500ms (Browser)
 - **Cached render**: 5-30ms
 
-Nitro's default storage is in-memory, which means the cache is **lost on server restart**. For production, configure a persistent driver (for example [Redis](https://redis.io) or Cloudflare KV) via `runtimeCacheStorage`. Append `?purge` to any OG image URL to manually invalidate its cache entry.
+Nitro's default storage is in-memory, which means the cache is **lost on server restart**. For production, point Nitro's `cache` storage at a persistent driver (for example [Redis](https://redis.io) or Cloudflare KV) via `nitro.storage.cache` — the module picks it up automatically. Or use the module-specific `runtimeCacheStorage` option if you want OG images on a separate mount. Append `?purge` to any OG image URL to manually invalidate its cache entry.
 
 ::callout{icon="i-heroicons-arrow-right" to="/docs/og-image/guides/runtime-cache"}
 See the [Runtime Cache guide](/docs/og-image/guides/runtime-cache) for storage drivers, cache keys, and TTL options.

--- a/docs/content/3.guides/11.performance.md
+++ b/docs/content/3.guides/11.performance.md
@@ -7,7 +7,7 @@ A first render takes 400-3500ms depending on renderer, but a cached render drops
 
 ## Caching
 
-The module enables in-memory SWR caching by default with a 72-hour TTL:
+The module enables in-memory caching by default with a 72-hour TTL and emits immutable `Cache-Control` headers so CDNs can serve cached copies without revalidation:
 
 - **First render**: 400-1500ms (Satori), 600-2500ms (Takumi), 1000-3500ms (Browser)
 - **Cached render**: 5-30ms

--- a/docs/content/3.guides/3.runtime-cache.md
+++ b/docs/content/3.guides/3.runtime-cache.md
@@ -99,7 +99,31 @@ Note that your **page URL's** query parameters (e.g., `/products?page=2`) are en
 
 ## Persistent Storage
 
-The default in-memory cache is lost on server restart. For production, use a persistent storage driver via the `runtimeCacheStorage` option, which accepts the same configuration as Nitro's [`storage`](https://nitro.build/guide/storage) option.
+The default in-memory cache is lost on server restart. For production you have two options:
+
+### Option 1: Configure Nitro's `cache` storage (recommended)
+
+The module writes cache entries under Nitro's `cache:` namespace, so pointing Nitro at a persistent driver is enough — no module-specific config needed:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    storage: {
+      cache: {
+        driver: 'redis',
+        host: 'localhost',
+        port: 6379,
+      },
+    },
+  },
+})
+```
+
+This also benefits anything else in your app that caches via Nitro (e.g. `cachedFunction`, `cachedEventHandler`, SWR route rules).
+
+### Option 2: `runtimeCacheStorage`
+
+If you want OG images on a separate mount from the rest of your Nitro cache, use `runtimeCacheStorage`, which accepts the same configuration as Nitro's [`storage`](https://nitro.build/guide/storage) option.
 
 ### Using Runtime Config
 

--- a/docs/content/3.guides/3.runtime-cache.md
+++ b/docs/content/3.guides/3.runtime-cache.md
@@ -59,7 +59,7 @@ By default, this uses **in-memory** storage. The cache is lost on server restart
 Every response includes HTTP cache headers that instruct CDN proxies to cache at the edge:
 
 ```
-Cache-Control: public, max-age=259200, s-maxage=259200, stale-while-revalidate=259200, stale-if-error=259200
+Cache-Control: public, max-age=259200, s-maxage=259200, immutable
 ETag: W/"<hash>"
 Last-Modified: <timestamp>
 Vary: accept-encoding, host
@@ -69,40 +69,21 @@ Vary: accept-encoding, host
 |-----------|---------|
 | `max-age` | Browser cache duration |
 | `s-maxage` | CDN/proxy cache duration |
-| `stale-while-revalidate` | Serve stale while refreshing in background |
-| `stale-if-error` | Serve stale if origin is unavailable |
+| `immutable` | Skip revalidation — URLs are content-addressed (params + component hash), so the response bytes never change for a given URL |
 
 When the CDN has a cached copy, requests never reach your server.
 
-### Auto-Configured Route Rules
+### Auto-Configured Cache Headers
 
-The module automatically adds route rules for both OG image endpoints:
+The module sets `Cache-Control` on every OG image response so CDNs cache it correctly without manual route rules:
 
-| Endpoint | Rule | Purpose |
-|----------|------|---------|
-| `/_og/d/**` (dynamic) | SWR with `cacheMaxAgeSeconds` TTL | Background revalidation for runtime-generated images |
-| `/_og/s/**` (prerendered) | `Cache-Control: public, max-age=31536000, immutable` | Aggressive caching for build-time generated images |
+| Endpoint | `Cache-Control` |
+|----------|-----------------|
+| `/_og/s/**` (prerendered) | `public, max-age=31536000, immutable` |
+| `/_og/d/**` (dynamic) | `public, max-age=<ttl>, s-maxage=<ttl>, immutable` |
+| `/_og/r/**` (resolver) | Same as dynamic |
 
-These rules enable platform-native caching features that go beyond HTTP headers:
-
-| Platform | What route rules add |
-|----------|---------------------|
-| **Vercel** | Durable ISR cache that **survives deployments** with background revalidation |
-| **Netlify** | CDN-level SWR caching |
-| **Cloudflare** | Edge caching via Cache API |
-
-Without the route rule, platforms like [Vercel](https://vercel.com) use their standard CDN cache which is **purged on every deployment**. The auto-configured rule upgrades this to durable caching.
-
-To override the defaults, set your own route rules. The module will not overwrite them:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  routeRules: {
-    '/_og/d/**': { isr: 60 * 60 * 24 }, // 1 day
-    '/_og/s/**': { headers: { 'cache-control': 'public, max-age=86400' } }
-  }
-})
-```
+Where `<ttl>`{lang="html"} is `cacheMaxAgeSeconds` (default 72 hours). URLs are content-addressed (encoded params + component hash), so `immutable` is safe — the response bytes never change for a given URL. No Nitro `swr`/`isr` route rule is needed (and it wouldn't work anyway, as `cachedEventHandler` JSON-serializes responses and breaks binary PNG/JPEG output).
 
 ## Query Parameters
 
@@ -165,7 +146,7 @@ export default defineNuxtConfig({
 })
 ```
 
-This controls the internal storage TTL, HTTP `Cache-Control` headers, and the auto-configured SWR route rule duration.
+This controls the internal storage TTL and HTTP `Cache-Control` header duration (`max-age` / `s-maxage`).
 
 ### Per Image
 

--- a/docs/content/3.guides/3.runtime-cache.md
+++ b/docs/content/3.guides/3.runtime-cache.md
@@ -69,7 +69,7 @@ Vary: accept-encoding, host
 |-----------|---------|
 | `max-age` | Browser cache duration |
 | `s-maxage` | CDN/proxy cache duration |
-| `immutable` | Skip revalidation — URLs are content-addressed (params + component hash), so the response bytes never change for a given URL |
+| `immutable` | Skip revalidation; URLs are content-addressed (params + component hash), so the response bytes never change for a given URL |
 
 When the CDN has a cached copy, requests never reach your server.
 
@@ -83,7 +83,7 @@ The module sets `Cache-Control` on every OG image response so CDNs cache it corr
 | `/_og/d/**` (dynamic) | `public, max-age=<ttl>, s-maxage=<ttl>, immutable` |
 | `/_og/r/**` (resolver) | Same as dynamic |
 
-Where `<ttl>`{lang="html"} is `cacheMaxAgeSeconds` (default 72 hours). URLs are content-addressed (encoded params + component hash), so `immutable` is safe — the response bytes never change for a given URL. No Nitro `swr`/`isr` route rule is needed (and it wouldn't work anyway, as `cachedEventHandler` JSON-serializes responses and breaks binary PNG/JPEG output).
+Where `<ttl>`{lang="html"} is `cacheMaxAgeSeconds` (default 72 hours). URLs are content-addressed (encoded params + component hash), so `immutable` is safe; the response bytes never change for a given URL. No Nitro `swr`/`isr` route rule is needed (and it wouldn't work anyway, as `cachedEventHandler` JSON-serializes responses and breaks binary PNG/JPEG output).
 
 ## Query Parameters
 

--- a/docs/content/3.guides/3.runtime-cache.md
+++ b/docs/content/3.guides/3.runtime-cache.md
@@ -103,7 +103,7 @@ The default in-memory cache is lost on server restart. For production you have t
 
 ### Option 1: Configure Nitro's `cache` storage (recommended)
 
-The module writes cache entries under Nitro's `cache:` namespace, so pointing Nitro at a persistent driver is enough — no module-specific config needed:
+The module writes cache entries under Nitro's `cache:` namespace, so pointing Nitro at a persistent driver is enough; no module-specific config needed:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/content/3.guides/4.resolve-og-images.md
+++ b/docs/content/3.guides/4.resolve-og-images.md
@@ -66,14 +66,14 @@ The extension is cosmetic. The redirect target is whatever the page declares.
 
 ## Caching
 
-The resolver is registered with a stale-while-revalidate route rule using your module's `cacheMaxAgeSeconds`. The first request for a given path fetches the page HTML; subsequent requests are served from Nitro's cache until the TTL expires.
+The resolver emits `Cache-Control: public, max-age=<ttl>, s-maxage=<ttl>, immutable` using your module's `cacheMaxAgeSeconds`, so CDNs cache the redirect without revalidation for the configured TTL.
 
-To override the default, set your own rule:
+To override the default, set your own headers via route rules:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   routeRules: {
-    '/_og/r/**': { swr: 60 * 60 } // 1 hour
+    '/_og/r/**': { headers: { 'cache-control': 'public, max-age=3600' } }
   }
 })
 ```

--- a/docs/content/4.api/3.config.md
+++ b/docs/content/4.api/3.config.md
@@ -141,7 +141,7 @@ See the [Build Cache guide](/docs/og-image/guides/build-cache) for CI configurat
 - Type: `number`{lang="ts"}
 - Default: `60 * 60 * 24 * 3`{lang="ts"} (3 days)
 
-Default cache duration in seconds for generated OG images. Controls the internal storage TTL, HTTP `Cache-Control` headers, and the auto-configured SWR route rule. Can be overridden per image via `defineOgImage`'s `cacheMaxAgeSeconds` option.
+Default cache duration in seconds for generated OG images. Controls the internal storage TTL and HTTP `Cache-Control` header duration (`max-age` / `s-maxage`). Can be overridden per image via `defineOgImage`'s `cacheMaxAgeSeconds` option.
 
 ```ts
 export default defineNuxtConfig({

--- a/src/module.ts
+++ b/src/module.ts
@@ -892,33 +892,40 @@ export default defineNuxtModule<ModuleOptions>({
     // only `headers` — no `swr`/`isr`/`cache` — because Nitro's
     // cachedEventHandler wraps the handler in a proxied event with stripped
     // headers AND JSON-serializes the response body, which corrupts binary
-    // PNG output (see #578). The handler still sets matching Cache-Control
-    // headers on successful responses; these route rules ensure the policy
-    // is visible to platform tooling even before the handler runs.
+    // PNG output (see #578). The image handler also sets its own Cache-Control
+    // on successful responses; these route rules surface the policy at the
+    // routing layer and cover the resolver endpoint, which redirects without
+    // emitting headers of its own.
     if (!nuxt.options.dev) {
       nuxt.options.routeRules = nuxt.options.routeRules || {}
 
       const ttl = config.cacheMaxAgeSeconds ?? config.defaults?.cacheMaxAgeSeconds ?? 60 * 60 * 24 * 3
-      // Dynamic URLs are content-addressed (encoded params + component hash),
-      // so the response is effectively immutable for a given URL — stale
-      // revalidation would just return identical bytes. Use `immutable` with
-      // the configured TTL instead.
-      const dynamicCacheControl = `public, max-age=${ttl}, s-maxage=${ttl}, immutable`
+      // Skip the dynamic/resolver cache rules entirely when caching is
+      // disabled (ttl <= 0). Setting `max-age=0, immutable` would conflict
+      // with the handler's `no-cache, no-store, must-revalidate` policy and
+      // re-enable caching depending on header-override order.
+      if (ttl > 0) {
+        // Dynamic URLs are content-addressed (encoded params + component hash),
+        // so the response is effectively immutable for a given URL — stale
+        // revalidation would just return identical bytes. Use `immutable` with
+        // the configured TTL instead.
+        const dynamicCacheControl = `public, max-age=${ttl}, s-maxage=${ttl}, immutable`
 
-      const ogDynamicRule = nuxt.options.routeRules['/_og/d/**']
-      if (!ogDynamicRule?.swr && !ogDynamicRule?.isr && !ogDynamicRule?.cache && !ogDynamicRule?.headers) {
-        nuxt.options.routeRules['/_og/d/**'] = defu(
-          nuxt.options.routeRules['/_og/d/**'] || {},
-          { headers: { 'cache-control': dynamicCacheControl } },
-        )
-      }
+        const ogDynamicRule = nuxt.options.routeRules['/_og/d/**']
+        if (!ogDynamicRule?.swr && !ogDynamicRule?.isr && !ogDynamicRule?.cache && !ogDynamicRule?.headers) {
+          nuxt.options.routeRules['/_og/d/**'] = defu(
+            nuxt.options.routeRules['/_og/d/**'] || {},
+            { headers: { 'cache-control': dynamicCacheControl } },
+          )
+        }
 
-      const ogResolveRule = nuxt.options.routeRules['/_og/r/**']
-      if (!ogResolveRule?.swr && !ogResolveRule?.isr && !ogResolveRule?.cache && !ogResolveRule?.headers) {
-        nuxt.options.routeRules['/_og/r/**'] = defu(
-          nuxt.options.routeRules['/_og/r/**'] || {},
-          { headers: { 'cache-control': dynamicCacheControl } },
-        )
+        const ogResolveRule = nuxt.options.routeRules['/_og/r/**']
+        if (!ogResolveRule?.swr && !ogResolveRule?.isr && !ogResolveRule?.cache && !ogResolveRule?.headers) {
+          nuxt.options.routeRules['/_og/r/**'] = defu(
+            nuxt.options.routeRules['/_og/r/**'] || {},
+            { headers: { 'cache-control': dynamicCacheControl } },
+          )
+        }
       }
 
       const ogStaticRule = nuxt.options.routeRules['/_og/s/**']

--- a/src/module.ts
+++ b/src/module.ts
@@ -887,49 +887,46 @@ export default defineNuxtModule<ModuleOptions>({
       handler: resolve('./runtime/server/routes/resolve'),
     })
 
-    // Add cache route rules for OG image endpoints so platforms like Vercel
-    // get durable caching (survives deployments) without manual config.
-    // Skipped if the user already configured a rule for a given route.
+    // Auto-configure cache-control headers for OG image endpoints so CDNs
+    // get correct caching policy at the routing layer. We deliberately set
+    // only `headers` — no `swr`/`isr`/`cache` — because Nitro's
+    // cachedEventHandler wraps the handler in a proxied event with stripped
+    // headers AND JSON-serializes the response body, which corrupts binary
+    // PNG output (see #578). The handler still sets matching Cache-Control
+    // headers on successful responses; these route rules ensure the policy
+    // is visible to platform tooling even before the handler runs.
     if (!nuxt.options.dev) {
       nuxt.options.routeRules = nuxt.options.routeRules || {}
 
-      // Dynamic endpoint: SWR for background revalidation.
-      // Skipped during tests because Nitro's cachedEventHandler wrapper
-      // changes the execution context and can break font loading.
-      if (config.runtimeCacheStorage !== false && !nuxt.options.test) {
-        const ogDynamicRule = nuxt.options.routeRules['/_og/d/**']
-        if (!ogDynamicRule?.swr && !ogDynamicRule?.isr && !ogDynamicRule?.cache && !ogDynamicRule?.headers) {
-          const ttl = config.cacheMaxAgeSeconds ?? config.defaults?.cacheMaxAgeSeconds ?? 60 * 60 * 24 * 3
-          nuxt.options.routeRules['/_og/d/**'] = defu(
-            nuxt.options.routeRules['/_og/d/**'] || {},
-            { swr: ttl },
-          )
-        }
+      const ttl = config.cacheMaxAgeSeconds ?? config.defaults?.cacheMaxAgeSeconds ?? 60 * 60 * 24 * 3
+      // Dynamic URLs are content-addressed (encoded params + component hash),
+      // so the response is effectively immutable for a given URL — stale
+      // revalidation would just return identical bytes. Use `immutable` with
+      // the configured TTL instead.
+      const dynamicCacheControl = `public, max-age=${ttl}, s-maxage=${ttl}, immutable`
+
+      const ogDynamicRule = nuxt.options.routeRules['/_og/d/**']
+      if (!ogDynamicRule?.swr && !ogDynamicRule?.isr && !ogDynamicRule?.cache && !ogDynamicRule?.headers) {
+        nuxt.options.routeRules['/_og/d/**'] = defu(
+          nuxt.options.routeRules['/_og/d/**'] || {},
+          { headers: { 'cache-control': dynamicCacheControl } },
+        )
       }
 
-      // Prerendered endpoint: immutable static assets baked at build time
+      const ogResolveRule = nuxt.options.routeRules['/_og/r/**']
+      if (!ogResolveRule?.swr && !ogResolveRule?.isr && !ogResolveRule?.cache && !ogResolveRule?.headers) {
+        nuxt.options.routeRules['/_og/r/**'] = defu(
+          nuxt.options.routeRules['/_og/r/**'] || {},
+          { headers: { 'cache-control': dynamicCacheControl } },
+        )
+      }
+
       const ogStaticRule = nuxt.options.routeRules['/_og/s/**']
       if (!ogStaticRule?.swr && !ogStaticRule?.isr && !ogStaticRule?.cache && !ogStaticRule?.headers) {
         nuxt.options.routeRules['/_og/s/**'] = defu(
           nuxt.options.routeRules['/_og/s/**'] || {},
           { headers: { 'cache-control': 'public, max-age=31536000, immutable' } },
         )
-      }
-
-      // Resolver endpoint: SWR to cache the redirect resolution. Each resolution
-      // costs one HTML fetch; SWR lets background revalidation keep it warm.
-      // Skipped during tests for the same reason as /_og/d/**: Nitro's
-      // cachedEventHandler wrapper changes the execution context and can break
-      // font loading in the tests that assert image output.
-      if (config.runtimeCacheStorage !== false && !nuxt.options.test) {
-        const ogResolveRule = nuxt.options.routeRules['/_og/r/**']
-        if (!ogResolveRule?.swr && !ogResolveRule?.isr && !ogResolveRule?.cache && !ogResolveRule?.headers) {
-          const ttl = config.cacheMaxAgeSeconds ?? config.defaults?.cacheMaxAgeSeconds ?? 60 * 60 * 24 * 3
-          nuxt.options.routeRules['/_og/r/**'] = defu(
-            nuxt.options.routeRules['/_og/r/**'] || {},
-            { swr: ttl },
-          )
-        }
       }
     }
 

--- a/src/runtime/server/util/cache.ts
+++ b/src/runtime/server/util/cache.ts
@@ -104,7 +104,7 @@ export async function useOgImageBufferCache(ctx: OgImageRenderEventContext, opti
         'Vary': 'accept-encoding, host',
         'etag': `W/"${digest(value)}"`,
         'last-modified': new Date().toUTCString(),
-        'cache-control': `public, max-age=${maxAge}, s-maxage=${maxAge}, stale-while-revalidate=${maxAge}, stale-if-error=${maxAge}`,
+        'cache-control': `public, max-age=${maxAge}, s-maxage=${maxAge}, immutable`,
       }
       setHeaders(ctx.e, headers)
       await cache.setItem(key, {

--- a/test/e2e/cache.test.ts
+++ b/test/e2e/cache.test.ts
@@ -66,7 +66,7 @@ describe('cache headers', () => {
     expect(ogUrl).toBeTruthy()
 
     const res = await fetch(ogUrl!)
-    expect(res.headers.get('cache-control')).toMatchInlineSnapshot(`"public, max-age=259200, s-maxage=259200, stale-while-revalidate=259200, stale-if-error=259200"`)
+    expect(res.headers.get('cache-control')).toMatchInlineSnapshot(`"public, max-age=259200, s-maxage=259200, immutable"`)
     expect(res.headers.get('x-og-cache')).toMatchInlineSnapshot(`"MISS"`)
     expect(res.headers.get('etag')).toBeTruthy()
     expect(res.headers.get('last-modified')).toBeTruthy()


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #578

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

In v6.3.8 the module started auto-applying Nitro `swr` route rules to `/_og/d/**` and `/_og/r/**` when `cacheMaxAgeSeconds` was set. On Cloudflare Workers, Nitro's `cachedEventHandler` wraps requests in a proxied event with stripped headers and JSON-serializes the response body, which breaks internal `fetchIsland` calls (403s) and corrupts binary PNG output.

This drops the auto SWR rules. Instead, we set immutable `Cache-Control` headers at the route level so CDNs still get the correct caching policy without wrapping the handler. URLs are content-addressed (params + component hash), so `immutable` is accurate; the response bytes never change for a given URL. Docs updated to match.