### PR TITLE
fix: resolve configured local fonts for OG images

### DIFF
--- a/src/build/fontless.ts
+++ b/src/build/fontless.ts
@@ -18,7 +18,7 @@ import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs-lite'
 import { RE_WHITESPACE } from '../util'
 import { extractCustomFontFamilies } from './css/css-utils'
-import { downloadFontFile, extractSubsetNames, fontKey, FONTS_URL_PREFIX, getStaticInterFonts, matchesFontRequirements, parseAppCssFontFaces, parseFontsFromTemplate, STATIC_FONTS_PREFIX } from './fonts'
+import { downloadFontFile, extractSubsetNames, fontKey, FONTS_URL_PREFIX, getStaticInterFonts, matchesFontRequirements, parseAppCssFontFaces, parseConfiguredLocalFonts, parseFontsFromTemplate, STATIC_FONTS_PREFIX } from './fonts'
 
 const RE_NON_ALPHANUMERIC = /[^a-z0-9]/gi
 
@@ -32,6 +32,7 @@ export interface ProcessFontsOptions {
   fontRequirements: FontRequirementsState
   convertedWoff2Files: Map<string, string>
   fontSubsets?: string[]
+  warnOnMissingStaticFonts?: boolean
 }
 
 interface DownloadedFont {
@@ -55,6 +56,16 @@ interface FontlessContext {
 
 function getFontlessContext(nuxt: Nuxt): FontlessContext | undefined {
   return (nuxt as any)._ogImageFontless
+}
+
+function getNuxtFontsFamilyConfig(nuxt: Nuxt, family: string): Record<string, unknown> | undefined {
+  const families = ((nuxt.options as any).fonts as { families?: Array<Record<string, unknown>> } | undefined)?.families
+  return families?.find(f => typeof f?.name === 'string' && f.name.toLowerCase() === family.toLowerCase())
+}
+
+function isConfiguredLocalFontFamily(nuxt: Nuxt, family: string): boolean {
+  const config = getNuxtFontsFamilyConfig(nuxt, family)
+  return !!config && config.global === true && (config.provider === 'local' || (!config.provider && !config.src))
 }
 
 export async function initFontless(options: {
@@ -312,21 +323,36 @@ async function downloadStaticFonts(options: {
 
     for (const family of unresolvedFamilies) {
       const local = matchedLocal.find(m => m.family === family)
+      const configuredFamily = getNuxtFontsFamilyConfig(options.nuxt, family)
       const lines = [
         `Could not resolve font "${family}" for OG images.`,
         `  Tried providers: ${providerList}.`,
       ]
-      if (local) {
+      if (configuredFamily && configuredFamily.global !== true) {
+        lines.push(
+          `  "${family}" is declared in fonts.families, but it is not global so @nuxt/fonts did not emit it in nuxt-fonts-global.css.`,
+          `  Set global: true, e.g. fonts: { families: [{ name: '${family}', provider: 'local', weights: [400, 700], global: true }] }.`,
+        )
+      }
+      else if (configuredFamily) {
+        lines.push(
+          `  "${family}" is declared with global: true, but @nuxt/fonts still did not emit @font-face for it.`,
+          `  Check that the configured provider/src, weights, styles, and file names match the available font files.`,
+        )
+        if (local)
+          lines.push(`  Found ${local.matches.length} matching file(s) under public/fonts/ (e.g. ${local.matches.slice(0, 2).join(', ')}).`)
+      }
+      else if (local) {
         lines.push(
           `  Found ${local.matches.length} matching file(s) under public/fonts/ (e.g. ${local.matches.slice(0, 2).join(', ')}) but @nuxt/fonts did not emit @font-face for "${family}".`,
-          `  Tailwind v4 @theme variables are not scanned by @nuxt/fonts. Either reference \`font-family: '${family}'\` from a CSS rule (not just a CSS variable),`,
-          `  or declare it explicitly: fonts: { families: [{ name: '${family}', provider: 'local' }] } in nuxt.config.`,
+          `  Tailwind v4 @theme variables are not scanned by @nuxt/fonts, and OG images only read globally emitted font faces.`,
+          `  Declare it explicitly with global: true, e.g. fonts: { families: [{ name: '${family}', provider: 'local', weights: [400, 700], global: true }] }.`,
         )
       }
       else {
         lines.push(
           `  Not a known Google/Bunny/Fontsource font, and no matching files under public/fonts/.`,
-          `  If this is a custom/local font, add it to nuxt.config: fonts: { families: [{ name: '${family}', src: '/path/to/font.woff2' }] }.`,
+          `  If this is a custom/local font, add it to nuxt.config with global: true: fonts: { families: [{ name: '${family}', src: '/path/to/font.woff2', global: true }] }.`,
           `  If it should resolve from a remote provider, check the spelling or add the provider to fonts.priority.`,
         )
       }
@@ -424,7 +450,7 @@ async function resolveAndDownloadFamily(options: {
  * Satori can't use WOFF2 directly — uses fontless to download static TTF/WOFF alternatives.
  */
 export async function convertWoff2ToTtf(options: ProcessFontsOptions): Promise<void> {
-  const { nuxt, logger, fontRequirements, convertedWoff2Files, fontSubsets } = options
+  const { nuxt, logger, fontRequirements, convertedWoff2Files, fontSubsets, warnOnMissingStaticFonts = true } = options
 
   const parsedFonts = await parseFontsFromTemplate(nuxt, { convertedWoff2Files })
 
@@ -440,6 +466,7 @@ export async function convertWoff2ToTtf(options: ProcessFontsOptions): Promise<v
   const woff2Fonts = parsedFonts.filter(f =>
     f.src.endsWith('.woff2')
     && !hasNonWoff2.has(fontKey(f))
+    && !isConfiguredLocalFontFamily(nuxt, f.family)
     && fontRequirements.weights.includes(f.weight)
     && fontRequirements.styles.includes(f.style as 'normal' | 'italic'),
   )
@@ -484,7 +511,7 @@ export async function convertWoff2ToTtf(options: ProcessFontsOptions): Promise<v
     if (convertedWoff2Files.size > 0) {
       logger.debug(`Resolved ${convertedWoff2Files.size} static font files via fontless`)
     }
-    else {
+    else if (warnOnMissingStaticFonts) {
       logger.warn(`No static fonts available for Satori. Falling back to bundled Inter font. Consider using 'takumi' renderer for variable font support.`)
     }
   }
@@ -557,6 +584,21 @@ export async function resolveOgImageFonts(options: {
   const allFonts = hasNuxtFonts
     ? await parseFontsFromTemplate(nuxt, { convertedWoff2Files, requiredWeights: fontRequirements.weights })
     : []
+
+  if (hasNuxtFonts) {
+    const configuredLocalFonts = parseConfiguredLocalFonts(nuxt)
+    if (configuredLocalFonts.length > 0) {
+      const existingKeys = new Set(allFonts.map(f => `${f.family}-${f.weight}-${f.style}`))
+      for (const font of configuredLocalFonts) {
+        const key = `${font.family}-${font.weight}-${font.style}`
+        if (!existingKeys.has(key)) {
+          allFonts.push(font)
+          existingKeys.add(key)
+        }
+      }
+      logger.debug(`Resolved ${configuredLocalFonts.length} configured local font faces from public/fonts`)
+    }
+  }
 
   // Auto-detect subsets from @nuxt/fonts CSS comments (e.g. devanagari, cyrillic)
   // so fontless downloads include non-Latin fonts instead of defaulting to latin-only

--- a/src/build/fontless.ts
+++ b/src/build/fontless.ts
@@ -65,7 +65,7 @@ function getNuxtFontsFamilyConfig(nuxt: Nuxt, family: string): Record<string, un
 
 function isConfiguredLocalFontFamily(nuxt: Nuxt, family: string): boolean {
   const config = getNuxtFontsFamilyConfig(nuxt, family)
-  return !!config && config.global === true && (config.provider === 'local' || (!config.provider && !config.src))
+  return !!config && config.global === true && (config.provider === 'local' || typeof config.src === 'string')
 }
 
 export async function initFontless(options: {

--- a/src/build/fonts.ts
+++ b/src/build/fonts.ts
@@ -8,12 +8,14 @@ import type { Nuxt } from 'nuxt/schema'
 import { existsSync } from 'node:fs'
 import * as fs from 'node:fs'
 import { writeFile } from 'node:fs/promises'
-import { join } from 'pathe'
+import { join, relative } from 'pathe'
 import { extractCustomFontFamilies } from './css/css-utils'
 import { extractFontFacesWithSubsets } from './css/font-face'
 
 const RE_FONT_FACE_BLOCK = /@font-face\s*\{[^}]+\}/g
 const RE_FONT_KEY = /^(.+)-(\d+)-(.+)$/
+const RE_FONT_EXT = /\.(?:woff2?|ttf|otf)$/i
+const RE_NON_WORD = /\W+/g
 
 // ============================================================================
 // Types
@@ -209,6 +211,145 @@ export async function parseAppCssFontFaces(nuxt: Nuxt): Promise<ParsedFont[]> {
       })
     }
   }
+
+  return results
+}
+
+// ============================================================================
+// Font Parsing from @nuxt/fonts Local Config
+// ============================================================================
+
+function fontFamilyToSlug(family: string): string {
+  return family.toLowerCase().replace(RE_NON_WORD, '')
+}
+
+function normalizeConfiguredWeights(value: unknown): number[] {
+  if (!Array.isArray(value))
+    return [400, 700]
+
+  const weights = new Set<number>()
+  for (const entry of value) {
+    if (typeof entry === 'number') {
+      weights.add(entry)
+      continue
+    }
+    if (typeof entry === 'string') {
+      const matches = entry.match(/\d{3}/g) || []
+      for (const match of matches)
+        weights.add(Number(match))
+    }
+  }
+  return weights.size > 0 ? [...weights] : [400, 700]
+}
+
+function normalizeConfiguredStyles(value: unknown): Array<'normal' | 'italic'> {
+  if (!Array.isArray(value))
+    return ['normal', 'italic']
+
+  const styles = value.filter((style): style is 'normal' | 'italic' => style === 'normal' || style === 'italic')
+  return styles.length > 0 ? styles : ['normal']
+}
+
+function detectWeight(filename: string): number | undefined {
+  const numeric = filename.match(/(?:^|[-_])([1-9]00)(?:[-_.]|$)/)?.[1]
+  if (numeric)
+    return Number(numeric)
+
+  if (/(?:^|[-_])bold(?:[-_.]|$)/i.test(filename))
+    return 700
+  if (/(?:^|[-_])regular(?:[-_.]|$)/i.test(filename))
+    return 400
+}
+
+function detectStyle(filename: string): 'normal' | 'italic' {
+  return /(?:^|[-_])(?:italic|oblique)(?:[-_.]|$)/i.test(filename) ? 'italic' : 'normal'
+}
+
+function stripFontDescriptors(filename: string): string {
+  return filename
+    .replace(RE_FONT_EXT, '')
+    .replace(/(?:^|[-_])(?:[1-9]00|thin|extra[-_]?light|light|regular|normal|medium|semi[-_]?bold|bold|extra[-_]?bold|black|italic|oblique|latin(?:[-_]?ext)?|cyrillic(?:[-_]?ext)?|greek(?:[-_]?ext)?|vietnamese)(?=[-_.]|$)/gi, '')
+    .replace(/[-_]+$/g, '')
+}
+
+/**
+ * Fallback for @nuxt/fonts local provider timing.
+ *
+ * @nuxt/fonts registers public font files in nitro:init, but og-image can need
+ * the font list while Nitro virtual modules are being generated. When a global
+ * local family is declared, synthesize the same public URLs directly from
+ * public/fonts so dev/test startup does not temporarily fall back to Inter.
+ */
+export function parseConfiguredLocalFonts(nuxt: Nuxt): ParsedFont[] {
+  const families = ((nuxt.options as any).fonts as { families?: Array<Record<string, unknown>> } | undefined)?.families || []
+  const localFamilies = families.filter(f =>
+    typeof f.name === 'string'
+    && f.global === true
+    && (f.provider === 'local' || (!f.provider && !f.src)),
+  )
+  if (localFamilies.length === 0)
+    return []
+
+  const publicDir = join(nuxt.options.rootDir, 'public')
+  const fontsDir = join(publicDir, 'fonts')
+  if (!existsSync(fontsDir))
+    return []
+
+  const files: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(path)
+      }
+      else if (RE_FONT_EXT.test(entry.name)) {
+        files.push(path)
+      }
+    }
+  }
+  walk(fontsDir)
+  files.sort()
+
+  const results: ParsedFont[] = []
+  const seen = new Set<string>()
+  for (const family of localFamilies) {
+    const name = family.name as string
+    const familySlug = fontFamilyToSlug(name)
+    const weights = normalizeConfiguredWeights(family.weights)
+    const styles = normalizeConfiguredStyles(family.styles)
+
+    for (const file of files) {
+      const filename = file.split('/').pop() || file
+      if (fontFamilyToSlug(stripFontDescriptors(filename)) !== familySlug)
+        continue
+
+      const weight = detectWeight(filename)
+      const style = detectStyle(filename)
+      if (!weight || !weights.includes(weight) || !styles.includes(style))
+        continue
+
+      const src = `/${relative(publicDir, file)}`
+      const key = fontKey({ family: name, weight, style })
+      if (seen.has(key))
+        continue
+      seen.add(key)
+
+      results.push({
+        family: name,
+        src,
+        weight,
+        style,
+        satoriSrc: src.endsWith('.woff2') ? undefined : src,
+      })
+    }
+  }
+
+  results.sort((a, b) =>
+    a.family.localeCompare(b.family)
+    || a.weight - b.weight
+    || (a.style === b.style ? 0 : a.style === 'normal' ? -1 : 1)
+    || a.src.localeCompare(b.src),
+  )
 
   return results
 }

--- a/src/build/fonts.ts
+++ b/src/build/fonts.ts
@@ -285,7 +285,7 @@ export function parseConfiguredLocalFonts(nuxt: Nuxt): ParsedFont[] {
   const localFamilies = families.filter(f =>
     typeof f.name === 'string'
     && f.global === true
-    && (f.provider === 'local' || (!f.provider && !f.src)),
+    && (f.provider === 'local' || typeof f.src === 'string'),
   )
   if (localFamilies.length === 0)
     return []

--- a/src/module.ts
+++ b/src/module.ts
@@ -1337,6 +1337,7 @@ export const resolve = (import.meta.dev || import.meta.prerender) ? devResolve :
           fontRequirements: fontRequirementsState,
           convertedWoff2Files,
           fontSubsets: config.fontSubsets,
+          warnOnMissingStaticFonts: hasSatoriRenderer(),
         })
       }
       const fonts = await resolveOgImageFonts({
@@ -1431,6 +1432,7 @@ export const rootDir = ${JSON.stringify(nuxt.options.rootDir)}`
           fontRequirements: fontRequirementsState,
           convertedWoff2Files,
           fontSubsets: config.fontSubsets,
+          warnOnMissingStaticFonts: hasSatoriRenderer(),
         })
         fontProcessingDone = true
       })

--- a/test/unit/fonts.test.ts
+++ b/test/unit/fonts.test.ts
@@ -278,6 +278,32 @@ describe('parseConfiguredLocalFonts', () => {
       rmSync(rootDir, { recursive: true, force: true })
     }
   })
+
+  it('does not treat providerless remote font families as local', () => {
+    const rootDir = join(tmpdir(), `og-image-local-fonts-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    const fontDir = join(rootDir, 'public/fonts')
+
+    try {
+      mkdirSync(fontDir, { recursive: true })
+      writeFileSync(join(fontDir, 'nunito-sans-400.woff2'), '')
+
+      const fonts = parseConfiguredLocalFonts({
+        options: {
+          rootDir,
+          fonts: {
+            families: [
+              { name: 'Nunito Sans', weights: [400], global: true },
+            ],
+          },
+        },
+      } as any)
+
+      expect(fonts).toEqual([])
+    }
+    finally {
+      rmSync(rootDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('extractFontFacesWithSubsets', () => {

--- a/test/unit/fonts.test.ts
+++ b/test/unit/fonts.test.ts
@@ -1,7 +1,10 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'pathe'
 import { describe, expect, it } from 'vitest'
 import { extractCustomFontFamilies } from '../../src/build/css/css-utils'
 import { extractFontFacesWithSubsets } from '../../src/build/css/font-face'
-import { fontKey, getStaticInterFonts, matchesFontRequirements, resolveFontFamilies } from '../../src/build/fonts'
+import { fontKey, getStaticInterFonts, matchesFontRequirements, parseConfiguredLocalFonts, resolveFontFamilies } from '../../src/build/fonts'
 import { selectFontSource } from '../../src/runtime/server/og-image/font-source'
 import { buildSubsetFamilyChain, renameSubsetFonts } from '../../src/runtime/server/og-image/font-subsets'
 import { codepointsIntersectRanges, extractCodepoints, parseUnicodeRange } from '../../src/runtime/server/og-image/unicode-range'
@@ -189,6 +192,91 @@ describe('getStaticInterFonts', () => {
     expect(fonts[0].satoriSrc).toBeDefined()
     expect(fonts[1].weight).toBe(700)
     expect(fonts[1].satoriSrc).toBeDefined()
+  })
+})
+
+describe('parseConfiguredLocalFonts', () => {
+  it('resolves global local font families from public/fonts', () => {
+    const rootDir = join(tmpdir(), `og-image-local-fonts-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    const fontDir = join(rootDir, 'public/fonts/sofia-pro')
+
+    try {
+      mkdirSync(fontDir, { recursive: true })
+      writeFileSync(join(fontDir, 'sofia-pro-soft-400.woff2'), '')
+      writeFileSync(join(fontDir, 'sofia-pro-soft-400-italic.woff2'), '')
+      writeFileSync(join(fontDir, 'sofia-pro-soft-700.woff2'), '')
+      writeFileSync(join(fontDir, 'sofia-pro-soft-900.woff2'), '')
+
+      const fonts = parseConfiguredLocalFonts({
+        options: {
+          rootDir,
+          fonts: {
+            families: [
+              {
+                name: 'sofia-pro-soft',
+                provider: 'local',
+                weights: [400, 700],
+                styles: ['normal', 'italic'],
+                global: true,
+              },
+            ],
+          },
+        },
+      } as any)
+
+      expect(fonts).toEqual([
+        {
+          family: 'sofia-pro-soft',
+          src: '/fonts/sofia-pro/sofia-pro-soft-400.woff2',
+          weight: 400,
+          style: 'normal',
+          satoriSrc: undefined,
+        },
+        {
+          family: 'sofia-pro-soft',
+          src: '/fonts/sofia-pro/sofia-pro-soft-400-italic.woff2',
+          weight: 400,
+          style: 'italic',
+          satoriSrc: undefined,
+        },
+        {
+          family: 'sofia-pro-soft',
+          src: '/fonts/sofia-pro/sofia-pro-soft-700.woff2',
+          weight: 700,
+          style: 'normal',
+          satoriSrc: undefined,
+        },
+      ])
+    }
+    finally {
+      rmSync(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores local font families that are not global', () => {
+    const rootDir = join(tmpdir(), `og-image-local-fonts-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    const fontDir = join(rootDir, 'public/fonts')
+
+    try {
+      mkdirSync(fontDir, { recursive: true })
+      writeFileSync(join(fontDir, 'custom-font-400.woff2'), '')
+
+      const fonts = parseConfiguredLocalFonts({
+        options: {
+          rootDir,
+          fonts: {
+            families: [
+              { name: 'custom-font', provider: 'local', weights: [400] },
+            ],
+          },
+        },
+      } as any)
+
+      expect(fonts).toEqual([])
+    }
+    finally {
+      rmSync(rootDir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- resolve configured global local @nuxt/fonts families directly from public/fonts when the @nuxt/fonts local provider has not emitted its global template yet
- skip remote static font fallback for configured local WOFF2 families so Takumi-only projects do not get misleading Satori/fontless warnings
- improve unresolved-font diagnostics to distinguish missing global: true from other local provider issues
- add unit coverage for configured local font parsing

## Testing
- pnpm exec eslint src/build/fontless.ts src/build/fonts.ts src/module.ts test/unit/fonts.test.ts
- pnpm exec vitest run test/unit/fonts.test.ts test/unit/resolve-og-fonts.test.ts