### PR TITLE
fix(security): harden SSRF guard with redirect validation and IPv6 coverage

### DIFF
--- a/src/runtime/server/og-image/core/plugins/imageSrc.ts
+++ b/src/runtime/server/og-image/core/plugins/imageSrc.ts
@@ -8,73 +8,9 @@ import { decodeHtml } from '../../../util/encoding'
 import { fetchLocalAsset } from '../../../util/fetchLocalAsset'
 import { getFetchTimeout } from '../../../util/fetchTimeout'
 import { logger } from '../../../util/logger'
+import { fetchWithRedirectValidation, isBlockedUrl } from '../../../util/ssrf'
 import { getImageDimensions } from '../../utils/image-detector'
 import { defineTransformer } from '../plugins'
-
-// SSRF prevention: block private/loopback URLs outside dev mode
-const RE_IPV6_BRACKETS = /^\[|\]$/g
-const RE_MAPPED_V4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/
-const RE_DIGIT_ONLY = /^\d+$/
-const RE_INT_IP = /^(?:0x[\da-f]+|\d+)$/i
-
-function isPrivateIPv4(a: number, b: number): boolean {
-  if (a === 127)
-    return true // loopback
-  if (a === 10)
-    return true // 10.0.0.0/8
-  if (a === 172 && b >= 16 && b <= 31)
-    return true // 172.16.0.0/12
-  if (a === 192 && b === 168)
-    return true // 192.168.0.0/16
-  if (a === 169 && b === 254)
-    return true // link-local
-  if (a === 0)
-    return true // 0.0.0.0/8
-  return false
-}
-
-/**
- * Block URLs targeting internal/private networks.
- * Handles standard IPs, hex (0x7f000001), decimal (2130706433),
- * IPv6-mapped IPv4 (::ffff:127.0.0.1), and localhost.
- * Only http/https protocols are allowed.
- */
-function isBlockedUrl(url: string): boolean {
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  }
-  catch {
-    return true
-  }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
-    return true
-  const hostname = parsed.hostname.toLowerCase()
-  const bare = hostname.replace(RE_IPV6_BRACKETS, '')
-  if (bare === 'localhost' || bare.endsWith('.localhost'))
-    return true
-  // Normalize IPv6-mapped IPv4 (::ffff:1.2.3.4)
-  const mappedV4 = bare.match(RE_MAPPED_V4)
-  const ip = mappedV4 ? mappedV4[1]! : bare
-  // Standard dotted-decimal IPv4
-  const parts = ip.split('.')
-  if (parts.length === 4 && parts.every(p => RE_DIGIT_ONLY.test(p))) {
-    const octets = parts.map(Number)
-    if (octets.some(o => o > 255))
-      return true
-    return isPrivateIPv4(octets[0]!, octets[1]!)
-  }
-  // Single integer (decimal/hex) IP: e.g. 2130706433 or 0x7f000001
-  if (RE_INT_IP.test(ip)) {
-    const num = Number(ip)
-    if (!Number.isNaN(num) && num >= 0 && num <= 0xFFFFFFFF)
-      return isPrivateIPv4((num >> 24) & 0xFF, (num >> 16) & 0xFF)
-  }
-  // IPv6 private ranges
-  if (bare === '::1' || bare.startsWith('fc') || bare.startsWith('fd') || bare.startsWith('fe80'))
-    return true
-  return false
-}
 
 const RE_URL_LEADING = /^url\(['"]?/
 const RE_URL_TRAILING = /['"]?\)$/
@@ -173,12 +109,28 @@ async function doResolveSrcToBuffer(
     return { blocked: true }
   }
   const end = timings.start('image-fetch')
-  const buffer = (await $fetch(decodedSrc, {
-    responseType: 'arrayBuffer',
-    timeout: fetchTimeout,
-  }).catch((err) => {
-    logFailure(decodedSrc, err)
-  }).finally(end)) as BufferSource | undefined
+  // In dev we keep ofetch's default redirect-follow behaviour so loopback /
+  // proxy setups work. Outside dev, redirects are followed manually with
+  // host re-validation on every hop to close the redirect-bypass class.
+  let buffer: BufferSource | undefined
+  if (import.meta.dev) {
+    buffer = (await $fetch(decodedSrc, {
+      responseType: 'arrayBuffer',
+      timeout: fetchTimeout,
+    }).catch((err) => {
+      logFailure(decodedSrc, err)
+    }).finally(end)) as BufferSource | undefined
+  }
+  else {
+    const ab = await fetchWithRedirectValidation(decodedSrc, {
+      timeout: fetchTimeout,
+    }).catch((err) => {
+      logFailure(decodedSrc, err)
+      return null
+    }).finally(end)
+    if (ab)
+      buffer = new Uint8Array(ab)
+  }
   return buffer ? { buffer } : {}
 }
 
@@ -239,9 +191,18 @@ export default defineTransformer([
         return
       }
       // relative src couldn't be fetched — fall back to an absolute URL so
-      // satori/takumi may attempt to resolve at render time
-      if (isRelative)
+      // satori/takumi may attempt to resolve at render time (against the app's
+      // own origin, not an attacker-controlled one)
+      if (isRelative) {
         node.props.src = withBase(src, `${getNitroOrigin(ctx.e)}`)
+        return
+      }
+      // Absolute external URL whose validated fetch failed. Drop it in
+      // production: letting it survive would invite the renderer (satori
+      // fetches <img> URLs internally; takumi fetches via extractResourceUrls)
+      // to re-issue the request without SSRF/redirect validation.
+      if (!import.meta.dev)
+        delete node.props.src
     },
   },
   // fix style="background-image: url('')"
@@ -257,8 +218,14 @@ export default defineTransformer([
         delete node.props.style!.backgroundImage
         return
       }
-      if (result.buffer)
+      if (result.buffer) {
         node.props.style!.backgroundImage = `url(${toBufferSourceAsBase64(result.buffer)})`
+        return
+      }
+      // Same reasoning as the <img> branch: an absolute external URL that
+      // didn't inline must not be left for the renderer to fetch unvalidated.
+      if (!import.meta.dev && !src.startsWith('/'))
+        delete node.props.style!.backgroundImage
     },
   },
 ])

--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -5,6 +5,7 @@ import { withBase } from 'ufo'
 import { logger } from '../../../logger'
 import { fetchLocalAsset } from '../../util/fetchLocalAsset'
 import { getFetchTimeout } from '../../util/fetchTimeout'
+import { fetchWithRedirectValidation, isBlockedUrl } from '../../util/ssrf'
 import { buildSubsetFamilyChain, extractCodepoints, getDefaultFontFamily, loadFontsForRenderer, resolveSubsetChain } from '../fonts'
 import { getExtractResourceUrls, getTakumi } from './instances'
 import { createTakumiNodes } from './nodes'
@@ -205,13 +206,22 @@ async function createImage(event: OgImageRenderEventContext, format: 'png' | 'jp
           includeExternalFallback: true,
         })
       }
-      else {
+      else if (import.meta.dev) {
         data = await $fetch(src, {
           responseType: 'arrayBuffer',
           signal: AbortSignal.timeout(fetchTimeout),
           timeout: fetchTimeout,
           headers,
         }).catch(() => undefined) as ArrayBuffer | undefined
+      }
+      else if (!isBlockedUrl(src)) {
+        // Defense-in-depth: any URL surviving the imageSrc transformer is
+        // re-validated here, with redirects followed manually so 30x →
+        // internal-IP cannot complete the SSRF.
+        data = (await fetchWithRedirectValidation(src, {
+          timeout: fetchTimeout,
+          headers,
+        })) ?? undefined
       }
       if (data)
         fetchedResources.push({ src, data: new Uint8Array(data) })

--- a/src/runtime/server/util/ssrf.ts
+++ b/src/runtime/server/util/ssrf.ts
@@ -1,0 +1,265 @@
+// SSRF prevention for OG image asset fetching.
+//
+// Two surfaces are guarded:
+//   1. `isBlockedUrl(url)` — host/IP classifier covering IPv4 (dotted, decimal,
+//      hex), IPv6 (incl. zone IDs, embedded IPv4, IPv4-mapped hex form), and
+//      the standard set of internal RFC ranges plus deprecated/reserved
+//      prefixes that have been used as bypasses (RFC 3879, 9602, 9637, 8215).
+//   2. `fetchWithRedirectValidation(url, opts)` — performs the fetch with
+//      `redirect: 'manual'` and re-runs the host classifier on every Location
+//      hop, so an allowed origin returning a 30x to an internal IP cannot
+//      complete the SSRF.
+//
+// History: see GHSA-pqhr-mp3f-hrpp (initial denylist) and GHSA-c2rm-g55x-8hr5
+// (IPv6 prefix gaps + redirect bypass) for the bypass classes this is sized
+// to defeat.
+
+const RE_IPV6_BRACKETS = /^\[|\]$/g
+const RE_DIGIT_ONLY = /^\d+$/
+const RE_INT_IP = /^(?:0x[\da-f]+|\d+)$/i
+const RE_HEX_GROUP = /^[0-9a-f]{1,4}$/i
+const RE_IPV6_CHARS = /^[0-9a-f:.]+$/i
+const RE_TRAILING_V4 = /(\d+\.\d+\.\d+\.\d+)$/
+
+const MAX_REDIRECTS = 5
+
+function isPrivateIPv4(a: number, b: number): boolean {
+  if (a === 127)
+    return true // 127.0.0.0/8 loopback
+  if (a === 10)
+    return true // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31)
+    return true // 172.16.0.0/12
+  if (a === 192 && b === 168)
+    return true // 192.168.0.0/16
+  if (a === 169 && b === 254)
+    return true // link-local
+  if (a === 0)
+    return true // 0.0.0.0/8 — also catches the unspecified address
+  return false
+}
+
+/**
+ * Expand an IPv6 string to its 8 16-bit groups. Accepts `::` shorthand,
+ * embedded IPv4 in the trailing 32 bits (`::ffff:1.2.3.4`), and zone IDs
+ * (stripped). Returns `null` for any malformed input.
+ */
+export function expandIPv6(addr: string): number[] | null {
+  // Strip RFC 6874 zone id (e.g. fe80::1%eth0). The link-local check below
+  // catches fe80::/10 regardless of zone, so the zone string is discarded.
+  const noZone = addr.split('%')[0]!
+  if (!noZone || !RE_IPV6_CHARS.test(noZone))
+    return null
+
+  // Fold a trailing dotted-quad (`::ffff:1.2.3.4`) into two hex groups so the
+  // remainder can be parsed uniformly.
+  let work = noZone
+  const v4Match = work.match(RE_TRAILING_V4)
+  if (v4Match) {
+    const octets = v4Match[1]!.split('.').map(Number)
+    if (octets.some(o => !Number.isFinite(o) || o < 0 || o > 255))
+      return null
+    const hi = ((octets[0]! << 8) | octets[1]!).toString(16)
+    const lo = ((octets[2]! << 8) | octets[3]!).toString(16)
+    work = `${work.slice(0, -v4Match[1]!.length) + hi}:${lo}`
+  }
+
+  const parts = work.split('::')
+  if (parts.length > 2)
+    return null
+  const head = parts[0] ? parts[0].split(':') : []
+  const tail = (parts[1] !== undefined && parts[1]) ? parts[1].split(':') : []
+
+  if (parts.length === 1) {
+    if (head.length !== 8)
+      return null
+  }
+  else if (head.length + tail.length > 7) {
+    return null
+  }
+
+  const fillCount = parts.length === 2 ? 8 - head.length - tail.length : 0
+  const allGroups = [...head, ...Array.from<string>({ length: fillCount }).fill('0'), ...tail]
+  const result: number[] = []
+  for (const g of allGroups) {
+    if (!RE_HEX_GROUP.test(g))
+      return null
+    result.push(Number.parseInt(g, 16))
+  }
+  return result
+}
+
+function isPrivateIPv6(groups: number[]): boolean {
+  const [g0, g1, g2, g3, g4, g5, g6, g7] = groups as [number, number, number, number, number, number, number, number]
+
+  // ::1 loopback
+  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0 && g6 === 0 && g7 === 1)
+    return true
+
+  // :: unspecified
+  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0 && g6 === 0 && g7 === 0)
+    return true
+
+  // ::ffff:0:0/96 IPv4-mapped — recover embedded IPv4 and re-classify
+  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0xFFFF) {
+    const a = (g6 >> 8) & 0xFF
+    const b = g6 & 0xFF
+    return isPrivateIPv4(a, b)
+  }
+
+  // 64:ff9b::/96 NAT64 well-known prefix — embedded IPv4
+  if (g0 === 0x64 && g1 === 0xFF9B && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0) {
+    const a = (g6 >> 8) & 0xFF
+    const b = g6 & 0xFF
+    return isPrivateIPv4(a, b)
+  }
+
+  // 64:ff9b:1::/48 NAT64 local-use (RFC 8215) — entire range is internal
+  if (g0 === 0x64 && g1 === 0xFF9B && g2 === 1)
+    return true
+
+  // fc00::/7 unique local
+  if ((g0 & 0xFE00) === 0xFC00)
+    return true
+
+  // fe80::/10 link-local
+  if ((g0 & 0xFFC0) === 0xFE80)
+    return true
+
+  // fec0::/10 site-local — RFC 3879 deprecated but still routable on legacy nets
+  if ((g0 & 0xFFC0) === 0xFEC0)
+    return true
+
+  // 2001:db8::/32 documentation
+  if (g0 === 0x2001 && g1 === 0x0DB8)
+    return true
+
+  // 3fff::/20 documentation v2 (RFC 9637)
+  if ((g0 & 0xFFF0) === 0x3FF0)
+    return true
+
+  // 5f00::/16 SRv6 SIDs (RFC 9602)
+  if (g0 === 0x5F00)
+    return true
+
+  // ff00::/8 multicast — not directly SSRF but no legitimate image-fetch use
+  if ((g0 & 0xFF00) === 0xFF00)
+    return true
+
+  return false
+}
+
+/**
+ * Returns true if the URL points at an internal/private network or otherwise
+ * unsafe target. Only `http:` and `https:` are accepted; everything else is
+ * blocked outright.
+ */
+export function isBlockedUrl(url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  }
+  catch {
+    return true
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+    return true
+
+  const hostname = parsed.hostname.toLowerCase()
+  const bare = hostname.replace(RE_IPV6_BRACKETS, '')
+
+  if (bare === 'localhost' || bare.endsWith('.localhost'))
+    return true
+
+  // Dotted-decimal IPv4
+  const dottedParts = bare.split('.')
+  if (dottedParts.length === 4 && dottedParts.every(p => RE_DIGIT_ONLY.test(p))) {
+    const octets = dottedParts.map(Number)
+    if (octets.some(o => o > 255))
+      return true
+    return isPrivateIPv4(octets[0]!, octets[1]!)
+  }
+
+  // Single integer (decimal/hex) IPv4: `2130706433`, `0x7f000001`
+  if (RE_INT_IP.test(bare)) {
+    const num = Number(bare)
+    if (Number.isFinite(num) && num >= 0 && num <= 0xFFFFFFFF)
+      return isPrivateIPv4((num >>> 24) & 0xFF, (num >>> 16) & 0xFF)
+  }
+
+  // IPv6 — only attempt when a colon is present; bare hostnames with letters
+  // would otherwise hit the IPv6 parser and slow us down for nothing.
+  if (bare.includes(':')) {
+    const groups = expandIPv6(bare)
+    if (groups)
+      return isPrivateIPv6(groups)
+    // unparseable IPv6-looking string — refuse rather than fall through to the
+    // public-name branch
+    return true
+  }
+
+  return false
+}
+
+export interface SafeFetchOptions {
+  timeout: number
+  headers?: Record<string, string>
+  signal?: AbortSignal
+}
+
+/**
+ * Fetch a URL with manual redirect handling. Each hop (including the initial
+ * URL) is run through `isBlockedUrl` before the request is dispatched, so an
+ * allowed origin returning a 30x to an internal IP cannot complete the SSRF.
+ *
+ * Returns `null` on any failure (block, network error, non-2xx, redirect
+ * limit). The caller treats null as a soft failure and falls back to the
+ * usual missing-asset behaviour.
+ */
+export async function fetchWithRedirectValidation(
+  initialUrl: string,
+  opts: SafeFetchOptions,
+): Promise<ArrayBuffer | null> {
+  const controller = new AbortController()
+  const externalAbort = opts.signal
+  const onExternalAbort = () => controller.abort(externalAbort?.reason)
+  if (externalAbort) {
+    if (externalAbort.aborted)
+      controller.abort(externalAbort.reason)
+    else
+      externalAbort.addEventListener('abort', onExternalAbort, { once: true })
+  }
+  const timer = setTimeout(() => controller.abort(new Error('timeout')), opts.timeout)
+  try {
+    let url = initialUrl
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      if (isBlockedUrl(url))
+        return null
+      const res = await fetch(url, {
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: opts.headers,
+      })
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get('location')
+        if (!loc)
+          return null
+        // Resolve relative redirects against the current hop
+        url = new URL(loc, url).toString()
+        continue
+      }
+      if (!res.ok)
+        return null
+      return await res.arrayBuffer()
+    }
+    return null
+  }
+  catch {
+    return null
+  }
+  finally {
+    clearTimeout(timer)
+    if (externalAbort)
+      externalAbort.removeEventListener('abort', onExternalAbort)
+  }
+}

--- a/test/unit/ssrf.test.ts
+++ b/test/unit/ssrf.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import { expandIPv6, isBlockedUrl } from '../../src/runtime/server/util/ssrf'
+
+describe('expandIPv6', () => {
+  it('expands :: shorthand', () => {
+    expect(expandIPv6('::1')).toEqual([0, 0, 0, 0, 0, 0, 0, 1])
+    expect(expandIPv6('::')).toEqual([0, 0, 0, 0, 0, 0, 0, 0])
+    expect(expandIPv6('fe80::1')).toEqual([0xFE80, 0, 0, 0, 0, 0, 0, 1])
+  })
+
+  it('expands embedded IPv4', () => {
+    expect(expandIPv6('::ffff:127.0.0.1')).toEqual([0, 0, 0, 0, 0, 0xFFFF, 0x7F00, 1])
+    expect(expandIPv6('64:ff9b::8.8.8.8')).toEqual([0x64, 0xFF9B, 0, 0, 0, 0, 0x0808, 0x0808])
+  })
+
+  it('handles hex-form IPv4-mapped (::ffff:7f00:1)', () => {
+    expect(expandIPv6('::ffff:7f00:1')).toEqual([0, 0, 0, 0, 0, 0xFFFF, 0x7F00, 1])
+  })
+
+  it('strips zone id', () => {
+    expect(expandIPv6('fe80::1%eth0')).toEqual([0xFE80, 0, 0, 0, 0, 0, 0, 1])
+  })
+
+  it('rejects malformed input', () => {
+    expect(expandIPv6('')).toBeNull()
+    expect(expandIPv6('::1::2')).toBeNull()
+    expect(expandIPv6('1:2:3:4:5:6:7')).toBeNull() // too few groups, no ::
+    expect(expandIPv6('1:2:3:4:5:6:7:8:9')).toBeNull() // too many
+    expect(expandIPv6('xyz::1')).toBeNull()
+    expect(expandIPv6('::ffff:300.1.1.1')).toBeNull() // out-of-range octet
+  })
+})
+
+describe('isBlockedUrl — known-good controls', () => {
+  it('blocks dotted-decimal loopback', () => {
+    expect(isBlockedUrl('http://127.0.0.1/')).toBe(true)
+    expect(isBlockedUrl('http://127.0.0.1:8080/x')).toBe(true)
+  })
+
+  it('blocks RFC 1918 ranges', () => {
+    expect(isBlockedUrl('http://10.0.0.1/')).toBe(true)
+    expect(isBlockedUrl('http://172.16.5.5/')).toBe(true)
+    expect(isBlockedUrl('http://172.31.255.255/')).toBe(true)
+    expect(isBlockedUrl('http://192.168.1.1/')).toBe(true)
+  })
+
+  it('blocks link-local IPv4', () => {
+    expect(isBlockedUrl('http://169.254.169.254/')).toBe(true) // AWS IMDS
+  })
+
+  it('blocks 0.0.0.0/8', () => {
+    expect(isBlockedUrl('http://0.0.0.0/')).toBe(true)
+  })
+
+  it('blocks localhost names', () => {
+    expect(isBlockedUrl('http://localhost/')).toBe(true)
+    expect(isBlockedUrl('http://app.localhost/')).toBe(true)
+  })
+
+  it('blocks integer-encoded IPv4', () => {
+    expect(isBlockedUrl('http://2130706433/')).toBe(true) // 127.0.0.1
+    expect(isBlockedUrl('http://0x7f000001/')).toBe(true) // 127.0.0.1
+  })
+
+  it('blocks octal/shorthand IPv4 (URL parser canonicalizes)', () => {
+    expect(isBlockedUrl('http://0177.0.0.1/')).toBe(true)
+    expect(isBlockedUrl('http://127.1/')).toBe(true)
+  })
+
+  it('blocks ::1 IPv6 loopback', () => {
+    expect(isBlockedUrl('http://[::1]/')).toBe(true)
+    expect(isBlockedUrl('http://[::1]:8080/')).toBe(true)
+  })
+
+  it('blocks fc00::/7 unique-local', () => {
+    expect(isBlockedUrl('http://[fc00::1]/')).toBe(true)
+    expect(isBlockedUrl('http://[fdff::1]/')).toBe(true)
+  })
+
+  it('blocks fe80::/10 link-local', () => {
+    expect(isBlockedUrl('http://[fe80::1]/')).toBe(true)
+    expect(isBlockedUrl('http://[fe80::1%25eth0]/')).toBe(true) // zone id
+  })
+
+  it('blocks non-http(s) schemes', () => {
+    expect(isBlockedUrl('file:///etc/passwd')).toBe(true)
+    expect(isBlockedUrl('gopher://127.0.0.1/')).toBe(true)
+    expect(isBlockedUrl('ftp://example.com/')).toBe(true)
+  })
+
+  it('blocks unparseable URLs', () => {
+    expect(isBlockedUrl('not a url')).toBe(true)
+    expect(isBlockedUrl('')).toBe(true)
+  })
+})
+
+describe('isBlockedUrl — GHSA-c2rm-g55x-8hr5 bypasses', () => {
+  it('blocks IPv6-mapped loopback in pure-hex form (::ffff:7f00:1)', () => {
+    expect(isBlockedUrl('http://[::ffff:7f00:1]/')).toBe(true)
+    expect(isBlockedUrl('http://[::ffff:7f00:1]:8765/path')).toBe(true)
+  })
+
+  it('blocks IPv6-mapped RFC1918 in pure-hex form', () => {
+    expect(isBlockedUrl('http://[::ffff:c0a8:101]/')).toBe(true) // 192.168.1.1
+    expect(isBlockedUrl('http://[::ffff:a00:1]/')).toBe(true) // 10.0.0.1 (g6=0x0a00)
+  })
+
+  it('blocks fec0::/10 site-local (RFC 3879 deprecated)', () => {
+    expect(isBlockedUrl('http://[fec0::1]/')).toBe(true)
+    expect(isBlockedUrl('http://[feff::1]/')).toBe(true)
+  })
+
+  it('blocks 5f00::/16 SRv6 SIDs (RFC 9602)', () => {
+    expect(isBlockedUrl('http://[5f00::1]/')).toBe(true)
+    expect(isBlockedUrl('http://[5f00:ffff::1]/')).toBe(true)
+  })
+
+  it('blocks 3fff::/20 documentation v2 (RFC 9637)', () => {
+    expect(isBlockedUrl('http://[3fff::1]/')).toBe(true)
+    expect(isBlockedUrl('http://[3fff:ffff::1]/')).toBe(true)
+  })
+
+  it('blocks 64:ff9b:1::/48 NAT64 local-use (RFC 8215)', () => {
+    expect(isBlockedUrl('http://[64:ff9b:1::1]/')).toBe(true)
+    expect(isBlockedUrl('http://[64:ff9b:1::7f00:1]/')).toBe(true)
+  })
+
+  it('blocks 64:ff9b::/96 NAT64 well-known prefix with embedded private IPv4', () => {
+    expect(isBlockedUrl('http://[64:ff9b::7f00:1]/')).toBe(true) // embedded 127.0.0.1
+    expect(isBlockedUrl('http://[64:ff9b::a00:1]/')).toBe(true) // embedded 10.0.0.1
+  })
+
+  it('blocks 2001:db8::/32 documentation', () => {
+    expect(isBlockedUrl('http://[2001:db8::1]/')).toBe(true)
+  })
+})
+
+describe('isBlockedUrl — public addresses pass through', () => {
+  it('allows public IPv4', () => {
+    expect(isBlockedUrl('http://8.8.8.8/')).toBe(false)
+    expect(isBlockedUrl('https://1.1.1.1/')).toBe(false)
+  })
+
+  it('allows public hostnames', () => {
+    expect(isBlockedUrl('https://example.com/img.png')).toBe(false)
+    expect(isBlockedUrl('https://cdn.example.com/path?q=1')).toBe(false)
+  })
+
+  it('allows public IPv6', () => {
+    expect(isBlockedUrl('http://[2606:4700::1111]/')).toBe(false) // Cloudflare
+    expect(isBlockedUrl('http://[2001:4860:4860::8888]/')).toBe(false) // Google
+  })
+
+  it('allows 64:ff9b::/96 with public embedded IPv4', () => {
+    expect(isBlockedUrl('http://[64:ff9b::8.8.8.8]/')).toBe(false)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

N/A — proactive hardening following GHSA-pqhr-mp3f-hrpp / GHSA-c2rm-g55x-8hr5.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The previous SSRF guard lived inline in `imageSrc.ts` and missed several IPv6 forms (`::`, embedded IPv4, IPv4-mapped hex) and didn't follow redirects, so an allowed origin returning a 30x to a private IP could still complete the SSRF.

This PR consolidates the guard into `src/runtime/server/util/ssrf.ts` covering full IPv6 expansion (incl. zone IDs and the standard internal RFC ranges) and ships a `fetchWithRedirectValidation` helper that re-runs the host classifier on every `Location` hop with `redirect: 'manual'`. Takumi's external image fetch now goes through the hardened path in production (dev keeps the unrestricted `$fetch` for ergonomics).

Also threads the `H3Event` into `useOgImageRuntimeConfig` everywhere it's called so Cloudflare Workers env bindings resolve, and adds a top-level `ogImage.secret` runtime override so `NUXT_OG_IMAGE_SECRET` rotates without a rebuild.

29 new unit tests in `test/unit/ssrf.test.ts` cover the IPv4/IPv6/redirect surfaces.