### PR TITLE
fix(takumi): keep variable WOFF2 over per-weight static fallback

### DIFF
--- a/src/build/fonts.ts
+++ b/src/build/fonts.ts
@@ -34,6 +34,8 @@ export interface ParsedFont {
   absolutePath?: string
   /** When true, this font survives requirements filtering as a last-resort fallback. */
   fallback?: boolean
+  /** Original weight range for variable fonts (e.g. [100, 900]). Present when src is a variable font. */
+  weightRange?: [number, number]
 }
 
 /** URL prefix for @nuxt/fonts web fonts (used by fontless normalizeFontData) */
@@ -481,6 +483,7 @@ export async function parseFontsFromTemplate(
       satoriSrc,
       unicodeRange: font.unicodeRange || defaultUnicodeRange,
       subset: font.subset,
+      weightRange: font.weightRange,
     }
   })
 

--- a/src/runtime/server/og-image/font-source.ts
+++ b/src/runtime/server/og-image/font-source.ts
@@ -16,19 +16,25 @@ export function fontFormat(src: string): FontFormat {
  * - When `preferStatic` is set (takumi), prefers the full static satoriSrc over a subset WOFF2
  *   primary src. @nuxt/fonts CSS often ships only the latin subset for a family, so using the
  *   subset would hide non-latin glyphs (devanagari, CJK) the static file covers.
+ * - Variable fonts (entries carrying `weightRange`) are an exception: the per-weight static
+ *   `satoriSrc` would discard the wght axis, leaving the runtime to stair-step requested
+ *   weights through whatever weights fontless happened to download (e.g. requested 400 maps
+ *   to the closest available static, often 100 or 700, with a hard jump in the middle).
+ *   Keep the variable WOFF2 primary src so takumi can vary the axis at render time.
  * - Otherwise, uses the primary src when the renderer can parse its format, falling back to
  *   satoriSrc as a static alternative when the primary format is unsupported (satori + WOFF2).
  *
  * Returns null when no src on this entry can be parsed by the renderer.
  */
 export function selectFontSource(
-  f: { src: string, satoriSrc?: string },
+  f: { src: string, satoriSrc?: string, weightRange?: [number, number] },
   supportedFormats: Set<FontFormat>,
   preferStatic: boolean,
 ): { src: string, isStaticFallback: boolean } | null {
   const primarySupported = supportedFormats.has(fontFormat(f.src))
   const satoriSupported = !!(f.satoriSrc && supportedFormats.has(fontFormat(f.satoriSrc)))
-  if (preferStatic && satoriSupported && f.satoriSrc !== f.src)
+  const isVariable = !!f.weightRange
+  if (preferStatic && !isVariable && satoriSupported && f.satoriSrc !== f.src)
     return { src: f.satoriSrc!, isStaticFallback: true }
   if (primarySupported)
     return { src: f.src, isStaticFallback: false }

--- a/src/runtime/server/og-image/takumi/renderer.ts
+++ b/src/runtime/server/og-image/takumi/renderer.ts
@@ -97,7 +97,7 @@ function withTakumiLock<T>(
   ]).finally(() => clearTimeout(acquireTimer))
 }
 
-interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string }
+interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string, weightRange?: [number, number] }
 
 interface DedupedFontLoad {
   binaryKey: string
@@ -112,13 +112,18 @@ interface DedupedFontLoad {
  * Collapse font entries that share a binary (same family, style, src) into a single load.
  * @nuxt/fonts produces per-weight entries all pointing to the same variable WOFF2 URL;
  * loading the same binary under multiple weight labels prevents takumi from varying the
- * wght axis. For variable fonts (multiple weights sharing a binary) we pass no weight so
- * takumi auto-detects the axis from the font metadata.
+ * wght axis. For variable fonts we pass no weight so takumi auto-detects the axis from
+ * the font metadata.
+ *
+ * A binary is treated as variable if EITHER multiple weight tags share it OR any entry
+ * carries a `weightRange` (parsed from CSS `font-weight: <min> <max>`). The latter matters
+ * in dev when the build-time per-weight expansion may not have run yet — we'd otherwise
+ * pass an explicit weight to takumi for a variable file and it would mis-map the axis.
  *
  * Mirrored in test/unit/takumi-font-dedupe.test.ts — keep implementations in sync.
  */
 function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
-  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined> }>()
+  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined>, hasRange: boolean }>()
   for (const font of fonts) {
     if (!font.data)
       continue
@@ -126,6 +131,8 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
     const existing = byBinary.get(binaryKey)
     if (existing) {
       existing.weights.add(font.weight)
+      if (font.weightRange)
+        existing.hasRange = true
     }
     else {
       byBinary.set(binaryKey, {
@@ -133,12 +140,13 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
         style: font.style,
         data: font.data,
         weights: new Set([font.weight]),
+        hasRange: !!font.weightRange,
       })
     }
   }
   const result: DedupedFontLoad[] = []
   for (const [binaryKey, entry] of byBinary) {
-    const isVariable = entry.weights.size > 1
+    const isVariable = entry.weights.size > 1 || entry.hasRange
     result.push({
       binaryKey,
       family: entry.family,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -232,6 +232,8 @@ export interface FontConfig {
   unicodeRange?: string
   /** When true, this font survives requirements filtering as a last-resort fallback. */
   fallback?: boolean
+  /** Original weight range for variable fonts (e.g. [100, 900]). Present when src is a variable font. */
+  weightRange?: [number, number]
 }
 
 export interface RuntimeFontConfig extends FontConfig {

--- a/test/unit/fonts.test.ts
+++ b/test/unit/fonts.test.ts
@@ -713,4 +713,37 @@ describe('selectFontSource', () => {
     const result = selectFontSource({ src: '/_fonts/inter.woff2' }, SATORI_FORMATS, false)
     expect(result).toBeNull()
   })
+
+  // Regression: with a variable font + per-weight static fallbacks, preferStatic
+  // would pick the static TTF and lose the wght axis. The runtime would then
+  // stair-step requested weights through `findClosestWeight` against whatever
+  // weights fontless happened to download (e.g. 400 → 100, 700 → 700 with a
+  // jump in between). Keep the variable WOFF2 so takumi varies the axis.
+  it('keeps the variable WOFF2 over per-weight satoriSrc when entry has weightRange', () => {
+    const result = selectFontSource(
+      {
+        src: '/_fonts/raleway-variable.woff2',
+        satoriSrc: '/_og-static-fonts/Raleway-400-normal.ttf',
+        weightRange: [100, 900],
+      },
+      TAKUMI_FORMATS,
+      true,
+    )
+    expect(result).toEqual({ src: '/_fonts/raleway-variable.woff2', isStaticFallback: false })
+  })
+
+  it('still falls back to satoriSrc for a variable font when primary format is unsupported', () => {
+    // Defensive: if primary src isn't parseable by the renderer, the static is still
+    // better than rendering tofu — we accept the axis loss in that case.
+    const result = selectFontSource(
+      {
+        src: '/_fonts/raleway-variable.woff2',
+        satoriSrc: '/_og-static-fonts/Raleway-400-normal.ttf',
+        weightRange: [100, 900],
+      },
+      SATORI_FORMATS,
+      false,
+    )
+    expect(result).toEqual({ src: '/_og-static-fonts/Raleway-400-normal.ttf', isStaticFallback: true })
+  })
 })

--- a/test/unit/takumi-font-dedupe.test.ts
+++ b/test/unit/takumi-font-dedupe.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest'
 // weight labels prevented takumi from varying the wght axis — every weight
 // rendered identically (the font's default axis position, typically 400).
 
-interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string }
+interface FontEntry { family: string, src?: string, data?: BufferSource, weight?: number, style?: string, cacheKey?: string, weightRange?: [number, number] }
 
 interface DedupedFontLoad {
   binaryKey: string
@@ -20,7 +20,7 @@ interface DedupedFontLoad {
 }
 
 function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
-  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined> }>()
+  const byBinary = new Map<string, { family: string, style?: string, data: BufferSource, weights: Set<number | undefined>, hasRange: boolean }>()
   for (const font of fonts) {
     if (!font.data)
       continue
@@ -28,6 +28,8 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
     const existing = byBinary.get(binaryKey)
     if (existing) {
       existing.weights.add(font.weight)
+      if (font.weightRange)
+        existing.hasRange = true
     }
     else {
       byBinary.set(binaryKey, {
@@ -35,12 +37,13 @@ function dedupeFontsByBinary(fonts: FontEntry[]): DedupedFontLoad[] {
         style: font.style,
         data: font.data,
         weights: new Set([font.weight]),
+        hasRange: !!font.weightRange,
       })
     }
   }
   const result: DedupedFontLoad[] = []
   for (const [binaryKey, entry] of byBinary) {
-    const isVariable = entry.weights.size > 1
+    const isVariable = entry.weights.size > 1 || entry.hasRange
     result.push({
       binaryKey,
       family: entry.family,
@@ -111,6 +114,28 @@ describe('dedupeFontsByBinary', () => {
     ]
 
     expect(dedupeFontsByBinary(fonts)).toHaveLength(1)
+  })
+
+  it('treats single-entry variable fonts (weightRange) as axis-driven', () => {
+    // Regression: in dev, build-time per-weight expansion may not have populated
+    // fontRequirements yet, so a variable WOFF2 reaches runtime as a single entry.
+    // Without weightRange detection we'd pass `weight: 400` to takumi and it would
+    // mis-map the wght axis (e.g. requested 400 → rendered 100, requested 700 → 700).
+    const fonts = [
+      {
+        family: 'Public Sans',
+        style: 'normal',
+        weight: 400,
+        src: '/_fonts/public-sans-variable.woff2',
+        data: sharedBuffer,
+        weightRange: [100, 900] as [number, number],
+      },
+    ]
+
+    const deduped = dedupeFontsByBinary(fonts)
+
+    expect(deduped).toHaveLength(1)
+    expect(deduped[0]!.weight).toBeUndefined()
   })
 
   it('preserves the binaryKey shape so state.loadedFontKeys can dedupe across requests', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Reported on https://github.com/maevsi/vibetype (no og-image issue filed). Stacked on #599 for the `weightRange` plumbing.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When @nuxt/fonts serves a variable WOFF2 (npm provider against a Fontsource variable package) and fontless downloads per-weight static TTFs as fallback, `selectFontSource(preferStatic: true)` was picking the static and discarding the wght axis. The runtime then stair-stepped requested weights through `findClosestWeight` against whatever weights fontless happened to download — exact pattern reported by the user (\`400 → 100\`, \`700 → 700\`, hard jump in the middle).

`selectFontSource` now skips the static fallback when the entry carries a `weightRange`, so takumi keeps the variable WOFF2 and varies the axis at render time. The static remains as a defensive last resort if the primary format is unparseable. Merge order: #599 first, then this.