### PR TITLE
fix: skip renderer prompt in non-interactive environments

### DIFF
--- a/docs/content/6.migration-guide/v6.md
+++ b/docs/content/6.migration-guide/v6.md
@@ -66,7 +66,7 @@ npm i playwright-core
 
 Running `nuxi dev` in an interactive terminal will prompt you to install missing dependencies automatically.
 
-In non-interactive environments (AI coding agents, CI, or any process without a TTY) there is nothing to answer the prompt, so the module skips it: it defaults to the `takumi` renderer and emits a warning. When run by an AI agent, a missing renderer dependency that cannot be installed throws a clear error (`npx nypm add @takumi-rs/core`) instead of silently producing broken images. Set `NUXT_OG_IMAGE_SKIP_ONBOARDING=1` to opt out of onboarding entirely.
+In non-interactive environments (AI coding agents, CI, or any process without a TTY) there is nothing to answer the prompt, so the module skips it: it defaults to the `takumi` renderer and emits a warning. When an AI agent runs the module and cannot install a missing renderer dependency, the module throws a clear error (`npx nypm add @takumi-rs/core`) instead of silently producing broken images. Set `NUXT_OG_IMAGE_SKIP_ONBOARDING=1` to opt out of onboarding entirely.
 
 ### Component Renderer Suffix Required
 

--- a/docs/content/6.migration-guide/v6.md
+++ b/docs/content/6.migration-guide/v6.md
@@ -64,7 +64,9 @@ npm i satori @resvg/resvg-wasm
 npm i playwright-core
 ```
 
-Running `nuxi dev` will prompt you to install missing dependencies automatically.
+Running `nuxi dev` in an interactive terminal will prompt you to install missing dependencies automatically.
+
+In non-interactive environments (AI coding agents, CI, or any process without a TTY) there is nothing to answer the prompt, so the module skips it: it defaults to the `takumi` renderer and emits a warning. When run by an AI agent, a missing renderer dependency that cannot be installed throws a clear error (`npx nypm add @takumi-rs/core`) instead of silently producing broken images. Set `NUXT_OG_IMAGE_SKIP_ONBOARDING=1` to opt out of onboarding entirely.
 
 ### Component Renderer Suffix Required
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -23,6 +23,7 @@ import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { hash } from 'ohash'
 import { isAbsolute, join } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
+import { isAgent } from 'std-env'
 import { setupBuildHandler } from './build/build'
 import { setupDevHandler } from './build/dev'
 import { setupDevToolsUI } from './build/devtools'
@@ -50,7 +51,7 @@ import { onInstall, onUpgrade } from './onboarding'
 import { logger } from './runtime/logger'
 import { registerTypeTemplates } from './templates'
 import { checkLocalChrome, getRegisteredBaseNames, getRendererFromFilename, hasResolvableDependency, isUndefinedOrTruthy, RE_LEGACY_SUFFIX } from './util'
-import { ensureProviderDependencies, getInstalledProviders, getMissingDependencies, getRecommendedBinding, promptForRendererSelection } from './utils/dependencies'
+import { canPromptInteractively, ensureProviderDependencies, getInstalledProviders, getMissingDependencies, getRecommendedBinding, promptForRendererSelection } from './utils/dependencies'
 
 export type {
   OgImageComponent,
@@ -1050,13 +1051,16 @@ export default defineNuxtModule<ModuleOptions>({
         ogImageComponentCtx.detectedRenderers.add(preferred.provider)
         logger.debug(`Using ${preferred.provider} renderer`)
       }
-      else if (nuxt.options.dev && !nuxt.options._prepare) {
+      else if (nuxt.options.dev && !nuxt.options._prepare && canPromptInteractively()) {
         const renderer = await promptForRendererSelection()
         ogImageComponentCtx.detectedRenderers.add(renderer)
         logger.debug(`Using ${renderer} renderer`)
       }
       else {
+        // non-interactive (agent, CI, or no TTY) — can't prompt, default to takumi.
+        // Warn so the choice is visible and the agent can pin a renderer explicitly.
         ogImageComponentCtx.detectedRenderers.add('takumi')
+        logger.warn('No OG image renderer dependency detected. Defaulting to `takumi` (non-interactive environment). Install `@takumi-rs/core`, or add a renderer component (e.g. components/OgImage/Default.satori.vue) to choose explicitly.')
       }
     }
 
@@ -1076,9 +1080,16 @@ export default defineNuxtModule<ModuleOptions>({
             if (success) {
               availableRenderers.add(renderer)
             }
+            else if (isAgent) {
+              // agents can't recover from a half-installed renderer — fail loud and actionable
+              throw new Error(`[nuxt-og-image] Failed to install ${renderer} dependencies: ${missing.join(', ')}. Install manually: npx nypm add ${missing.join(' ')}`)
+            }
             else {
               logger.error(`Failed to install ${renderer} dependencies. Templates using this renderer won't work.`)
             }
+          }
+          else if (isAgent) {
+            throw new Error(`[nuxt-og-image] ${renderer} renderer missing dependencies: ${missing.join(', ')}. Install with: npx nypm add ${missing.join(' ')}`)
           }
           else {
             logger.error(`${renderer} renderer missing dependencies: ${missing.join(', ')}. Install with: npx nypm add ${missing.join(' ')}`)

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -10,6 +10,7 @@ import { promptFontsMigration } from './migrations/fonts'
 import { logger } from './runtime/logger'
 import { getRendererFromFilename, hasResolvableDependency } from './util'
 import {
+  canPromptInteractively,
   ensureProviderDependencies,
   getInstalledProviders,
   getMissingDependencies,
@@ -73,6 +74,13 @@ export async function onInstall(nuxt: Nuxt): Promise<void> {
         + 'See: https://nuxtseo.com/og-image/getting-started',
       )
     }
+    return
+  }
+
+  // non-interactive environment (AI agent or no TTY) — can't prompt, skip onboarding.
+  // module setup auto-detects installed providers and defaults to takumi.
+  if (!canPromptInteractively()) {
+    logger.info('Skipping interactive onboarding (non-interactive environment). Defaulting to the takumi renderer.')
     return
   }
 

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -203,7 +203,10 @@ export async function ensureProviderDependencies(
 }
 
 export interface InteractiveEnv {
+  /** stdout is a TTY (std-env `hasTTY`, derived from `process.stdout.isTTY`) */
   hasTTY: boolean
+  /** stdin is a TTY — prompts read from stdin, so a piped/redirected stdin can't answer */
+  hasStdinTTY: boolean
   isAgent: boolean
   isCI: boolean
 }
@@ -211,9 +214,19 @@ export interface InteractiveEnv {
 /**
  * Whether we can safely show an interactive prompt. AI agents and CI runners have no
  * TTY to answer a `consola.prompt`, so prompting there hangs or crashes the dev boot.
+ *
+ * Both stdout AND stdin must be TTYs: `std-env`'s `hasTTY` only reflects stdout, but a
+ * prompt reads from stdin, so a redirected/piped stdin (e.g. `nuxt dev < /dev/null`, or a
+ * parent spawning with `stdio: ['pipe', 'inherit', 'inherit']`) can never deliver an answer
+ * even when the terminal output looks interactive.
  */
-export function canPromptInteractively(env: InteractiveEnv = { hasTTY, isAgent, isCI }): boolean {
-  return env.hasTTY && !env.isAgent && !env.isCI
+export function canPromptInteractively(env: InteractiveEnv = {
+  hasTTY,
+  hasStdinTTY: Boolean(process.stdin?.isTTY),
+  isAgent,
+  isCI,
+}): boolean {
+  return env.hasTTY && env.hasStdinTTY && !env.isAgent && !env.isCI
 }
 
 export async function promptForRendererSelection(): Promise<ProviderName> {

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -1,6 +1,7 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { RuntimeCompatibilitySchema } from '../runtime/types'
 import { addDependency, detectPackageManager } from 'nypm'
+import { hasTTY, isAgent, isCI } from 'std-env'
 import { getPresetNitroPresetCompatibility, resolveOgImagePreset } from '../compatibility'
 import { logger } from '../runtime/logger'
 import { hasResolvableDependency } from '../util'
@@ -199,6 +200,20 @@ export async function ensureProviderDependencies(
   }
 
   return { success: true, installed }
+}
+
+export interface InteractiveEnv {
+  hasTTY: boolean
+  isAgent: boolean
+  isCI: boolean
+}
+
+/**
+ * Whether we can safely show an interactive prompt. AI agents and CI runners have no
+ * TTY to answer a `consola.prompt`, so prompting there hangs or crashes the dev boot.
+ */
+export function canPromptInteractively(env: InteractiveEnv = { hasTTY, isAgent, isCI }): boolean {
+  return env.hasTTY && !env.isAgent && !env.isCI
 }
 
 export async function promptForRendererSelection(): Promise<ProviderName> {

--- a/test/unit/interactive-env.test.ts
+++ b/test/unit/interactive-env.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { canPromptInteractively } from '../../src/utils/dependencies'
+
+describe('canPromptInteractively', () => {
+  it('prompts only in a real interactive terminal', () => {
+    expect(canPromptInteractively({ hasTTY: true, isAgent: false, isCI: false })).toBe(true)
+  })
+
+  it('does not prompt when there is no TTY', () => {
+    expect(canPromptInteractively({ hasTTY: false, isAgent: false, isCI: false })).toBe(false)
+  })
+
+  it('does not prompt when running as an AI agent', () => {
+    // even with a TTY, agents have no human to answer the prompt
+    expect(canPromptInteractively({ hasTTY: true, isAgent: true, isCI: false })).toBe(false)
+  })
+
+  it('does not prompt in CI', () => {
+    expect(canPromptInteractively({ hasTTY: true, isAgent: false, isCI: true })).toBe(false)
+  })
+})

--- a/test/unit/interactive-env.test.ts
+++ b/test/unit/interactive-env.test.ts
@@ -3,19 +3,24 @@ import { canPromptInteractively } from '../../src/utils/dependencies'
 
 describe('canPromptInteractively', () => {
   it('prompts only in a real interactive terminal', () => {
-    expect(canPromptInteractively({ hasTTY: true, isAgent: false, isCI: false })).toBe(true)
+    expect(canPromptInteractively({ hasTTY: true, hasStdinTTY: true, isAgent: false, isCI: false })).toBe(true)
   })
 
-  it('does not prompt when there is no TTY', () => {
-    expect(canPromptInteractively({ hasTTY: false, isAgent: false, isCI: false })).toBe(false)
+  it('does not prompt when stdout is not a TTY', () => {
+    expect(canPromptInteractively({ hasTTY: false, hasStdinTTY: true, isAgent: false, isCI: false })).toBe(false)
+  })
+
+  it('does not prompt when stdin is not a TTY', () => {
+    // e.g. `nuxt dev < /dev/null` or a piped stdin: output looks interactive but no answer can arrive
+    expect(canPromptInteractively({ hasTTY: true, hasStdinTTY: false, isAgent: false, isCI: false })).toBe(false)
   })
 
   it('does not prompt when running as an AI agent', () => {
     // even with a TTY, agents have no human to answer the prompt
-    expect(canPromptInteractively({ hasTTY: true, isAgent: true, isCI: false })).toBe(false)
+    expect(canPromptInteractively({ hasTTY: true, hasStdinTTY: true, isAgent: true, isCI: false })).toBe(false)
   })
 
   it('does not prompt in CI', () => {
-    expect(canPromptInteractively({ hasTTY: true, isAgent: false, isCI: true })).toBe(false)
+    expect(canPromptInteractively({ hasTTY: true, hasStdinTTY: true, isAgent: false, isCI: true })).toBe(false)
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When no renderer dependency is detected, `nuxi dev` shows a `consola` prompt asking which renderer to install. AI coding agents and CI runners have no TTY to answer it, so the dev boot hangs or crashes.

This gates the prompt behind a new `canPromptInteractively()` helper (`hasTTY && !isAgent && !isCI` from `std-env`). Non-interactive runs now default to the `takumi` renderer and emit a warning instead of prompting. When an AI agent hits a missing renderer dependency that can't be auto-installed, the module throws an actionable error (`npx nypm add @takumi-rs/core`) rather than silently producing broken images. `onInstall` onboarding reuses the same helper.

Added `test/unit/interactive-env.test.ts` covering the four env combinations, and a migration-guide note documenting the non-interactive behaviour.