### PR TITLE
fix(takumi): serialize WASM calls

### DIFF
--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -15,6 +15,11 @@ interface TakumiState {
   renderer: any
   loadedFontKeys: Set<string>
   loadedFamilies: Set<string>
+  // Serializes WASM-touching work on the shared Renderer. The renderer is
+  // reused across requests in the same isolate (nitroApp is module-scope on
+  // CF Workers etc.) and concurrent loadFont/render calls share linear memory,
+  // which can corrupt state and burn CPU until the wall-clock fires.
+  lock: Promise<unknown>
 }
 
 async function getTakumiState(event: OgImageRenderEventContext): Promise<TakumiState> {
@@ -26,8 +31,15 @@ async function getTakumiState(event: OgImageRenderEventContext): Promise<TakumiS
     renderer: new Renderer(),
     loadedFontKeys: new Set(),
     loadedFamilies: new Set(),
+    lock: Promise.resolve(),
   } satisfies TakumiState
   return nitro._takumiState
+}
+
+function withTakumiLock<T>(state: TakumiState, fn: () => Promise<T>): Promise<T> {
+  const next = state.lock.then(fn, fn)
+  state.lock = next.catch(() => undefined)
+  return next
 }
 
 async function loadFontsIntoRenderer(state: TakumiState, fonts: Array<{ family: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string }>) {
@@ -120,23 +132,9 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
   const subsetChains = buildSubsetFamilyChain(fonts)
 
   const state = await getTakumiState(event)
-  await loadFontsIntoRenderer(state, fonts)
 
-  const rootStyle = nodes.style ?? {}
-  // If fontFamilyOverride was renamed into subsets, use the chain instead
-  if (fontFamilyOverride) {
-    const chain = subsetChains.get(fontFamilyOverride)
-    if (chain) {
-      rootStyle.fontFamily = chain.map(f => `"${f}"`).join(', ')
-    }
-    else if (state.loadedFamilies.has(fontFamilyOverride)) {
-      rootStyle.fontFamily = fontFamilyOverride
-    }
-  }
-  nodes.style = rootStyle
-
-  rewriteFontFamilies(nodes, state.loadedFamilies, subsetChains)
-
+  // Resource extraction + fetching can run outside the WASM lock — they don't
+  // touch the shared Renderer instance, so concurrent requests can overlap I/O.
   const extractResourceUrls = await getExtractResourceUrls()
   const resourceUrls = await extractResourceUrls(nodes)
 
@@ -186,7 +184,26 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
     devicePixelRatio: dpr,
   })
 
-  return await timings.measure('render-takumi', () => state.renderer.render(nodes, renderOptions))
+  // WASM critical section: loadFont and render mutate the shared Renderer's
+  // linear memory. Serializing per isolate avoids cross-request corruption.
+  return await withTakumiLock(state, () => timings.measure('render-takumi', async () => {
+    await loadFontsIntoRenderer(state, fonts)
+
+    const rootStyle = nodes.style ?? {}
+    if (fontFamilyOverride) {
+      const chain = subsetChains.get(fontFamilyOverride)
+      if (chain) {
+        rootStyle.fontFamily = chain.map(f => `"${f}"`).join(', ')
+      }
+      else if (state.loadedFamilies.has(fontFamilyOverride)) {
+        rootStyle.fontFamily = fontFamilyOverride
+      }
+    }
+    nodes.style = rootStyle
+    rewriteFontFamilies(nodes, state.loadedFamilies, subsetChains)
+
+    return state.renderer.render(nodes, renderOptions)
+  }))
 }
 
 const TakumiRenderer: Renderer = {

--- a/src/runtime/server/util/fetchLocalAsset.ts
+++ b/src/runtime/server/util/fetchLocalAsset.ts
@@ -35,14 +35,27 @@ export async function fetchLocalAsset(
   const { fetchTimeout, headers, includeExternalFallback = false, onStepFailure } = options
   const deadline = AbortSignal.timeout(fetchTimeout)
 
-  let result = await tryCloudflareAssetsFetch(event, path, deadline).catch((err) => {
+  // Caller-side timeout enforcement: some transports (notably Nitro's
+  // event.$fetch on Cloudflare Workers) don't propagate AbortSignal to the
+  // in-process handler, so a hung upstream blocks beyond fetchTimeout. Race
+  // each step against a shared timer so the deadline is enforced regardless.
+  let expired = false
+  const timer = new Promise<undefined>((resolve) => {
+    setTimeout(() => {
+      expired = true
+      resolve(undefined)
+    }, fetchTimeout)
+  })
+  const race = <T>(p: Promise<T | undefined>): Promise<T | undefined> => Promise.race([p, timer])
+
+  let result = await race(tryCloudflareAssetsFetch(event, path, deadline).catch((err) => {
     onStepFailure?.(path, err)
     return undefined
-  })
-  if (result || deadline.aborted)
+  }))
+  if (result || expired)
     return result
 
-  result = await event.$fetch(path, {
+  result = await race(event.$fetch(path, {
     responseType: 'arrayBuffer',
     signal: deadline,
     timeout: fetchTimeout,
@@ -50,12 +63,12 @@ export async function fetchLocalAsset(
   }).catch((err: unknown) => {
     onStepFailure?.(path, err)
     return undefined
-  }) as ArrayBuffer | undefined
-  if (result || deadline.aborted || !includeExternalFallback)
+  }) as Promise<ArrayBuffer | undefined>)
+  if (result || expired || !includeExternalFallback)
     return result
 
   const absolute = `${getNitroOrigin(event)}${path}`
-  return await $fetch(absolute, {
+  return await race($fetch(absolute, {
     responseType: 'arrayBuffer',
     signal: deadline,
     timeout: fetchTimeout,
@@ -63,5 +76,5 @@ export async function fetchLocalAsset(
   }).catch((err: unknown) => {
     onStepFailure?.(absolute, err)
     return undefined
-  }) as ArrayBuffer | undefined
+  }) as Promise<ArrayBuffer | undefined>)
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Two fixes hardening the runtime against concurrency and hang issues observed on serverless platforms (notably Cloudflare Workers), where the `nitroApp` instance is shared across requests within a single isolate.

- **takumi renderer**: Adds a per-isolate promise lock around `loadFont`/`render`. The shared `Renderer`'s WASM linear memory is corrupted by overlapping calls, causing wedged renders that burn CPU until the wall-clock deadline. Resource extraction and asset fetching remain outside the lock so I/O can still overlap.
- **fetchLocalAsset**: Races each fetch step against a caller-side timer. `event.$fetch` on Cloudflare doesn't propagate `AbortSignal` into the in-process handler, so a hung upstream blocked beyond `fetchTimeout`. The shared timer guarantees the caller-supplied deadline is enforced across all three fallback steps (cloudflare assets, nitro `$fetch`, absolute `$fetch`).