### PR TITLE
test: bump setup timeout to 240s

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
             '**/.claude/**',
             '**/node_modules/**',
           ],
+          hookTimeout: 240_000,
         },
       }),
     ],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

tests seem to be timing out in some instances (https://github.com/nuxt/ecosystem-ci/actions/runs/25022232846/job/73436708454) and I thought we might be able to bump the setup timeout to account for things like slow runner, slow font fetching, and so on.

~~(only doing it for the public-sans test as this seems to be the one that's timing out)~~