### PR TITLE
fix: add image fetch timeouts and Server-Timing instrumentation

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -209,6 +209,17 @@ export interface ModuleOptions {
     /** Render timeout in milliseconds. Returns 408 on timeout. @default 15000 */
     renderTimeout?: number
     /**
+     * Per-image fetch timeout in milliseconds.
+     *
+     * Applies to remote `<img>` / `background-image` fetches done while resolving templates.
+     * A stalled resource can otherwise consume the entire `renderTimeout` budget, which
+     * shows up as near-total request timeouts on edge platforms (e.g. Cloudflare Workers
+     * when the image URL routes back through the same worker).
+     *
+     * @default 3000
+     */
+    imageFetchTimeout?: number
+    /**
      * Maximum allowed length (in characters) for the query string on runtime OG image requests.
      * Requests exceeding this limit receive a 400 response.
      *
@@ -1530,6 +1541,7 @@ export const rootDir = ${JSON.stringify(nuxt.options.rootDir)}`
           maxDimension: config.security?.maxDimension ?? 2048,
           maxDpr: config.security?.maxDpr ?? 2,
           renderTimeout: config.security?.renderTimeout ?? 15_000,
+          imageFetchTimeout: config.security?.imageFetchTimeout ?? 3_000,
           maxQueryParamSize: config.security?.maxQueryParamSize ?? (config.security?.strict ? 2048 : null),
           restrictRuntimeImagesToOrigin: config.security?.restrictRuntimeImagesToOrigin === true || (config.security?.strict && config.security?.restrictRuntimeImagesToOrigin == null)
             ? []

--- a/src/runtime/server/og-image/bindings/font-assets/cloudflare.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/cloudflare.ts
@@ -1,9 +1,9 @@
 import type { H3Event } from 'h3'
 import type { FontConfig } from '../../../../types'
-import { getRequestHost } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { withBase } from 'ufo'
-import { getCloudflareAssets, tryCloudflareAssetsFetch } from '../../../util/cloudflareAssets'
+import { getCloudflareAssets } from '../../../util/cloudflareAssets'
+import { fetchLocalAsset } from '../../../util/fetchLocalAsset'
 import { getFetchTimeout } from '../../../util/fetchTimeout'
 import { useOgImageRuntimeConfig } from '../../../utils'
 
@@ -12,24 +12,12 @@ export async function resolve(event: H3Event, font: FontConfig) {
   const { app } = useRuntimeConfig()
   const fullPath = withBase(path, app.baseURL)
   const timeout = getFetchTimeout(useOgImageRuntimeConfig())
-  const assets = getCloudflareAssets(event)
 
-  const assetsBuffer = await tryCloudflareAssetsFetch(event, fullPath, AbortSignal.timeout(timeout))
-  if (assetsBuffer)
-    return Buffer.from(assetsBuffer)
+  const ab = await fetchLocalAsset(event, fullPath, { fetchTimeout: timeout })
+  if (ab)
+    return Buffer.from(ab)
 
-  // Fallback: use event.fetch (Nitro localFetch) which routes through the h3 app
-  // and can serve public assets from Nitro's built-in asset handler.
-  if (typeof event.fetch === 'function') {
-    const origin = event.context.cloudflare?.request?.url || `https://${getRequestHost(event) || 'localhost'}`
-    const url = new URL(fullPath, origin).href
-    const res = await event.fetch(url, { signal: AbortSignal.timeout(timeout) } as any).catch(() => null) as Response | null
-    if (res?.ok) {
-      return Buffer.from(await res.arrayBuffer())
-    }
-  }
-
-  if (!assets && !event.context._ogImageWarnedMissingAssets) {
+  if (!getCloudflareAssets(event) && !event.context._ogImageWarnedMissingAssets) {
     event.context._ogImageWarnedMissingAssets = true
     console.warn(
       `[Nuxt OG Image] No ASSETS binding found on Cloudflare Workers. Font loading will fail. `

--- a/src/runtime/server/og-image/bindings/font-assets/cloudflare.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/cloudflare.ts
@@ -2,32 +2,27 @@ import type { H3Event } from 'h3'
 import type { FontConfig } from '../../../../types'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { withBase } from 'ufo'
+import { getCloudflareAssets, tryCloudflareAssetsFetch } from '../../../util/cloudflareAssets'
+import { getFetchTimeout } from '../../../util/fetchTimeout'
+import { useOgImageRuntimeConfig } from '../../../utils'
 
 export async function resolve(event: H3Event, font: FontConfig) {
   const path = font.src || font.localPath
   const { app } = useRuntimeConfig()
   const fullPath = withBase(path, app.baseURL)
+  const timeout = getFetchTimeout(useOgImageRuntimeConfig())
+  const assets = getCloudflareAssets(event)
 
-  // Try ASSETS binding first (Cloudflare Pages / Workers with static assets)
-  // This is the recommended approach and requires either:
-  // - nitro.cloudflare.deployConfig: true (generates wrangler.json with ASSETS binding)
-  // - A wrangler.toml/json with [assets] configured
-  const assets = event.context.cloudflare?.env?.ASSETS || event.context.ASSETS
-  if (assets && typeof assets.fetch === 'function') {
-    const origin = event.context.cloudflare?.request?.url || `https://${event.headers.get('host') || 'localhost'}`
-    const url = new URL(fullPath, origin).href
-    const res = await assets.fetch(url).catch(() => null) as Response | null
-    if (res?.ok) {
-      return Buffer.from(await res.arrayBuffer())
-    }
-  }
+  const assetsBuffer = await tryCloudflareAssetsFetch(event, fullPath, AbortSignal.timeout(timeout))
+  if (assetsBuffer)
+    return Buffer.from(assetsBuffer)
 
   // Fallback: use event.fetch (Nitro localFetch) which routes through the h3 app
   // and can serve public assets from Nitro's built-in asset handler.
   if (typeof event.fetch === 'function') {
     const origin = event.context.cloudflare?.request?.url || `https://${event.headers.get('host') || 'localhost'}`
     const url = new URL(fullPath, origin).href
-    const res = await event.fetch(url).catch(() => null) as Response | null
+    const res = await event.fetch(url, { signal: AbortSignal.timeout(timeout) } as any).catch(() => null) as Response | null
     if (res?.ok) {
       return Buffer.from(await res.arrayBuffer())
     }

--- a/src/runtime/server/og-image/bindings/font-assets/cloudflare.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/cloudflare.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
 import type { FontConfig } from '../../../../types'
+import { getRequestHost } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { withBase } from 'ufo'
 import { getCloudflareAssets, tryCloudflareAssetsFetch } from '../../../util/cloudflareAssets'
@@ -20,7 +21,7 @@ export async function resolve(event: H3Event, font: FontConfig) {
   // Fallback: use event.fetch (Nitro localFetch) which routes through the h3 app
   // and can serve public assets from Nitro's built-in asset handler.
   if (typeof event.fetch === 'function') {
-    const origin = event.context.cloudflare?.request?.url || `https://${event.headers.get('host') || 'localhost'}`
+    const origin = event.context.cloudflare?.request?.url || `https://${getRequestHost(event) || 'localhost'}`
     const url = new URL(fullPath, origin).href
     const res = await event.fetch(url, { signal: AbortSignal.timeout(timeout) } as any).catch(() => null) as Response | null
     if (res?.ok) {

--- a/src/runtime/server/og-image/bindings/font-assets/dev-prerender.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/dev-prerender.ts
@@ -6,6 +6,8 @@ import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { join } from 'pathe'
 import { withBase } from 'ufo'
+import { getFetchTimeout } from '../../../util/fetchTimeout'
+import { useOgImageRuntimeConfig } from '../../../utils'
 
 let fontUrlMapping: Record<string, string> | undefined
 
@@ -19,6 +21,7 @@ async function loadFontUrlMapping(): Promise<Record<string, string>> {
 
 export async function resolve(event: H3Event, font: FontConfig): Promise<Buffer> {
   const path = font.src || font.localPath
+  const timeout = getFetchTimeout(useOgImageRuntimeConfig())
 
   // Static bundled fonts — read directly from absolute path
   if (font.absolutePath) {
@@ -48,7 +51,7 @@ export async function resolve(event: H3Event, font: FontConfig): Promise<Buffer>
 
       const mapping = await loadFontUrlMapping()
       if (mapping[filename]) {
-        const res = await fetch(mapping[filename]).catch(() => null)
+        const res = await fetch(mapping[filename], { signal: AbortSignal.timeout(timeout) }).catch(() => null)
         if (res?.ok)
           return Buffer.from(await res.arrayBuffer())
       }
@@ -78,7 +81,7 @@ export async function resolve(event: H3Event, font: FontConfig): Promise<Buffer>
     const filename = path.slice('/_fonts/'.length)
     const mapping = await loadFontUrlMapping()
     if (mapping[filename]) {
-      const res = await fetch(mapping[filename]).catch(() => null)
+      const res = await fetch(mapping[filename], { signal: AbortSignal.timeout(timeout) }).catch(() => null)
       if (res?.ok)
         return Buffer.from(await res.arrayBuffer())
     }
@@ -99,7 +102,7 @@ export async function resolve(event: H3Event, font: FontConfig): Promise<Buffer>
     const reqUrl = getRequestURL(event)
     const origin = `${reqUrl.protocol}//${reqUrl.host}`
     const url = new URL(withBase(path, app.baseURL), origin).href
-    const res = await fetch(url).catch(() => null)
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeout) }).catch(() => null)
     if (res?.ok) {
       return Buffer.from(await res.arrayBuffer())
     }
@@ -108,6 +111,7 @@ export async function resolve(event: H3Event, font: FontConfig): Promise<Buffer>
   // @ts-expect-error excessive stack depth from Nuxt typed routes
   const arrayBuffer = await event.$fetch(fullPath, {
     responseType: 'arrayBuffer',
+    timeout,
   }) as ArrayBuffer
   return Buffer.from(arrayBuffer)
 }

--- a/src/runtime/server/og-image/bindings/font-assets/node.ts
+++ b/src/runtime/server/og-image/bindings/font-assets/node.ts
@@ -3,13 +3,16 @@ import type { FontConfig } from '../../../../types'
 import { getNitroOrigin } from '#site-config/server/composables'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { withBase } from 'ufo'
+import { getFetchTimeout } from '../../../util/fetchTimeout'
+import { useOgImageRuntimeConfig } from '../../../utils'
 
 export async function resolve(event: H3Event, font: FontConfig) {
   const path = font.src || font.localPath
   const { app } = useRuntimeConfig()
   const fullPath = withBase(path, app.baseURL)
   const origin = getNitroOrigin(event)
-  const res = await fetch(new URL(fullPath, origin).href).catch(() => null)
+  const timeout = getFetchTimeout(useOgImageRuntimeConfig())
+  const res = await fetch(new URL(fullPath, origin).href, { signal: AbortSignal.timeout(timeout) }).catch(() => null)
   if (res?.ok) {
     return Buffer.from(await res.arrayBuffer())
   }
@@ -17,6 +20,7 @@ export async function resolve(event: H3Event, font: FontConfig) {
   // (behind a proxy, serverless, or server not fully started)
   const arrayBuffer = await event.$fetch(fullPath, {
     responseType: 'arrayBuffer',
+    timeout,
   }) as ArrayBuffer
   return Buffer.from(arrayBuffer)
 }

--- a/src/runtime/server/og-image/browser/screenshot.ts
+++ b/src/runtime/server/og-image/browser/screenshot.ts
@@ -5,6 +5,7 @@ import { getNitroOrigin } from '#site-config/server/composables'
 import { withQuery } from 'ufo'
 import { toValue } from 'vue'
 import { buildOgImageUrl } from '../../../shared'
+import { getFetchTimeout } from '../../util/fetchTimeout'
 import { logger } from '../../util/logger'
 import { useOgImageRuntimeConfig } from '../../utils'
 
@@ -79,8 +80,9 @@ async function takeScreenshot(page: Page, selector: string | undefined, options:
   return await page.screenshot(puppeteerOptions)
 }
 
-export async function createScreenshot({ basePath, e, options, extension }: OgImageRenderEventContext, browser: Browser): Promise<Buffer> {
-  const { colorPreference, defaults, security } = useOgImageRuntimeConfig()
+export async function createScreenshot({ basePath, e, options, extension, timings }: OgImageRenderEventContext, browser: Browser): Promise<Buffer> {
+  const runtimeConfig = useOgImageRuntimeConfig()
+  const { colorPreference, defaults, security } = runtimeConfig
   // For browser renderer, we need to load the HTML template with options encoded in URL
   const path = options.component === 'PageScreenshot' ? basePath : buildOgImageUrl(options, 'html', false, defaults, security?.secret || undefined).url
 
@@ -110,7 +112,9 @@ export async function createScreenshot({ basePath, e, options, extension }: OgIm
     }
     if (import.meta.prerender && !options.html) {
       // we need to do a nitro fetch for the HTML instead of rendering with browser
-      options.html = await e.$fetch(path).catch(() => undefined) as string
+      const endFetch = timings.start('html-fetch')
+      options.html = await e.$fetch(path, { timeout: getFetchTimeout(runtimeConfig) }).catch(() => undefined) as string
+      endFetch()
     }
 
     await setViewport(
@@ -159,7 +163,7 @@ export async function createScreenshot({ basePath, e, options, extension }: OgIm
       }, _options.mask)
     }
 
-    return await takeScreenshot(page, _options.selector, screenshotOptions)
+    return await timings.measure('render-browser', () => takeScreenshot(page, _options.selector, screenshotOptions))
   }
   finally {
     await page.close()

--- a/src/runtime/server/og-image/browser/screenshot.ts
+++ b/src/runtime/server/og-image/browser/screenshot.ts
@@ -112,9 +112,8 @@ export async function createScreenshot({ basePath, e, options, extension, timing
     }
     if (import.meta.prerender && !options.html) {
       // we need to do a nitro fetch for the HTML instead of rendering with browser
-      const endFetch = timings.start('html-fetch')
-      options.html = await e.$fetch(path, { timeout: getFetchTimeout(runtimeConfig) }).catch(() => undefined) as string
-      endFetch()
+      options.html = await timings.measure('html-fetch', () =>
+        e.$fetch(path, { timeout: getFetchTimeout(runtimeConfig) }).catch(() => undefined)) as string
     }
 
     await setViewport(

--- a/src/runtime/server/og-image/context.ts
+++ b/src/runtime/server/og-image/context.ts
@@ -21,6 +21,7 @@ import { decodeOgImageParams, extractEncodedSegment, sanitizeProps, separateProp
 import { autoEjectCommunityTemplate } from '../util/auto-eject'
 import { createNitroRouteRuleMatcher } from '../util/kit'
 import { normaliseOptions } from '../util/options'
+import { createTimings, TIMING_CTX_KEY } from '../util/timings'
 import { useOgImageRuntimeConfig } from '../utils'
 import { getBrowserRenderer, getSatoriRenderer, getTakumiRenderer } from './instances'
 
@@ -257,6 +258,8 @@ export async function resolveContext(e: H3Event): Promise<H3Error | OgImageRende
       statusMessage: `[Nuxt OG Image] Renderer "${rendererType}" is not available. Component "${normalised.component?.pascalName}" requires the ${rendererType} renderer but it's not bundled for this preset.`,
     })
   }
+  const timings = (e.context[TIMING_CTX_KEY] as ReturnType<typeof createTimings>) || createTimings()
+  e.context[TIMING_CTX_KEY] = timings
   const ctx: OgImageRenderEventContext = {
     e,
     key,
@@ -267,6 +270,7 @@ export async function resolveContext(e: H3Event): Promise<H3Error | OgImageRende
     extension,
     basePath,
     options: normalised.options,
+    timings,
     _nitro: useNitroApp(),
   }
   // call the nitro hook

--- a/src/runtime/server/og-image/core/plugins/imageSrc.ts
+++ b/src/runtime/server/og-image/core/plugins/imageSrc.ts
@@ -155,38 +155,52 @@ async function doResolveSrcToBuffer(
       buffer = await resolveLocalFilePathImage(publicStoragePath, srcWithoutBase)
     }
     if (!buffer && !import.meta.prerender) {
-      // CF Workers ASSETS binding: hits the static asset handler directly.
-      // No subrequest billed, no middleware re-run. Returns undefined for
-      // non-asset paths so Nitro routes still resolve via localFetch below.
+      // Shared deadline across the fallback ladder: a broken URL should not
+      // burn 3× fetchTimeout before the render sees the failure.
+      const deadline = AbortSignal.timeout(fetchTimeout)
+      const remaining = () => {
+        // rough approximation; ofetch's own timeout also enforces upper bound
+        return deadline.aborted ? 1 : fetchTimeout
+      }
       const end = timings.start('image-fetch')
-      buffer = await tryCloudflareAssetsFetch(e, src, AbortSignal.timeout(fetchTimeout))
-        .catch((err) => {
-          logFailure(src, err)
-          return undefined
-        })
-      if (!buffer) {
-        buffer = (await e.$fetch(src, {
-          responseType: 'arrayBuffer',
-          timeout: fetchTimeout,
-          headers: SUBREQUEST_HEADERS,
-        }).catch((err) => {
-          logFailure(src, err)
-        })) as BufferSource | undefined
+      try {
+        // CF Workers ASSETS binding: hits the static asset handler directly.
+        // No subrequest billed, no middleware re-run. Returns undefined for
+        // non-asset paths so Nitro routes still resolve via localFetch below.
+        buffer = await tryCloudflareAssetsFetch(e, src, deadline)
+          .catch((err) => {
+            logFailure(src, err)
+            return undefined
+          })
+        if (!buffer && !deadline.aborted) {
+          // Nitro localFetch: resolves dynamic routes (not just static assets).
+          buffer = (await e.$fetch(src, {
+            responseType: 'arrayBuffer',
+            signal: deadline,
+            timeout: remaining(),
+            headers: SUBREQUEST_HEADERS,
+          }).catch((err) => {
+            logFailure(src, err)
+          })) as BufferSource | undefined
+        }
+        if (!buffer && !deadline.aborted) {
+          // Real external fetch: for platforms where the static asset is served
+          // by platform-level routing (Vercel, Netlify edge) and never reaches
+          // Nitro. Uses global $fetch (ofetch) for a true HTTP hop.
+          const absolute = `${getNitroOrigin(e)}${src}`
+          buffer = (await $fetch(absolute, {
+            responseType: 'arrayBuffer',
+            signal: deadline,
+            timeout: remaining(),
+            headers: SUBREQUEST_HEADERS,
+          }).catch((err) => {
+            logFailure(absolute, err)
+          })) as BufferSource | undefined
+        }
       }
-      if (!buffer) {
-        // Last-resort: same-origin subrequest for platforms without an ASSETS
-        // binding but with platform-level static routing (Vercel, Netlify, etc).
-        const absolute = `${getNitroOrigin(e)}${src}`
-        buffer = (await e.$fetch(src, {
-          baseURL: getNitroOrigin(e),
-          responseType: 'arrayBuffer',
-          timeout: fetchTimeout,
-          headers: SUBREQUEST_HEADERS,
-        }).catch((err) => {
-          logFailure(absolute, err)
-        })) as BufferSource | undefined
+      finally {
+        end()
       }
-      end()
     }
     return buffer ? { buffer } : {}
   }
@@ -202,8 +216,7 @@ async function doResolveSrcToBuffer(
     timeout: fetchTimeout,
   }).catch((err) => {
     logFailure(decodedSrc, err)
-  })) as BufferSource | undefined
-  end()
+  }).finally(end)) as BufferSource | undefined
   return buffer ? { buffer } : {}
 }
 

--- a/src/runtime/server/og-image/core/plugins/imageSrc.ts
+++ b/src/runtime/server/og-image/core/plugins/imageSrc.ts
@@ -97,7 +97,11 @@ async function resolveLocalFilePathImage(publicStoragePath: string, src: string)
 }
 
 function toBufferSourceAsBase64(buf: BufferSource): string {
-  const ab = buf instanceof ArrayBuffer ? buf : buf.buffer as ArrayBuffer
+  const ab = buf instanceof ArrayBuffer
+    ? buf
+    : ArrayBuffer.isView(buf)
+      ? buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
+      : buf
   return toBase64Image(ab)
 }
 
@@ -213,7 +217,12 @@ function applyImageDimensions(node: VNode, buffer: BufferSource) {
   // infer missing dimensions from the image's natural aspect ratio
   if (node.props.width && node.props.height)
     return
-  const dimensions = getImageDimensions(buffer as Uint8Array)
+  const view = buffer instanceof Uint8Array
+    ? buffer
+    : ArrayBuffer.isView(buffer)
+      ? new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+      : new Uint8Array(buffer)
+  const dimensions = getImageDimensions(view)
   if (!dimensions?.width || !dimensions?.height)
     return
   const naturalAspectRatio = dimensions.width / dimensions.height

--- a/src/runtime/server/og-image/core/plugins/imageSrc.ts
+++ b/src/runtime/server/og-image/core/plugins/imageSrc.ts
@@ -4,8 +4,8 @@ import { getNitroOrigin } from '#site-config/server/composables/getNitroOrigin'
 import { useStorage } from 'nitropack/runtime'
 import { withBase, withoutLeadingSlash } from 'ufo'
 import { toBase64Image } from '../../../../shared'
-import { tryCloudflareAssetsFetch } from '../../../util/cloudflareAssets'
 import { decodeHtml } from '../../../util/encoding'
+import { fetchLocalAsset } from '../../../util/fetchLocalAsset'
 import { getFetchTimeout } from '../../../util/fetchTimeout'
 import { logger } from '../../../util/logger'
 import { getImageDimensions } from '../../utils/image-detector'
@@ -155,52 +155,14 @@ async function doResolveSrcToBuffer(
       buffer = await resolveLocalFilePathImage(publicStoragePath, srcWithoutBase)
     }
     if (!buffer && !import.meta.prerender) {
-      // Shared deadline across the fallback ladder: a broken URL should not
-      // burn 3× fetchTimeout before the render sees the failure.
-      const deadline = AbortSignal.timeout(fetchTimeout)
-      const remaining = () => {
-        // rough approximation; ofetch's own timeout also enforces upper bound
-        return deadline.aborted ? 1 : fetchTimeout
-      }
-      const end = timings.start('image-fetch')
-      try {
-        // CF Workers ASSETS binding: hits the static asset handler directly.
-        // No subrequest billed, no middleware re-run. Returns undefined for
-        // non-asset paths so Nitro routes still resolve via localFetch below.
-        buffer = await tryCloudflareAssetsFetch(e, src, deadline)
-          .catch((err) => {
-            logFailure(src, err)
-            return undefined
-          })
-        if (!buffer && !deadline.aborted) {
-          // Nitro localFetch: resolves dynamic routes (not just static assets).
-          buffer = (await e.$fetch(src, {
-            responseType: 'arrayBuffer',
-            signal: deadline,
-            timeout: remaining(),
-            headers: SUBREQUEST_HEADERS,
-          }).catch((err) => {
-            logFailure(src, err)
-          })) as BufferSource | undefined
-        }
-        if (!buffer && !deadline.aborted) {
-          // Real external fetch: for platforms where the static asset is served
-          // by platform-level routing (Vercel, Netlify edge) and never reaches
-          // Nitro. Uses global $fetch (ofetch) for a true HTTP hop.
-          const absolute = `${getNitroOrigin(e)}${src}`
-          buffer = (await $fetch(absolute, {
-            responseType: 'arrayBuffer',
-            signal: deadline,
-            timeout: remaining(),
-            headers: SUBREQUEST_HEADERS,
-          }).catch((err) => {
-            logFailure(absolute, err)
-          })) as BufferSource | undefined
-        }
-      }
-      finally {
-        end()
-      }
+      const ab = await timings.measure('image-fetch', () => fetchLocalAsset(e, src, {
+        fetchTimeout,
+        headers: SUBREQUEST_HEADERS,
+        includeExternalFallback: true,
+        onStepFailure: logFailure,
+      }))
+      if (ab)
+        buffer = new Uint8Array(ab)
     }
     return buffer ? { buffer } : {}
   }

--- a/src/runtime/server/og-image/core/plugins/imageSrc.ts
+++ b/src/runtime/server/og-image/core/plugins/imageSrc.ts
@@ -1,9 +1,12 @@
+import type { H3Event } from 'h3'
 import type { OgImageRenderEventContext, VNode } from '../../../../types'
 import { getNitroOrigin } from '#site-config/server/composables/getNitroOrigin'
 import { useStorage } from 'nitropack/runtime'
 import { withBase, withoutLeadingSlash } from 'ufo'
 import { toBase64Image } from '../../../../shared'
+import { tryCloudflareAssetsFetch } from '../../../util/cloudflareAssets'
 import { decodeHtml } from '../../../util/encoding'
+import { getFetchTimeout } from '../../../util/fetchTimeout'
 import { logger } from '../../../util/logger'
 import { getImageDimensions } from '../../utils/image-detector'
 import { defineTransformer } from '../plugins'
@@ -76,10 +79,13 @@ function isBlockedUrl(url: string): boolean {
 const RE_URL_LEADING = /^url\(['"]?/
 const RE_URL_TRAILING = /['"]?\)$/
 
+// Marker header lets downstream middleware short-circuit expensive work on
+// subrequests we make during OG image rendering (e.g. on CF Workers where a
+// logo/asset path may route back through the same worker).
+const SUBREQUEST_HEADERS = { 'x-nuxt-og-image': '1' }
+
 async function resolveLocalFilePathImage(publicStoragePath: string, src: string) {
-  // try hydrating from storage
-  // we need to read the file using unstorage
-  // because we can't fetch public files using $fetch when prerendering
+  // try hydrating from storage — can't fetch public files via $fetch when prerendering
   const normalizedSrc = withoutLeadingSlash(src
     .replace('_nuxt/@fs/', '')
     .replace('_nuxt/', '')
@@ -90,150 +96,185 @@ async function resolveLocalFilePathImage(publicStoragePath: string, src: string)
     return await useStorage().getItemRaw(key)
 }
 
-// for relative links we embed them as base64 input or just fix the URL to be absolute
+function toBufferSourceAsBase64(buf: BufferSource): string {
+  const ab = buf instanceof ArrayBuffer ? buf : buf.buffer as ArrayBuffer
+  return toBase64Image(ab)
+}
+
+interface ResolveResult {
+  buffer?: BufferSource
+  blocked?: boolean
+}
+
+// Per-render dedup: the same URL referenced multiple times in a template
+// (e.g. logo in header + footer) resolves once. Scoped by H3Event so buffers
+// don't leak across renders — entries drop with the event reference.
+const renderCaches = new WeakMap<H3Event, Map<string, Promise<ResolveResult>>>()
+
+function getRenderCache(e: H3Event): Map<string, Promise<ResolveResult>> {
+  let cache = renderCaches.get(e)
+  if (!cache) {
+    cache = new Map()
+    renderCaches.set(e, cache)
+  }
+  return cache
+}
+
+function resolveSrcToBuffer(
+  src: string,
+  kind: 'image' | 'background-image',
+  ctx: OgImageRenderEventContext,
+): Promise<ResolveResult> {
+  const cache = getRenderCache(ctx.e)
+  const existing = cache.get(src)
+  if (existing)
+    return existing
+  const promise = doResolveSrcToBuffer(src, kind, ctx)
+  cache.set(src, promise)
+  return promise
+}
+
+async function doResolveSrcToBuffer(
+  src: string,
+  kind: 'image' | 'background-image',
+  { e, publicStoragePath, runtimeConfig, timings }: OgImageRenderEventContext,
+): Promise<ResolveResult> {
+  const fetchTimeout = getFetchTimeout(runtimeConfig)
+  const logFailure = (url: string, err: unknown) => {
+    logger.debug(`[og-image] ${kind} fetch failed (${url}): ${(err as Error)?.message || err}`)
+  }
+
+  if (src.startsWith('/')) {
+    let buffer: BufferSource | undefined
+    if (import.meta.prerender || import.meta.dev) {
+      const srcWithoutBase = src.replace(runtimeConfig.app.baseURL, '/')
+      buffer = await resolveLocalFilePathImage(publicStoragePath, srcWithoutBase)
+    }
+    if (!buffer && !import.meta.prerender) {
+      // CF Workers ASSETS binding: hits the static asset handler directly.
+      // No subrequest billed, no middleware re-run. Returns undefined for
+      // non-asset paths so Nitro routes still resolve via localFetch below.
+      const end = timings.start('image-fetch')
+      buffer = await tryCloudflareAssetsFetch(e, src, AbortSignal.timeout(fetchTimeout))
+        .catch((err) => {
+          logFailure(src, err)
+          return undefined
+        })
+      if (!buffer) {
+        buffer = (await e.$fetch(src, {
+          responseType: 'arrayBuffer',
+          timeout: fetchTimeout,
+          headers: SUBREQUEST_HEADERS,
+        }).catch((err) => {
+          logFailure(src, err)
+        })) as BufferSource | undefined
+      }
+      if (!buffer) {
+        // Last-resort: same-origin subrequest for platforms without an ASSETS
+        // binding but with platform-level static routing (Vercel, Netlify, etc).
+        const absolute = `${getNitroOrigin(e)}${src}`
+        buffer = (await e.$fetch(src, {
+          baseURL: getNitroOrigin(e),
+          responseType: 'arrayBuffer',
+          timeout: fetchTimeout,
+          headers: SUBREQUEST_HEADERS,
+        }).catch((err) => {
+          logFailure(absolute, err)
+        })) as BufferSource | undefined
+      }
+      end()
+    }
+    return buffer ? { buffer } : {}
+  }
+
+  const decodedSrc = decodeHtml(src)
+  if (!import.meta.dev && isBlockedUrl(decodedSrc)) {
+    logger.warn(`Blocked internal ${kind} fetch: ${decodedSrc}`)
+    return { blocked: true }
+  }
+  const end = timings.start('image-fetch')
+  const buffer = (await $fetch(decodedSrc, {
+    responseType: 'arrayBuffer',
+    timeout: fetchTimeout,
+  }).catch((err) => {
+    logFailure(decodedSrc, err)
+  })) as BufferSource | undefined
+  end()
+  return buffer ? { buffer } : {}
+}
+
+function applyImageDimensions(node: VNode, buffer: BufferSource) {
+  // convert string dimensions to numbers for Satori
+  if (typeof node.props.width === 'string')
+    node.props.width = Number(node.props.width) || undefined
+  if (typeof node.props.height === 'string')
+    node.props.height = Number(node.props.height) || undefined
+
+  // infer missing dimensions from the image's natural aspect ratio
+  if (node.props.width && node.props.height)
+    return
+  const dimensions = getImageDimensions(buffer as Uint8Array)
+  if (!dimensions?.width || !dimensions?.height)
+    return
+  const naturalAspectRatio = dimensions.width / dimensions.height
+  if (node.props.width && !node.props.height) {
+    node.props.height = Math.round(node.props.width / naturalAspectRatio)
+  }
+  else if (node.props.height && !node.props.width) {
+    node.props.width = Math.round(node.props.height * naturalAspectRatio)
+  }
+  else {
+    node.props.width = dimensions.width
+    node.props.height = dimensions.height
+  }
+}
+
 export default defineTransformer([
   // fix <img src="">
   {
     filter: (node: VNode) => node.type === 'img' && node.props?.src,
-    transform: async (node: VNode, { e, publicStoragePath, runtimeConfig }: OgImageRenderEventContext) => {
+    transform: async (node: VNode, ctx: OgImageRenderEventContext) => {
       let src: string = node.props.src!
-      const isRelative = src.startsWith('/')
-      let dimensions
-      let imageBuffer: BufferSource | undefined
-
+      if (src.startsWith('data:'))
+        return
       if (src.endsWith('.webp')) {
         logger.warn('Using WebP images with Satori is not supported. Please consider switching image format or use the chromium renderer.', src)
       }
+      const isRelative = src.startsWith('/')
+      if (!isRelative)
+        src = node.props.src = decodeHtml(src)
 
-      if (isRelative) {
-        if (import.meta.prerender || import.meta.dev) {
-          const srcWithoutBase = src.replace(runtimeConfig.app.baseURL, '')
-          // try hydrating from storage
-          // we need to read the file using unstorage
-          // because we can't fetch public files using $fetch when prerendering
-          imageBuffer = await resolveLocalFilePathImage(publicStoragePath, srcWithoutBase)
-        }
-        if (!imageBuffer) {
-          // see if we can fetch it from a kv host if we're using an edge provider
-          imageBuffer = (await e.$fetch(src, { responseType: 'arrayBuffer' })
-            .catch(() => {})) as BufferSource | undefined
-          if (!imageBuffer && !import.meta.prerender) {
-            // see if we can fetch it from a kv host if we're using an edge provider
-            imageBuffer = (await e.$fetch(src, {
-              baseURL: getNitroOrigin(e),
-              responseType: 'arrayBuffer',
-            })
-              .catch(() => {})) as BufferSource | undefined
-          }
-        }
-        // convert relative images to base64 as satori will have no chance of resolving
-        if (imageBuffer) {
-          const buffer = imageBuffer instanceof ArrayBuffer ? imageBuffer : imageBuffer.buffer as ArrayBuffer
-          node.props.src = toBase64Image(buffer)
-        }
+      const result = await resolveSrcToBuffer(src, 'image', ctx)
+      if (result.blocked) {
+        delete node.props.src
+        return
       }
-      // avoid trying to fetch base64 image uris
-      else if (!src.startsWith('data:')) {
-        src = decodeHtml(src)
-        // Block private/loopback URLs outside dev to prevent SSRF
-        if (!import.meta.dev && isBlockedUrl(src)) {
-          logger.warn(`Blocked internal image fetch: ${src}`)
-          delete node.props.src
-        }
-        else {
-          node.props.src = src
-          // fetch remote images and embed as base64 to avoid satori re-fetching at render time
-          imageBuffer = (await $fetch(src, {
-            responseType: 'arrayBuffer',
-          })
-            .catch(() => {})) as BufferSource | undefined
-          if (imageBuffer) {
-            const buffer = imageBuffer instanceof ArrayBuffer ? imageBuffer : imageBuffer.buffer as ArrayBuffer
-            node.props.src = toBase64Image(buffer)
-          }
-        }
+      if (result.buffer) {
+        node.props.src = toBufferSourceAsBase64(result.buffer)
+        applyImageDimensions(node, result.buffer)
+        return
       }
-
-      // convert string dimensions to numbers for Satori
-      if (typeof node.props.width === 'string')
-        node.props.width = Number(node.props.width) || undefined
-      if (typeof node.props.height === 'string')
-        node.props.height = Number(node.props.height) || undefined
-
-      // if we're missing either a height or width on an image we can try and compute it using the image size
-      if (imageBuffer && (!node.props.width || !node.props.height)) {
-        dimensions = getImageDimensions(imageBuffer as Uint8Array)
-        // apply a natural aspect ratio if missing a dimension
-        if (dimensions?.width && dimensions?.height) {
-          const naturalAspectRatio = dimensions.width / dimensions.height
-          if (node.props.width && !node.props.height) {
-            node.props.height = Math.round(node.props.width / naturalAspectRatio)
-          }
-          else if (node.props.height && !node.props.width) {
-            node.props.width = Math.round(node.props.height * naturalAspectRatio)
-          }
-          else if (!node.props.width && !node.props.height) {
-            node.props.width = dimensions.width
-            node.props.height = dimensions.height
-          }
-        }
-      }
-      // if it's still relative, we need to swap out the src for an absolute URL
-      if (typeof node.props.src === 'string' && node.props.src.startsWith('/')) {
-        if (imageBuffer) {
-          const buffer = imageBuffer instanceof ArrayBuffer ? imageBuffer : imageBuffer.buffer as ArrayBuffer
-          node.props.src = toBase64Image(buffer)
-        }
-        else {
-          // with query to avoid satori caching issue
-          node.props.src = `${withBase(src, `${getNitroOrigin(e)}`)}?${Date.now()}`
-        }
-      }
+      // relative src couldn't be fetched — fall back to an absolute URL so
+      // satori/takumi may attempt to resolve at render time
+      if (isRelative)
+        node.props.src = withBase(src, `${getNitroOrigin(ctx.e)}`)
     },
   },
   // fix style="background-image: url('')"
   {
     filter: (node: VNode) => node.props?.style?.backgroundImage?.includes('url('),
-    transform: async (node: VNode, { e, publicStoragePath, runtimeConfig }: OgImageRenderEventContext) => {
-      // same as the above, need to swap out relative background images for absolute
+    transform: async (node: VNode, ctx: OgImageRenderEventContext) => {
       const backgroundImage = node.props.style!.backgroundImage!
       const src = backgroundImage.replace(RE_URL_LEADING, '').replace(RE_URL_TRAILING, '')
       if (src.startsWith('data:'))
         return
-      const isRelative = src?.startsWith('/')
-      let imageBuffer: BufferSource | undefined
-      if (isRelative) {
-        if (import.meta.prerender || import.meta.dev) {
-          const srcWithoutBase = src.replace(runtimeConfig.app.baseURL, '/')
-          imageBuffer = await resolveLocalFilePathImage(publicStoragePath, srcWithoutBase)
-        }
-        if (!imageBuffer) {
-          imageBuffer = (await e.$fetch(src, { responseType: 'arrayBuffer' })
-            .catch(() => {})) as BufferSource | undefined
-          if (!imageBuffer && !import.meta.prerender) {
-            imageBuffer = (await e.$fetch(src, {
-              baseURL: getNitroOrigin(e),
-              responseType: 'arrayBuffer',
-            }).catch(() => {})) as BufferSource | undefined
-          }
-        }
+      const result = await resolveSrcToBuffer(src, 'background-image', ctx)
+      if (result.blocked) {
+        delete node.props.style!.backgroundImage
+        return
       }
-      else {
-        const decodedSrc = decodeHtml(src)
-        if (!import.meta.dev && isBlockedUrl(decodedSrc)) {
-          logger.warn(`Blocked internal background-image fetch: ${decodedSrc}`)
-          delete node.props.style!.backgroundImage
-        }
-        else {
-          imageBuffer = (await $fetch(decodedSrc, {
-            responseType: 'arrayBuffer',
-          }).catch(() => {})) as BufferSource | undefined
-        }
-      }
-      if (imageBuffer) {
-        const buffer = imageBuffer instanceof ArrayBuffer ? imageBuffer : imageBuffer.buffer as ArrayBuffer
-        node.props.style!.backgroundImage = `url(${toBase64Image(buffer)})`
-      }
+      if (result.buffer)
+        node.props.style!.backgroundImage = `url(${toBufferSourceAsBase64(result.buffer)})`
     },
   },
 ])

--- a/src/runtime/server/og-image/core/transforms/emojis/fetch.ts
+++ b/src/runtime/server/og-image/core/transforms/emojis/fetch.ts
@@ -28,31 +28,39 @@ export async function getEmojiSvg(ctx: OgImageRenderEventContext, emojiChar: str
   // If not in cache, try API calls
   if (!svg) {
     const timeout = getFetchTimeout(ctx.runtimeConfig)
+    // Shared deadline across all name candidates so one emoji can't consume
+    // more than `timeout` ms total (retries disabled for the same reason).
+    const deadline = AbortSignal.timeout(timeout)
     const endTiming = ctx.timings.start('emoji-fetch')
-    // Try each possible name with the API
-    for (const iconName of possibleNames) {
-      try {
-        svg = await $fetch(`https://api.iconify.design/${emojiSet}/${iconName}.svg`, {
-          responseType: 'text',
-          retry: 2,
-          retryDelay: 500,
-          timeout,
-        })
-
-        // Iconify API returns literal '404' text (not HTTP 404) for missing icons
-        if (svg && svg !== '404') {
-          // Cache this successful match
-          const key = ['1', emojiSet, iconName].join('|')
-          await emojiCache.setItem(key, svg as string)
+    try {
+      for (const iconName of possibleNames) {
+        if (deadline.aborted)
           break
+        try {
+          svg = await $fetch(`https://api.iconify.design/${emojiSet}/${iconName}.svg`, {
+            responseType: 'text',
+            retry: 0,
+            signal: deadline,
+            timeout,
+          })
+
+          // Iconify API returns literal '404' text (not HTTP 404) for missing icons
+          if (svg && svg !== '404') {
+            // Cache this successful match
+            const key = ['1', emojiSet, iconName].join('|')
+            await emojiCache.setItem(key, svg as string)
+            break
+          }
+        }
+        catch {
+          // Continue to the next name if this one fails
+          svg = null
         }
       }
-      catch {
-        // Continue to the next name if this one fails
-        svg = null
-      }
     }
-    endTiming()
+    finally {
+      endTiming()
+    }
   }
 
   if (svg) {

--- a/src/runtime/server/og-image/core/transforms/emojis/fetch.ts
+++ b/src/runtime/server/og-image/core/transforms/emojis/fetch.ts
@@ -1,6 +1,7 @@
 import type { OgImageRenderEventContext } from '../../../../../types'
 import { emojiCache } from '#og-image-cache'
 import { $fetch } from 'ofetch'
+import { getFetchTimeout } from '../../../../util/fetchTimeout'
 import { getEmojiCodePoint, getEmojiIconNames } from './emoji-utils'
 
 /**
@@ -26,6 +27,8 @@ export async function getEmojiSvg(ctx: OgImageRenderEventContext, emojiChar: str
 
   // If not in cache, try API calls
   if (!svg) {
+    const timeout = getFetchTimeout(ctx.runtimeConfig)
+    const endTiming = ctx.timings.start('emoji-fetch')
     // Try each possible name with the API
     for (const iconName of possibleNames) {
       try {
@@ -33,6 +36,7 @@ export async function getEmojiSvg(ctx: OgImageRenderEventContext, emojiChar: str
           responseType: 'text',
           retry: 2,
           retryDelay: 500,
+          timeout,
         })
 
         // Iconify API returns literal '404' text (not HTTP 404) for missing icons
@@ -48,6 +52,7 @@ export async function getEmojiSvg(ctx: OgImageRenderEventContext, emojiChar: str
         svg = null
       }
     }
+    endTiming()
   }
 
   if (svg) {

--- a/src/runtime/server/og-image/satori/renderer.ts
+++ b/src/runtime/server/og-image/satori/renderer.ts
@@ -119,17 +119,17 @@ async function createPng(event: OgImageRenderEventContext) {
     throw new Error('Failed to create SVG')
   const options = defu(event.options.resvg, resvgOptions)
   const Resvg = await getResvg()
-  const endResvg = event.timings.start('render-resvg')
-  const resvg = new Resvg(svg, options)
-  const pngData = resvg.render()
-  const png = pngData.asPng()
-  endResvg()
-  // Free WASM resources when using @resvg/resvg-wasm (no-op for native binding)
-  if (typeof (pngData as any).free === 'function')
-    (pngData as any).free()
-  if (typeof (resvg as any).free === 'function')
-    (resvg as any).free()
-  return png
+  return event.timings.measure('render-resvg', () => {
+    const resvg = new Resvg(svg, options)
+    const pngData = resvg.render()
+    const png = pngData.asPng()
+    // Free WASM resources when using @resvg/resvg-wasm (no-op for native binding)
+    if (typeof (pngData as any).free === 'function')
+      (pngData as any).free()
+    if (typeof (resvg as any).free === 'function')
+      (resvg as any).free()
+    return png
+  })
 }
 
 async function createJpeg(event: OgImageRenderEventContext) {

--- a/src/runtime/server/og-image/satori/renderer.ts
+++ b/src/runtime/server/og-image/satori/renderer.ts
@@ -35,7 +35,7 @@ function withWarningCapture<T>(fn: () => Promise<T>): Promise<{ result: T, warni
 }
 
 export async function createSvg(event: OgImageRenderEventContext): Promise<{ svg: string | void, warnings: string[], fonts: RuntimeFontConfig[] }> {
-  const { options } = event
+  const { options, timings } = event
   const { satoriOptions: _satoriOptions } = useOgImageRuntimeConfig()
   const { fontFamilyOverride, defaultFont } = getDefaultFontFamily(options)
   const [satori, vnodes] = await Promise.all([
@@ -44,13 +44,13 @@ export async function createSvg(event: OgImageRenderEventContext): Promise<{ svg
   ])
   const codepoints = extractCodepoints(vnodes)
   const hasCustomFonts = Array.isArray(options.fonts) && options.fonts.length > 0
-  const fonts = await loadFontsForRenderer(event, {
+  const fonts = await timings.measure('font-load', () => loadFontsForRenderer(event, {
     supportedFormats: new Set(['ttf', 'otf', 'woff'] as const),
     component: options.component,
     fontFamilyOverride: fontFamilyOverride || defaultFont,
     codepoints,
     fontDefs: options.fonts,
-  })
+  }))
 
   await event._nitro.hooks.callHook('nuxt-og-image:satori:vnodes', vnodes, event)
   // Remap to satori's font format (requires `name` instead of `family`).
@@ -106,9 +106,9 @@ export async function createSvg(event: OgImageRenderEventContext): Promise<{ svg
     height: options.height!,
   }) as SatoriOptions
 
-  const { result, warnings } = await withWarningCapture(() =>
+  const { result, warnings } = await timings.measure('render-satori', () => withWarningCapture(() =>
     satori(vnodes, satoriOptions),
-  )
+  ))
   return { svg: result, warnings, fonts }
 }
 
@@ -119,9 +119,11 @@ async function createPng(event: OgImageRenderEventContext) {
     throw new Error('Failed to create SVG')
   const options = defu(event.options.resvg, resvgOptions)
   const Resvg = await getResvg()
+  const endResvg = event.timings.start('render-resvg')
   const resvg = new Resvg(svg, options)
   const pngData = resvg.render()
   const png = pngData.asPng()
+  endResvg()
   // Free WASM resources when using @resvg/resvg-wasm (no-op for native binding)
   if (typeof (pngData as any).free === 'function')
     (pngData as any).free()
@@ -144,9 +146,9 @@ async function createJpeg(event: OgImageRenderEventContext) {
     throw new Error('Sharp dependency could not be loaded. Please check you have it installed and are using a compatible runtime.')
   })
   const options = defu(event.options.sharp, sharpOptions)
-  return sharp(svgBuffer, options)
+  return event.timings.measure('render-sharp', () => sharp(svgBuffer, options)
     .jpeg(options as JpegOptions)
-    .toBuffer()
+    .toBuffer())
 }
 
 /**

--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -146,12 +146,11 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
   const fetchedResources: Array<{ src: string, data: Uint8Array }> = []
   if (resourceUrls.length) {
     const fetchTimeout = getFetchTimeout(event.runtimeConfig)
-    const endFetch = timings.start('resource-fetch')
     // Marker header lets downstream middleware short-circuit expensive work
     // on subrequests we make during OG image rendering (e.g. on CF Workers
     // where a logo/asset path may route back through the same worker).
     const headers = { 'x-nuxt-og-image': '1' }
-    await Promise.all(resourceUrls.map(async (src) => {
+    await timings.measure('resource-fetch', () => Promise.all(resourceUrls.map(async (src) => {
       const urlsToTry = [src]
       if (src.startsWith('/')) {
         urlsToTry.push(withBase(src, origin))
@@ -160,15 +159,18 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
         }
       }
 
+      // Shared deadline so a broken resource doesn't burn urlsToTry × fetchTimeout.
+      const deadline = AbortSignal.timeout(fetchTimeout)
       for (const url of urlsToTry) {
-        const data = await $fetch(url, { responseType: 'arrayBuffer', timeout: fetchTimeout, headers }).catch(() => null)
+        if (deadline.aborted)
+          break
+        const data = await $fetch(url, { responseType: 'arrayBuffer', signal: deadline, timeout: fetchTimeout, headers }).catch(() => null)
         if (data) {
           fetchedResources.push({ src, data: new Uint8Array(data as ArrayBuffer) })
           break
         }
       }
-    }))
-    endFetch()
+    })))
   }
 
   // Default to 1x DPR for consistent output with satori (1200x600).

--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -1,9 +1,9 @@
 import type { Node } from '@takumi-rs/core'
 import type { OgImageRenderEventContext, Renderer } from '../../../types'
-import { getNitroOrigin } from '#site-config/server/composables'
 import { defu } from 'defu'
 import { withBase } from 'ufo'
 import { logger } from '../../../logger'
+import { fetchLocalAsset } from '../../util/fetchLocalAsset'
 import { getFetchTimeout } from '../../util/fetchTimeout'
 import { buildSubsetFamilyChain, extractCodepoints, getDefaultFontFamily, loadFontsForRenderer, resolveSubsetChain } from '../fonts'
 import { getExtractResourceUrls, getTakumi } from './instances'
@@ -140,7 +140,6 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
   const extractResourceUrls = await getExtractResourceUrls()
   const resourceUrls = await extractResourceUrls(nodes)
 
-  const origin = getNitroOrigin(event.e)
   const baseURL = event.runtimeConfig.app.baseURL
 
   const fetchedResources: Array<{ src: string, data: Uint8Array }> = []
@@ -151,25 +150,26 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
     // where a logo/asset path may route back through the same worker).
     const headers = { 'x-nuxt-og-image': '1' }
     await timings.measure('resource-fetch', () => Promise.all(resourceUrls.map(async (src) => {
-      const urlsToTry = [src]
+      let data: ArrayBuffer | undefined
       if (src.startsWith('/')) {
-        urlsToTry.push(withBase(src, origin))
-        if (baseURL && baseURL !== '/' && !src.startsWith(baseURL)) {
-          urlsToTry.push(withBase(withBase(src, baseURL), origin))
-        }
+        // withBase is a no-op if src already starts with baseURL
+        const path = withBase(src, baseURL)
+        data = await fetchLocalAsset(event.e, path, {
+          fetchTimeout,
+          headers,
+          includeExternalFallback: true,
+        })
       }
-
-      // Shared deadline so a broken resource doesn't burn urlsToTry × fetchTimeout.
-      const deadline = AbortSignal.timeout(fetchTimeout)
-      for (const url of urlsToTry) {
-        if (deadline.aborted)
-          break
-        const data = await $fetch(url, { responseType: 'arrayBuffer', signal: deadline, timeout: fetchTimeout, headers }).catch(() => null)
-        if (data) {
-          fetchedResources.push({ src, data: new Uint8Array(data as ArrayBuffer) })
-          break
-        }
+      else {
+        data = await $fetch(src, {
+          responseType: 'arrayBuffer',
+          signal: AbortSignal.timeout(fetchTimeout),
+          timeout: fetchTimeout,
+          headers,
+        }).catch(() => undefined) as ArrayBuffer | undefined
       }
+      if (data)
+        fetchedResources.push({ src, data: new Uint8Array(data) })
     })))
   }
 

--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -4,6 +4,7 @@ import { getNitroOrigin } from '#site-config/server/composables'
 import { defu } from 'defu'
 import { withBase } from 'ufo'
 import { logger } from '../../../logger'
+import { getFetchTimeout } from '../../util/fetchTimeout'
 import { buildSubsetFamilyChain, extractCodepoints, getDefaultFontFamily, loadFontsForRenderer, resolveSubsetChain } from '../fonts'
 import { getExtractResourceUrls, getTakumi } from './instances'
 import { createTakumiNodes } from './nodes'
@@ -107,12 +108,12 @@ function rewriteFontFamilies(node: Node, loadedFamilies: Set<string>, subsetChai
 }
 
 async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jpeg' | 'webp') {
-  const { options } = event
+  const { options, timings } = event
 
   const { fontFamilyOverride, defaultFont } = getDefaultFontFamily(options)
   const nodes = await createTakumiNodes(event)
   const codepoints = extractCodepoints(nodes)
-  const fonts = await loadFontsForRenderer(event, { supportedFormats: new Set(['ttf', 'woff2'] as const), component: options.component, fontFamilyOverride: fontFamilyOverride || defaultFont, codepoints })
+  const fonts = await timings.measure('font-load', () => loadFontsForRenderer(event, { supportedFormats: new Set(['ttf', 'woff2'] as const), component: options.component, fontFamilyOverride: fontFamilyOverride || defaultFont, codepoints }))
 
   await event._nitro.hooks.callHook('nuxt-og-image:takumi:nodes' as any, nodes, event)
 
@@ -143,23 +144,32 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
   const baseURL = event.runtimeConfig.app.baseURL
 
   const fetchedResources: Array<{ src: string, data: Uint8Array }> = []
-  await Promise.all(resourceUrls.map(async (src) => {
-    const urlsToTry = [src]
-    if (src.startsWith('/')) {
-      urlsToTry.push(withBase(src, origin))
-      if (baseURL && baseURL !== '/' && !src.startsWith(baseURL)) {
-        urlsToTry.push(withBase(withBase(src, baseURL), origin))
+  if (resourceUrls.length) {
+    const fetchTimeout = getFetchTimeout(event.runtimeConfig)
+    const endFetch = timings.start('resource-fetch')
+    // Marker header lets downstream middleware short-circuit expensive work
+    // on subrequests we make during OG image rendering (e.g. on CF Workers
+    // where a logo/asset path may route back through the same worker).
+    const headers = { 'x-nuxt-og-image': '1' }
+    await Promise.all(resourceUrls.map(async (src) => {
+      const urlsToTry = [src]
+      if (src.startsWith('/')) {
+        urlsToTry.push(withBase(src, origin))
+        if (baseURL && baseURL !== '/' && !src.startsWith(baseURL)) {
+          urlsToTry.push(withBase(withBase(src, baseURL), origin))
+        }
       }
-    }
 
-    for (const url of urlsToTry) {
-      const data = await $fetch(url, { responseType: 'arrayBuffer' }).catch(() => null)
-      if (data) {
-        fetchedResources.push({ src, data: new Uint8Array(data as ArrayBuffer) })
-        break
+      for (const url of urlsToTry) {
+        const data = await $fetch(url, { responseType: 'arrayBuffer', timeout: fetchTimeout, headers }).catch(() => null)
+        if (data) {
+          fetchedResources.push({ src, data: new Uint8Array(data as ArrayBuffer) })
+          break
+        }
       }
-    }
-  }))
+    }))
+    endFetch()
+  }
 
   // Default to 1x DPR for consistent output with satori (1200x600).
   // Users can set `takumi.devicePixelRatio: 2` in defineOgImage options for higher resolution.
@@ -174,7 +184,7 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
     devicePixelRatio: dpr,
   })
 
-  return await state.renderer.render(nodes, renderOptions)
+  return await timings.measure('render-takumi', () => state.renderer.render(nodes, renderOptions))
 }
 
 const TakumiRenderer: Renderer = {

--- a/src/runtime/server/util/cloudflareAssets.ts
+++ b/src/runtime/server/util/cloudflareAssets.ts
@@ -1,4 +1,5 @@
 import type { H3Event } from 'h3'
+import { getRequestHost } from 'h3'
 
 interface AssetsBinding {
   fetch: (request: string | Request, init?: RequestInit) => Promise<Response>
@@ -35,7 +36,7 @@ export async function tryCloudflareAssetsFetch(
   if (!assets)
     return
   const origin = event.context.cloudflare?.request?.url
-    || `https://${event.headers.get('host') || 'localhost'}`
+    || `https://${getRequestHost(event) || 'localhost'}`
   const url = new URL(path, origin).href
   const res = await assets.fetch(url, signal ? { signal } : undefined).catch(() => null)
   if (!res || !res.ok)

--- a/src/runtime/server/util/cloudflareAssets.ts
+++ b/src/runtime/server/util/cloudflareAssets.ts
@@ -1,0 +1,44 @@
+import type { H3Event } from 'h3'
+
+interface AssetsBinding {
+  fetch: (request: string | Request, init?: RequestInit) => Promise<Response>
+}
+
+/**
+ * Access the Cloudflare Workers ASSETS binding if available.
+ *
+ * Requires either:
+ * - `nitro.cloudflare.deployConfig: true` (generates wrangler.json with ASSETS)
+ * - A wrangler.toml/json with `[assets]` configured
+ */
+export function getCloudflareAssets(event: H3Event): AssetsBinding | undefined {
+  const assets = event.context.cloudflare?.env?.ASSETS || (event.context as any).ASSETS
+  return assets && typeof assets.fetch === 'function' ? assets as AssetsBinding : undefined
+}
+
+/**
+ * Fetch a path directly from the CF Workers ASSETS binding.
+ *
+ * Prefer this over same-origin subrequests on Workers: it hits the static asset
+ * handler without billing a subrequest and without re-running the Worker's
+ * middleware chain.
+ *
+ * Returns `undefined` when no ASSETS binding is available or the asset doesn't
+ * exist (letting callers fall through to other resolution strategies).
+ */
+export async function tryCloudflareAssetsFetch(
+  event: H3Event,
+  path: string,
+  signal?: AbortSignal,
+): Promise<ArrayBuffer | undefined> {
+  const assets = getCloudflareAssets(event)
+  if (!assets)
+    return
+  const origin = event.context.cloudflare?.request?.url
+    || `https://${event.headers.get('host') || 'localhost'}`
+  const url = new URL(path, origin).href
+  const res = await assets.fetch(url, signal ? { signal } : undefined).catch(() => null)
+  if (!res || !res.ok)
+    return
+  return res.arrayBuffer()
+}

--- a/src/runtime/server/util/eventHandlers.ts
+++ b/src/runtime/server/util/eventHandlers.ts
@@ -18,12 +18,19 @@ export async function imageEventHandler(e: H3Event) {
   if (ctx instanceof H3Error)
     return ctx
   const timings = ctx.timings
-  const emitServerTiming = () => {
+  try {
+    return await renderOgImage(e, ctx)
+  }
+  finally {
     timings.record('total', performance.now() - reqStart)
     const header = timings.header()
     if (header)
       setHeader(e, 'Server-Timing', header)
   }
+}
+
+async function renderOgImage(e: H3Event, ctx: Exclude<Awaited<ReturnType<typeof resolveContext>>, H3Error>) {
+  const timings = ctx.timings
 
   const { isDevToolsContextRequest, extension, renderer } = ctx
   const { debug, baseCacheKey, security } = useOgImageRuntimeConfig()
@@ -139,7 +146,6 @@ export async function imageEventHandler(e: H3Event) {
     : null
   if (buildCachedImage) {
     timings.record('cache-hit', 0)
-    emitServerTiming()
     return buildCachedImage
   }
 
@@ -148,15 +154,12 @@ export async function imageEventHandler(e: H3Event) {
     cacheMaxAgeSeconds: ctx.options.cacheMaxAgeSeconds,
     baseCacheKey,
     secret: security?.secret,
-  })
-  endCacheLookup()
+  }).finally(endCacheLookup)
   // we sent a 304 not modified
   if (typeof cacheApi === 'undefined') {
-    emitServerTiming()
     return
   }
   if (cacheApi instanceof H3Error) {
-    emitServerTiming()
     return cacheApi
   }
 
@@ -165,7 +168,7 @@ export async function imageEventHandler(e: H3Event) {
     timings.record('cache-hit', 0)
   }
   if (!image) {
-    const timeout = security?.renderTimeout || 15_000
+    const timeout = security?.renderTimeout ?? 15_000
     let timer: ReturnType<typeof setTimeout> | undefined
     const endRender = timings.start('render-total')
     image = await Promise.race([
@@ -185,11 +188,9 @@ export async function imageEventHandler(e: H3Event) {
       endRender()
     })
     if (image instanceof H3Error) {
-      emitServerTiming()
       return image
     }
     if (!image) {
-      emitServerTiming()
       return createError({
         statusCode: 500,
         statusMessage: `Failed to generate og.${extension}.`,
@@ -201,6 +202,5 @@ export async function imageEventHandler(e: H3Event) {
       setBuildCachedImage(ctx.options, extension, image as Buffer, ctx.options.cacheMaxAgeSeconds)
     }
   }
-  emitServerTiming()
   return image
 }

--- a/src/runtime/server/util/eventHandlers.ts
+++ b/src/runtime/server/util/eventHandlers.ts
@@ -10,12 +10,20 @@ import { useOgImageRuntimeConfig } from '../utils'
 import { useOgImageBufferCache } from './cache'
 
 export async function imageEventHandler(e: H3Event) {
+  const reqStart = performance.now()
   const ctx = await resolveContext(e).catch((err: any) => {
     logger.error(`resolveContext error for ${e.path}:`, err?.message || err)
     throw err
   })
   if (ctx instanceof H3Error)
     return ctx
+  const timings = ctx.timings
+  const emitServerTiming = () => {
+    timings.record('total', performance.now() - reqStart)
+    const header = timings.header()
+    if (header)
+      setHeader(e, 'Server-Timing', header)
+  }
 
   const { isDevToolsContextRequest, extension, renderer } = ctx
   const { debug, baseCacheKey, security } = useOgImageRuntimeConfig()
@@ -130,24 +138,36 @@ export async function imageEventHandler(e: H3Event) {
     ? getBuildCachedImage(ctx.options, extension)
     : null
   if (buildCachedImage) {
+    timings.record('cache-hit', 0)
+    emitServerTiming()
     return buildCachedImage
   }
 
+  const endCacheLookup = timings.start('cache-lookup')
   const cacheApi = await useOgImageBufferCache(ctx, {
     cacheMaxAgeSeconds: ctx.options.cacheMaxAgeSeconds,
     baseCacheKey,
     secret: security?.secret,
   })
+  endCacheLookup()
   // we sent a 304 not modified
-  if (typeof cacheApi === 'undefined')
+  if (typeof cacheApi === 'undefined') {
+    emitServerTiming()
     return
-  if (cacheApi instanceof H3Error)
+  }
+  if (cacheApi instanceof H3Error) {
+    emitServerTiming()
     return cacheApi
+  }
 
   let image: H3Error | BufferSource | Buffer | Uint8Array | false | void = cacheApi.cachedItem
+  if (image) {
+    timings.record('cache-hit', 0)
+  }
   if (!image) {
     const timeout = security?.renderTimeout || 15_000
     let timer: ReturnType<typeof setTimeout> | undefined
+    const endRender = timings.start('render-total')
     image = await Promise.race([
       renderer.createImage(ctx),
       new Promise<never>((_, reject) => {
@@ -162,10 +182,14 @@ export async function imageEventHandler(e: H3Event) {
       throw err
     }).finally(() => {
       clearTimeout(timer)
+      endRender()
     })
-    if (image instanceof H3Error)
+    if (image instanceof H3Error) {
+      emitServerTiming()
       return image
+    }
     if (!image) {
+      emitServerTiming()
       return createError({
         statusCode: 500,
         statusMessage: `Failed to generate og.${extension}.`,
@@ -177,5 +201,6 @@ export async function imageEventHandler(e: H3Event) {
       setBuildCachedImage(ctx.options, extension, image as Buffer, ctx.options.cacheMaxAgeSeconds)
     }
   }
+  emitServerTiming()
   return image
 }

--- a/src/runtime/server/util/fetchLocalAsset.ts
+++ b/src/runtime/server/util/fetchLocalAsset.ts
@@ -1,0 +1,67 @@
+import type { H3Event } from 'h3'
+import { getNitroOrigin } from '#site-config/server/composables'
+import { $fetch } from 'ofetch'
+import { tryCloudflareAssetsFetch } from './cloudflareAssets'
+
+export interface FetchLocalAssetOptions {
+  fetchTimeout: number
+  headers?: Record<string, string>
+  /**
+   * Also attempt an external HTTP fetch to `getNitroOrigin(event) + path` when
+   * ASSETS and Nitro localFetch both miss. Enable for platforms where static
+   * files are served by edge routing that never reaches the Nitro handler
+   * (Vercel, Netlify). Disable for CF Workers where no ASSETS means no assets.
+   */
+  includeExternalFallback?: boolean
+  onStepFailure?: (url: string, err: unknown) => void
+}
+
+/**
+ * Resolve a same-origin asset path to bytes, trying (in order):
+ *   1. Cloudflare Workers ASSETS binding
+ *   2. Nitro localFetch (`event.$fetch`) — resolves dynamic routes too
+ *   3. External `$fetch` to the Nitro origin (opt-in)
+ *
+ * All steps share a single `AbortSignal.timeout(fetchTimeout)` so a broken
+ * URL can't burn N× the configured budget.
+ *
+ * Returns `undefined` when every step fails or times out.
+ */
+export async function fetchLocalAsset(
+  event: H3Event,
+  path: string,
+  options: FetchLocalAssetOptions,
+): Promise<ArrayBuffer | undefined> {
+  const { fetchTimeout, headers, includeExternalFallback = false, onStepFailure } = options
+  const deadline = AbortSignal.timeout(fetchTimeout)
+
+  let result = await tryCloudflareAssetsFetch(event, path, deadline).catch((err) => {
+    onStepFailure?.(path, err)
+    return undefined
+  })
+  if (result || deadline.aborted)
+    return result
+
+  result = await event.$fetch(path, {
+    responseType: 'arrayBuffer',
+    signal: deadline,
+    timeout: fetchTimeout,
+    headers,
+  }).catch((err: unknown) => {
+    onStepFailure?.(path, err)
+    return undefined
+  }) as ArrayBuffer | undefined
+  if (result || deadline.aborted || !includeExternalFallback)
+    return result
+
+  const absolute = `${getNitroOrigin(event)}${path}`
+  return await $fetch(absolute, {
+    responseType: 'arrayBuffer',
+    signal: deadline,
+    timeout: fetchTimeout,
+    headers,
+  }).catch((err: unknown) => {
+    onStepFailure?.(absolute, err)
+    return undefined
+  }) as ArrayBuffer | undefined
+}

--- a/src/runtime/server/util/fetchTimeout.ts
+++ b/src/runtime/server/util/fetchTimeout.ts
@@ -1,5 +1,5 @@
 import type { OgImageRuntimeConfig } from '../../types'
 
 export function getFetchTimeout(runtimeConfig: OgImageRuntimeConfig): number {
-  return runtimeConfig.security?.imageFetchTimeout || 3000
+  return runtimeConfig.security?.imageFetchTimeout ?? 3000
 }

--- a/src/runtime/server/util/fetchTimeout.ts
+++ b/src/runtime/server/util/fetchTimeout.ts
@@ -1,5 +1,12 @@
 import type { OgImageRuntimeConfig } from '../../types'
 
+// Minimum floor: AbortSignal.timeout(0) aborts synchronously and negative
+// values throw RangeError on Node. Clamp so misconfigured values fail soft.
+const MIN_TIMEOUT_MS = 100
+
 export function getFetchTimeout(runtimeConfig: OgImageRuntimeConfig): number {
-  return runtimeConfig.security?.imageFetchTimeout ?? 3000
+  const value = runtimeConfig.security?.imageFetchTimeout ?? 3000
+  if (!Number.isFinite(value) || value < MIN_TIMEOUT_MS)
+    return MIN_TIMEOUT_MS
+  return value
 }

--- a/src/runtime/server/util/fetchTimeout.ts
+++ b/src/runtime/server/util/fetchTimeout.ts
@@ -1,0 +1,5 @@
+import type { OgImageRuntimeConfig } from '../../types'
+
+export function getFetchTimeout(runtimeConfig: OgImageRuntimeConfig): number {
+  return runtimeConfig.security?.imageFetchTimeout || 3000
+}

--- a/src/runtime/server/util/timings.ts
+++ b/src/runtime/server/util/timings.ts
@@ -20,6 +20,10 @@ function sanitizeName(name: string): string {
 
 export function createTimings(): Timings {
   const totals = new Map<string, { dur: number, count: number }>()
+  // Per-name interval tracking so overlapping parallel spans (e.g. image-fetch
+  // inside Promise.all) report wall time, not summed CPU-across-parallel.
+  interface SpanState { open: number, windowStart: number, wall: number }
+  const spans = new Map<string, SpanState>()
 
   const record = (name: string, ms: number) => {
     const key = sanitizeName(name)
@@ -34,10 +38,41 @@ export function createTimings(): Timings {
   }
 
   const start = (name: string) => {
+    const key = sanitizeName(name)
     const t0 = performance.now()
+    const span = spans.get(key) ?? { open: 0, windowStart: 0, wall: 0 }
+    if (span.open === 0)
+      span.windowStart = t0
+    span.open += 1
+    spans.set(key, span)
+    let ended = false
     return () => {
-      const ms = performance.now() - t0
-      record(name, ms)
+      if (ended)
+        return 0
+      ended = true
+      const t1 = performance.now()
+      const ms = t1 - t0
+      span.open -= 1
+      if (span.open === 0) {
+        span.wall += t1 - span.windowStart
+        const existing = totals.get(key)
+        if (existing) {
+          // Replace summed dur with accumulated wall time; keep count as span-count.
+          existing.dur = span.wall
+          existing.count += 1
+        }
+        else {
+          totals.set(key, { dur: span.wall, count: 1 })
+        }
+      }
+      else {
+        // Still overlapping spans open; bump count only.
+        const existing = totals.get(key)
+        if (existing)
+          existing.count += 1
+        else
+          totals.set(key, { dur: 0, count: 1 })
+      }
       return ms
     }
   }

--- a/src/runtime/server/util/timings.ts
+++ b/src/runtime/server/util/timings.ts
@@ -1,0 +1,77 @@
+export interface TimingEntry {
+  name: string
+  dur: number
+  count?: number
+}
+
+export interface Timings {
+  start: (name: string) => () => number
+  record: (name: string, ms: number) => void
+  measure: <T>(name: string, fn: () => Promise<T> | T) => Promise<T>
+  entries: () => TimingEntry[]
+  header: () => string
+}
+
+const RE_TOKEN = /[^\w-]/g
+
+function sanitizeName(name: string): string {
+  return name.replace(RE_TOKEN, '_')
+}
+
+export function createTimings(): Timings {
+  const totals = new Map<string, { dur: number, count: number }>()
+
+  const record = (name: string, ms: number) => {
+    const key = sanitizeName(name)
+    const existing = totals.get(key)
+    if (existing) {
+      existing.dur += ms
+      existing.count += 1
+    }
+    else {
+      totals.set(key, { dur: ms, count: 1 })
+    }
+  }
+
+  const start = (name: string) => {
+    const t0 = performance.now()
+    return () => {
+      const ms = performance.now() - t0
+      record(name, ms)
+      return ms
+    }
+  }
+
+  const measure = async <T>(name: string, fn: () => Promise<T> | T): Promise<T> => {
+    const end = start(name)
+    try {
+      return await fn()
+    }
+    finally {
+      end()
+    }
+  }
+
+  const entries = (): TimingEntry[] =>
+    Array.from(totals.entries()).map(([name, v]) => ({
+      name,
+      dur: Math.round(v.dur * 1000) / 1000,
+      count: v.count > 1 ? v.count : undefined,
+    }))
+
+  const header = () =>
+    entries()
+      .map(({ name, dur, count }) => {
+        const desc = count ? `;desc="n=${count}"` : ''
+        return `${name}${desc};dur=${dur}`
+      })
+      .join(', ')
+
+  return { start, record, measure, entries, header }
+}
+
+export const TIMING_CTX_KEY = '_ogImageTimings'
+
+export function getTimingsFromEvent(e: { context: Record<string, any> }): Timings | undefined {
+  return e.context[TIMING_CTX_KEY]
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -6,6 +6,7 @@ import type { NitroRuntimeHooks } from 'nitropack/types'
 import type { SatoriOptions } from 'satori'
 import type { JpegOptions, SharpOptions } from 'sharp'
 import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { Timings } from './server/util/timings'
 
 interface NitroApp {
   hooks: Hookable<NitroRuntimeHooks>
@@ -22,6 +23,7 @@ export interface OgImageRenderEventContext {
   isDevToolsContextRequest: boolean
   publicStoragePath: string
   runtimeConfig: OgImageRuntimeConfig
+  timings: Timings
   _nitro: NitroApp
 }
 
@@ -68,6 +70,7 @@ export interface OgImageRuntimeConfig {
     maxDimension: number
     maxDpr: number
     renderTimeout: number
+    imageFetchTimeout: number
     maxQueryParamSize: number | null
     restrictRuntimeImagesToOrigin: false | string[]
     secret: string


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Remote image, font, emoji, and HTML subrequests previously shared the entire `renderTimeout` budget — a single stalled asset could consume the whole window (especially on Cloudflare Workers when a logo URL routes back through the same worker). This PR adds a dedicated `security.imageFetchTimeout` option (default `3000ms`) applied per-request, so a slow origin no longer starves the render.

The render pipeline now emits a `Server-Timing` response header covering cache lookup, font load, fetch phases, and each renderer (satori / takumi / browser / resvg / sharp), making slow renders diagnosable in DevTools without local profiling. A per-render image dedup cache resolves the same URL once per template, and a new `cloudflareAssets` helper routes local asset subrequests through the Workers `ASSETS` binding when available — skipping subrequest billing and middleware re-entry.