### PR TITLE
fix: runtime secret override via NUXT_OG_IMAGE_SECRET

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1558,6 +1558,17 @@ export const rootDir = ${JSON.stringify(nuxt.options.rootDir)}`
       // @ts-expect-error untyped
       nuxt.options.runtimeConfig['nuxt-og-image'] = runtimeConfig
 
+      // Top-level alias so `NUXT_OG_IMAGE_SECRET` env var maps automatically via
+      // Nuxt's standard runtime override convention (NUXT_<KEY> -> runtimeConfig.<key>).
+      // Read by useOgImageRuntimeConfig and prefers this value over security.secret
+      // when set, allowing runtime overrides on platforms like Cloudflare Workers
+      // where env bindings are surfaced through the event context.
+      const existingOgImageCfg = (nuxt.options.runtimeConfig as Record<string, any>).ogImage
+      ;(nuxt.options.runtimeConfig as Record<string, any>).ogImage = {
+        ...(existingOgImageCfg && typeof existingOgImageCfg === 'object' ? existingOgImageCfg : {}),
+        secret: (existingOgImageCfg as any)?.secret || config.security?.secret || process.env.NUXT_OG_IMAGE_SECRET || '',
+      }
+
       // Non-sensitive subset exposed to the browser so defineOgImage can refresh
       // og:image meta tags on SPA navigation (#567). `defaults` feed the SSG
       // URL-rebuild fallback path; `hasServerRuntime` gates the `/_og/r/` resolver

--- a/src/runtime/server/og-image/browser/screenshot.ts
+++ b/src/runtime/server/og-image/browser/screenshot.ts
@@ -81,7 +81,7 @@ async function takeScreenshot(page: Page, selector: string | undefined, options:
 }
 
 export async function createScreenshot({ basePath, e, options, extension, timings }: OgImageRenderEventContext, browser: Browser): Promise<Buffer> {
-  const runtimeConfig = useOgImageRuntimeConfig()
+  const runtimeConfig = useOgImageRuntimeConfig(e)
   const { colorPreference, defaults, security } = runtimeConfig
   // For browser renderer, we need to load the HTML template with options encoded in URL
   const path = options.component === 'PageScreenshot' ? basePath : buildOgImageUrl(options, 'html', false, defaults, security?.secret || undefined).url

--- a/src/runtime/server/og-image/context.ts
+++ b/src/runtime/server/og-image/context.ts
@@ -48,7 +48,7 @@ export function resolvePathCacheKey(e: H3Event, path: string, resolvedOptions?: 
 }
 
 export async function resolveContext(e: H3Event): Promise<H3Error | OgImageRenderEventContext> {
-  const runtimeConfig = useOgImageRuntimeConfig()
+  const runtimeConfig = useOgImageRuntimeConfig(e)
   // we need to resolve the url ourselves as Nitro may be stripping the base
   const resolvePathWithBase = createSitePathResolver(e, {
     absolute: false,

--- a/src/runtime/server/routes/debug.json.ts
+++ b/src/runtime/server/routes/debug.json.ts
@@ -12,7 +12,7 @@ import { useOgImageRuntimeConfig } from '../utils'
 export default defineEventHandler(async (e) => {
   // set json header
   setHeader(e, 'Content-Type', 'application/json')
-  const runtimeConfig = useOgImageRuntimeConfig()
+  const runtimeConfig = useOgImageRuntimeConfig(e)
   return {
     siteConfigUrl: getSiteConfig(e as any).url,
     origin: getNitroOrigin(e),

--- a/src/runtime/server/routes/resolve.ts
+++ b/src/runtime/server/routes/resolve.ts
@@ -52,7 +52,7 @@ function resolveTargetPath(event: H3Event): string {
 }
 
 export default defineEventHandler(async (event) => {
-  const runtimeConfig = useOgImageRuntimeConfig()
+  const runtimeConfig = useOgImageRuntimeConfig(event)
   const security = runtimeConfig.security
 
   // Origin restriction: mirror imageEventHandler — block runtime requests from

--- a/src/runtime/server/util/eventHandlers.ts
+++ b/src/runtime/server/util/eventHandlers.ts
@@ -33,7 +33,7 @@ async function renderOgImage(e: H3Event, ctx: Exclude<Awaited<ReturnType<typeof 
   const timings = ctx.timings
 
   const { isDevToolsContextRequest, extension, renderer } = ctx
-  const { debug, baseCacheKey, security } = useOgImageRuntimeConfig()
+  const { debug, baseCacheKey, security } = useOgImageRuntimeConfig(e)
 
   // Origin restriction: block runtime requests from unknown hosts.
   // Loopback requests (localhost, 127.0.0.1, ::1) are allowed only when URL

--- a/src/runtime/server/utils.ts
+++ b/src/runtime/server/utils.ts
@@ -36,9 +36,20 @@ export function getOgImagePath(_pagePath: string, _options?: Partial<OgImageOpti
 
 export function useOgImageRuntimeConfig(e?: H3Event) {
   const c = useRuntimeConfig(e)
+  const moduleCfg = (c['nuxt-og-image'] as Record<string, any> | undefined) || {}
+  // Top-level `ogImage.secret` is populated by Nuxt's standard env override
+  // (`NUXT_OG_IMAGE_SECRET`) and takes precedence over the build-time
+  // `security.secret` so deployments can rotate the secret without rebuilding.
+  // Passing the event matters on platforms like Cloudflare Workers where env
+  // bindings are only resolved when an event is available.
+  const overrideSecret = (c as Record<string, any>).ogImage?.secret as string | undefined
+  const security = overrideSecret
+    ? { ...(moduleCfg.security || {}), secret: overrideSecret }
+    : moduleCfg.security
   return {
     defaults: {},
-    ...(c['nuxt-og-image'] as Record<string, any>),
+    ...moduleCfg,
+    security,
     app: {
       baseURL: c.app.baseURL,
     },


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Maps `runtimeConfig.ogImage.secret` alongside the existing `runtimeConfig['nuxt-og-image'].security.secret`, so the standard `NUXT_<KEY>` -> `runtimeConfig.<key>` env override convention applies and deployments can rotate the secret without rebuilding.

`useOgImageRuntimeConfig` now accepts the H3 event and prefers the top-level override when set; this matters on Cloudflare Workers where env bindings are only resolved once an event is in scope. All server call sites that have an event were updated to pass it (`context.ts`, `eventHandlers.ts`, `resolve.ts`, `debug.json.ts`, `screenshot.ts`).

Non-breaking: existing `config.security.secret` and the build-time `process.env.NUXT_OG_IMAGE_SECRET` read continue to work; the runtime override is additive.