### PR TITLE
fix: iMessage Preview displaying multiple images

### DIFF
--- a/src/runtime/shared.ts
+++ b/src/runtime/shared.ts
@@ -15,15 +15,15 @@ export function generateMeta(url: OgImagePrebuilt['url'] | string, resolvedOptio
 
   const meta: ResolvableMeta[] = []
 
-  if (!isTwitterOnly) {
-    meta.push({ property: 'og:image', content: url })
-    meta.push({ property: 'og:image:type', content: () => `image/${getExtension(toValue(url) as string) || resolvedOptions.extension}` })
-  }
-
   if (includeTwitter) {
     meta.push({ name: 'twitter:card', content: 'summary_large_image' })
     meta.push({ name: 'twitter:image', content: url })
     meta.push({ name: 'twitter:image:src', content: url })
+  }
+
+  if (!isTwitterOnly) {
+    meta.push({ property: 'og:image', content: url })
+    meta.push({ property: 'og:image:type', content: () => `image/${getExtension(toValue(url) as string) || resolvedOptions.extension}` })
   }
 
   if (resolvedOptions.width) {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

iMessage on iOS/macOS displays multiple images in the preview instead of selecting only one. This happens if multiple `og:image`  tags are present. This behavior is only altered if an `twitter:image` tag is present, and only if this tag is before the first `og:image`. 
In addition the `twitter:image` must be identical to an `og:image` tag, else the the default behavior of using all og images is triggered. This prevents that even the definition of an `twitter` only image and then multiple 'other'  images would not work as the twitter image url would not match any og image.

So the easy fix is to switch the placement of the `og:image` and `twitter:image` tags around.