### PR TITLE
chore: add hookable types explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "get-image-colors": "catalog:",
     "globby": "catalog:",
     "happy-dom": "catalog:",
+    "hookable": "catalog:",
     "jest-image-snapshot": "catalog:",
     "lightningcss": "catalog:",
     "nuxt": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     happy-dom:
       specifier: ^20.9.0
       version: 20.9.0
+    hookable:
+      specifier: ^5.5.3
+      version: 5.5.3
     jest-image-snapshot:
       specifier: ^6.5.2
       version: 6.5.2
@@ -508,6 +511,9 @@ importers:
       happy-dom:
         specifier: 'catalog:'
         version: 20.9.0
+      hookable:
+        specifier: 'catalog:'
+        version: 5.5.3
       jest-image-snapshot:
         specifier: 'catalog:'
         version: 6.5.2
@@ -1643,7 +1649,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,6 +72,7 @@ catalog:
   get-image-colors: ^4.0.1
   globby: ^16.2.0
   happy-dom: ^20.9.0
+  hookable: ^5.5.3
   jest-image-snapshot: ^6.5.2
   lightningcss: ^1.32.0
   magic-string: ^0.30.21


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

discovered in https://github.com/nuxt/ecosystem-ci/actions/runs/24979026915

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

nitro v2 uses hookable v5, nuxt uses hookable v6

this adds an explicit dev dep on the version of hookable that nitro uses so the types don't mismatch here.