### PR TITLE
test: bump `setupTimeout` for public-sans-repro fixture

### DIFF
--- a/test/e2e/public-sans-repro.test.ts
+++ b/test/e2e/public-sans-repro.test.ts
@@ -14,6 +14,7 @@ await setup({
   rootDir: resolve('../fixtures/public-sans-repro'),
   server: true,
   build: true,
+  setupTimeout: 240_000,
 })
 
 setupImageSnapshots(SNAPSHOT_LOOSE)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

noticed ecosystem-ci hanging at exactly 2min, which suggests a test timeout rather than a upgrade regression