### PR TITLE
fix: dispose prior og:image head entry on client navigation

### DIFF
--- a/src/runtime/app/client-utils.ts
+++ b/src/runtime/app/client-utils.ts
@@ -1,11 +1,38 @@
+import type { ActiveHeadEntry, Head, UseHeadInput } from '@unhead/vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import type { DefineOgImageInput, OgImageOptions, OgImageOptionsInternal, OgImagePrebuilt } from '../types'
 import { componentNames } from '#build/nuxt-og-image/components.mjs'
 import { defu } from 'defu'
-import { useHead, useRuntimeConfig } from 'nuxt/app'
+import { injectHead, useHead, useRuntimeConfig } from 'nuxt/app'
 import { joinURL, withQuery } from 'ufo'
 import { toValue } from 'vue'
 import { buildOgImageUrl, generateMeta, separateProps } from '../shared'
+
+// Per-head-client map of active useHead entries, keyed by og key. Scoped to the
+// Nuxt app via its head instance (released automatically when the head GCs).
+// SPA navigations from a persistent scope (app.vue, layout, root plugin) would
+// otherwise accumulate one useHead entry per navigation, since Vue's scope-
+// dispose only fires on component unmount.
+const clientEntriesByHead: WeakMap<object, Map<string, ActiveHeadEntry<Head>>> = /* @__PURE__ */ new WeakMap()
+
+function registerClientOgHead(ogKey: string, input: UseHeadInput, options?: Parameters<typeof useHead>[1]): void {
+  let entries: Map<string, ActiveHeadEntry<Head>> | undefined
+  try {
+    const head = injectHead() as object | undefined
+    if (head) {
+      entries = clientEntriesByHead.get(head)
+      if (!entries) {
+        entries = new Map()
+        clientEntriesByHead.set(head, entries)
+      }
+    }
+  }
+  catch {}
+  entries?.get(ogKey)?.dispose()
+  const entry = useHead(input, options) as ActiveHeadEntry<Head> | undefined
+  if (entry && entries)
+    entries.set(ogKey, entry)
+}
 
 /**
  * Client-only helpers used by `defineOgImage` during SPA navigation. Lives in its
@@ -112,19 +139,20 @@ export function clientProcessOgImageOptions(
     if (route.query)
       (validOptions as OgImageOptionsInternal)._query = route.query
 
+    const ogKey = (validOptions as OgImageOptions).key || 'og'
+
     // Prebuilt URL override: user pointed at a specific URL, use it directly.
     if ((validOptions as OgImagePrebuilt).url) {
       const url = (validOptions as OgImagePrebuilt).url as string
-      useHead({ meta: generateMeta(url, validOptions) }, { tagPriority: 'high' })
+      registerClientOgHead(ogKey, { meta: generateMeta(url, validOptions) }, { tagPriority: 'high' })
       paths.push(url)
       continue
     }
 
     // SSR: route through the resolver for a guaranteed match with the server URL.
     if (publicCfg.hasServerRuntime) {
-      const ogKey = (validOptions as OgImageOptions).key || 'og'
       const finalUrl = buildResolverUrl(baseURL, basePath, ogKey, route.query as Record<string, any> | undefined)
-      useHead({ meta: generateMeta(finalUrl, validOptions) }, { tagPriority: 35 })
+      registerClientOgHead(ogKey, { meta: generateMeta(finalUrl, validOptions) }, { tagPriority: 35 })
       paths.push(finalUrl)
       continue
     }
@@ -143,7 +171,7 @@ export function clientProcessOgImageOptions(
     const finalUrl = opts._query && Object.keys(opts._query).length
       ? withQuery(resolvedUrl, { _query: opts._query })
       : resolvedUrl
-    useHead({ meta: generateMeta(finalUrl, opts) }, { processTemplateParams: true, tagPriority: 35 })
+    registerClientOgHead(ogKey, { meta: generateMeta(finalUrl, opts) }, { processTemplateParams: true, tagPriority: 35 })
     paths.push(finalUrl)
   }
 

--- a/test/e2e/spa-nav.test.ts
+++ b/test/e2e/spa-nav.test.ts
@@ -65,6 +65,44 @@ describe('sPA navigation og:image', () => {
     await page.close()
   }, 60000)
 
+  // Regression for client-side head-entry leak: each SPA navigation re-registered
+  // a fresh useHead without disposing the prior one, so og:* meta tags accumulated
+  // in the DOM (and their head entries in unhead). After N round-trips there should
+  // still be exactly one og:image tag.
+  it.runIf(process.env.HAS_CHROME)('does not accumulate og:image meta tags across navigations', async () => {
+    const page = await createPage(undefined)
+    await page.goto(url('/satori/spa-nav-a'), { waitUntil: 'networkidle' })
+    await page.waitForTimeout(2000)
+
+    for (let i = 0; i < 3; i++) {
+      await Promise.all([
+        page.waitForURL('**/satori/spa-nav-b'),
+        page.click('#to-b'),
+      ])
+      await page.waitForFunction(
+        () => document.querySelector('meta[property="og:image"]')?.getAttribute('content')?.includes('/_og/r/satori/spa-nav-b'),
+        null,
+        { timeout: 5000 },
+      )
+      await Promise.all([
+        page.waitForURL('**/satori/spa-nav-a'),
+        page.click('#to-a'),
+      ])
+      await page.waitForFunction(
+        () => document.querySelector('meta[property="og:image"]')?.getAttribute('content')?.includes('/_og/r/satori/spa-nav-a'),
+        null,
+        { timeout: 5000 },
+      )
+    }
+
+    const ogImageCount = await page.locator('meta[property="og:image"]').count()
+    expect(ogImageCount).toBe(1)
+    const twitterImageCount = await page.locator('meta[name="twitter:image"]').count()
+    expect(twitterImageCount).toBeLessThanOrEqual(1)
+
+    await page.close()
+  }, 60000)
+
   it.runIf(process.env.HAS_CHROME)('forwards query params through the resolver URL', async () => {
     const page = await createPage(undefined)
     await page.goto(url('/satori/spa-nav-a'), { waitUntil: 'networkidle' })


### PR DESCRIPTION
### 🔗 Linked issue

Related to #575 (regression since v6.4.1 / f8cdc32e)

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Since v6.4.1, SPA navigation in `nuxt-og-image` called `useHead()` without disposing the prior entry. When `defineOgImage` ran from a persistent scope (app.vue, layouts, root plugins), Vue's scope-dispose never fired, so `og:*` meta tags and their reactive bindings accumulated in the DOM and in unhead across every navigation.

Fix tracks active `useHead` entries in a per-head `WeakMap` keyed by og key, disposing the prior entry before registering the replacement. Added a regression e2e test that round-trips between two routes and asserts exactly one `og:image` meta tag remains.