### PR TITLE
fix(takumi): treat single-entry variable fonts as axis-driven (defensive)

### DIFF
--- a/src/build/fonts.ts
+++ b/src/build/fonts.ts
@@ -34,6 +34,8 @@ export interface ParsedFont {
   absolutePath?: string
   /** When true, this font survives requirements filtering as a last-resort fallback. */
   fallback?: boolean
+  /** Original weight range for variable fonts (e.g. [100, 900]). Present when src is a variable font. */
+  weightRange?: [number, number]
 }
 
 /** URL prefix for @nuxt/fonts web fonts (used by fontless normalizeFontData) */
@@ -481,6 +483,7 @@ export async function parseFontsFromTemplate(
       satoriSrc,
       unicodeRange: font.unicodeRange || defaultUnicodeRange,
       subset: font.subset,
+      weightRange: font.weightRange,
     }
   })
 

--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -97,7 +97,7 @@ function withTakumiLock<T>(
   ]).finally(() => clearTimeout(acquireTimer))
 }
 
-interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string }
+interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string, weightRange?: [number, number] }
 
 interface DedupedFontLoad {
   binaryKey: string
@@ -112,13 +112,18 @@ interface DedupedFontLoad {
  * Collapse font entries that share a binary (same family, style, src) into a single load.
  * @nuxt/fonts produces per-weight entries all pointing to the same variable WOFF2 URL;
  * loading the same binary under multiple weight labels prevents takumi from varying the
- * wght axis. For variable fonts (multiple weights sharing a binary) we pass no weight so
- * takumi auto-detects the axis from the font metadata.
+ * wght axis. For variable fonts we pass no weight so takumi auto-detects the axis from
+ * the font metadata.
+ *
+ * A binary is treated as variable if EITHER multiple weight tags share it OR any entry
+ * carries a `weightRange` (parsed from CSS `font-weight: <min> <max>`). The latter matters
+ * in dev when the build-time per-weight expansion may not have run yet — we'd otherwise
+ * pass an explicit weight to takumi for a variable file and it would mis-map the axis.
  *
  * Mirrored in test/unit/takumi-font-dedupe.test.ts — keep implementations in sync.
  */
 function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
-  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined> }>()
+  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined>, hasRange: boolean }>()
   for (const font of fonts) {
     if (!font.data)
       continue
@@ -126,6 +131,8 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
     const existing = byBinary.get(binaryKey)
     if (existing) {
       existing.weights.add(font.weight)
+      if (font.weightRange)
+        existing.hasRange = true
     }
     else {
       byBinary.set(binaryKey, {
@@ -133,12 +140,13 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
         style: font.style,
         data: font.data,
         weights: new Set([font.weight]),
+        hasRange: !!font.weightRange,
       })
     }
   }
   const result: DedupedFontLoad[] = []
   for (const [binaryKey, entry] of byBinary) {
-    const isVariable = entry.weights.size > 1
+    const isVariable = entry.weights.size > 1 || entry.hasRange
     result.push({
       binaryKey,
       family: entry.family,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -232,6 +232,8 @@ export interface FontConfig {
   unicodeRange?: string
   /** When true, this font survives requirements filtering as a last-resort fallback. */
   fallback?: boolean
+  /** Original weight range for variable fonts (e.g. [100, 900]). Present when src is a variable font. */
+  weightRange?: [number, number]
 }
 
 export interface RuntimeFontConfig extends FontConfig {

--- a/test/unit/takumi-font-dedupe.test.ts
+++ b/test/unit/takumi-font-dedupe.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest'
 // weight labels prevented takumi from varying the wght axis — every weight
 // rendered identically (the font's default axis position, typically 400).
 
-interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string }
+interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string, weightRange?: [number, number] }
 
 interface DedupedFontLoad {
   binaryKey: string
@@ -20,7 +20,7 @@ interface DedupedFontLoad {
 }
 
 function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
-  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined> }>()
+  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined>, hasRange: boolean }>()
   for (const font of fonts) {
     if (!font.data)
       continue
@@ -28,6 +28,8 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
     const existing = byBinary.get(binaryKey)
     if (existing) {
       existing.weights.add(font.weight)
+      if (font.weightRange)
+        existing.hasRange = true
     }
     else {
       byBinary.set(binaryKey, {
@@ -35,12 +37,13 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
         style: font.style,
         data: font.data,
         weights: new Set([font.weight]),
+        hasRange: !!font.weightRange,
       })
     }
   }
   const result: DedupedFontLoad[] = []
   for (const [binaryKey, entry] of byBinary) {
-    const isVariable = entry.weights.size > 1
+    const isVariable = entry.weights.size > 1 || entry.hasRange
     result.push({
       binaryKey,
       family: entry.family,
@@ -111,6 +114,28 @@ describe('dedupeFontsByBinary', () => {
     ]
 
     expect(dedupeFontsByBinary(fonts)).toHaveLength(1)
+  })
+
+  it('treats single-entry variable fonts (weightRange) as axis-driven', () => {
+    // Regression: in dev, build-time per-weight expansion may not have populated
+    // fontRequirements yet, so a variable WOFF2 reaches runtime as a single entry.
+    // Without weightRange detection we'd pass `weight: 400` to takumi and it would
+    // mis-map the wght axis (e.g. requested 400 → rendered 100, requested 700 → 700).
+    const fonts = [
+      {
+        family: 'Public Sans',
+        style: 'normal',
+        weight: 400,
+        src: '/_fonts/public-sans-variable.woff2',
+        data: sharedBuffer,
+        weightRange: [100, 900] as [number, number],
+      },
+    ]
+
+    const deduped = dedupeFontsByBinary(fonts)
+
+    expect(deduped).toHaveLength(1)
+    expect(deduped[0]!.weight).toBeUndefined()
   })
 
   it('preserves the binaryKey shape so state.loadedFontKeys can dedupe across requests', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Reported on https://github.com/maevsi/vibetype (no og-image issue filed).

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`dedupeFontsByBinary` flagged a binary as variable only when multiple weight tags shared it (`weights.size > 1`). With a single-entry variable WOFF2 it would pass an explicit `weight` to `takumi.loadFont` instead of letting the renderer auto-detect the wght axis. Propagates `weightRange` from the @nuxt/fonts CSS parser through `ParsedFont` and `FontConfig` so dedupe can detect a variable binary regardless of how many weight tags are present.

This is a defensive consistency fix — end-to-end testing of the vibetype reproducer showed takumi auto-varies the axis correctly even with the explicit weight, so this PR alone does not fix the user-visible weight regression. The actual fix lives in #600 and depends on this one for the `weightRange` plumbing.