### PR TITLE
fix: block embedded-IPv4 IPv6 bypasses 

### DIFF
--- a/src/runtime/server/util/ssrf.ts
+++ b/src/runtime/server/util/ssrf.ts
@@ -107,10 +107,32 @@ function isPrivateIPv6(groups: number[]): boolean {
     return isPrivateIPv4(a, b)
   }
 
+  // ::/96 IPv4-compatible (deprecated, RFC 4291) — embedded IPv4 in the last 32 bits.
+  // Covers ::127.0.0.1, ::169.254.169.254 (metadata) etc. that legacy stacks still route.
+  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0) {
+    const a = (g6 >> 8) & 0xFF
+    const b = g6 & 0xFF
+    return isPrivateIPv4(a, b)
+  }
+
+  // ::ffff:0:0/96 IPv4-translated (RFC 2765/6052) — embedded IPv4 in the last 32 bits
+  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0xFFFF && g5 === 0) {
+    const a = (g6 >> 8) & 0xFF
+    const b = g6 & 0xFF
+    return isPrivateIPv4(a, b)
+  }
+
   // 64:ff9b::/96 NAT64 well-known prefix — embedded IPv4
   if (g0 === 0x64 && g1 === 0xFF9B && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0) {
     const a = (g6 >> 8) & 0xFF
     const b = g6 & 0xFF
+    return isPrivateIPv4(a, b)
+  }
+
+  // 2002::/16 6to4 — embedded IPv4 in the next 32 bits
+  if (g0 === 0x2002) {
+    const a = (g1 >> 8) & 0xFF
+    const b = g1 & 0xFF
     return isPrivateIPv4(a, b)
   }
 

--- a/test/unit/ssrf.test.ts
+++ b/test/unit/ssrf.test.ts
@@ -130,6 +130,24 @@ describe('isBlockedUrl — GHSA-c2rm-g55x-8hr5 bypasses', () => {
     expect(isBlockedUrl('http://[64:ff9b::a00:1]/')).toBe(true) // embedded 10.0.0.1
   })
 
+  it('blocks 2002::/16 6to4 addresses with embedded private IPv4', () => {
+    expect(isBlockedUrl('http://[2002:7f00:0001::]/')).toBe(true) // embedded 127.0.0.1
+    expect(isBlockedUrl('http://[2002:a9fe:a9fe::]/')).toBe(true) // embedded 169.254.169.254
+    expect(isBlockedUrl('http://[2002:0a00:0001::]/')).toBe(true) // embedded 10.0.0.1
+  })
+
+  it('blocks ::/96 IPv4-compatible (deprecated) with embedded private IPv4', () => {
+    expect(isBlockedUrl('http://[::127.0.0.1]/')).toBe(true) // loopback
+    expect(isBlockedUrl('http://[::7f00:1]/')).toBe(true) // loopback, hex form
+    expect(isBlockedUrl('http://[::a9fe:a9fe]/')).toBe(true) // 169.254.169.254 metadata
+    expect(isBlockedUrl('http://[::0a00:1]/')).toBe(true) // 10.0.0.1
+  })
+
+  it('blocks ::ffff:0:0/96 IPv4-translated with embedded private IPv4', () => {
+    expect(isBlockedUrl('http://[::ffff:0:127.0.0.1]/')).toBe(true) // 127.0.0.1
+    expect(isBlockedUrl('http://[::ffff:0:a9fe:a9fe]/')).toBe(true) // 169.254.169.254
+  })
+
   it('blocks 2001:db8::/32 documentation', () => {
     expect(isBlockedUrl('http://[2001:db8::1]/')).toBe(true)
   })
@@ -153,5 +171,13 @@ describe('isBlockedUrl — public addresses pass through', () => {
 
   it('allows 64:ff9b::/96 with public embedded IPv4', () => {
     expect(isBlockedUrl('http://[64:ff9b::8.8.8.8]/')).toBe(false)
+  })
+
+  it('allows 2002::/16 6to4 addresses with embedded public IPv4', () => {
+    expect(isBlockedUrl('http://[2002:0808:0808::]/')).toBe(false) // embedded 8.8.8.8
+  })
+
+  it('allows ::/96 IPv4-compatible with embedded public IPv4', () => {
+    expect(isBlockedUrl('http://[::8.8.8.8]/')).toBe(false) // embedded 8.8.8.8
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #621 (GHSA-65xc-mg8p-36rf, incomplete fix of CVE-2026-44589).

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`isPrivateIPv6` decoded embedded IPv4 for the `::ffff:` (IPv4-mapped) and `64:ff9b::` (NAT64) forms but not for three other standard forms that also carry an IPv4 address. Addresses like `[2002:a9fe:a9fe::]` (6to4 → 169.254.169.254 metadata), `[::127.0.0.1]`, and `[::169.254.169.254]` therefore passed the SSRF filter and could reach localhost / internal / cloud-metadata targets.

Each of these now recovers the embedded IPv4 and re-classifies via `isPrivateIPv4`, mirroring the existing branches:

- `2002::/16` — 6to4 (RFC 3056)
- `::/96` — IPv4-compatible (deprecated, RFC 4291)
- `::ffff:0:0/96` — IPv4-translated (RFC 2765/6052)

Decode-and-classify is deliberate: it blocks every private-embedded address (the actual SSRF vectors) while leaving public targets and legitimate global-unicast space (`2001::`, `2003::`, …) untouched. A blanket `2002::/16` block, or the advisory's suggested `(g0 & 0xFF00) === 0x2000`, would over-block — the latter actually matches all of `2000::/8`.

The duplicate `fec0::/10` check the advisory cites only exists in a stale `dist` build; current source already has the correct `fe80::/10` + `fec0::/10` pair.

Covered by 6 new cases in `test/unit/ssrf.test.ts` (private forms blocked, public 6to4 / IPv4-compatible still allowed). Full suite: 34 passing.