### PR TITLE
fix(content): declare zod as optional peer dependency (#622)

### DIFF
--- a/docs/content/4.integrations/1.content.md
+++ b/docs/content/4.integrations/1.content.md
@@ -13,8 +13,6 @@ You can see a demo of this integration in the [Nuxt OG Image & Nuxt Content Play
 
 Add `defineOgImageSchema()`{lang="ts"} to your collection's schema to enable the `ogImage` frontmatter key.
 
-Pass your own `z` instance with `defineOgImageSchema({ z })`{lang="ts"}. Nuxt Content infers collection types from the schema you provide, so the `ogImage` field must be built with the same [Zod](https://zod.dev) version your project uses. Omitting `z` falls back to the module's bundled Zod, which can differ and drop `ogImage` from the generated `ContentCollectionItem` type.
-
 ```ts [content.config.ts]
 import { defineCollection, defineContentConfig } from '@nuxt/content'
 import { defineOgImageSchema } from 'nuxt-og-image/content'
@@ -26,12 +24,16 @@ export default defineContentConfig({
       type: 'page',
       source: '**/*.md',
       schema: z.object({
-        ogImage: defineOgImageSchema({ z }),
+        ogImage: defineOgImageSchema(),
       }),
     }),
   },
 })
 ```
+
+::note
+Nuxt Content infers collection types from the schema you provide, so the `ogImage` field needs the same [Zod](https://zod.dev) instance your project uses. The module resolves Zod from your project (it's an optional peer dependency), so this works automatically. If you have multiple Zod versions installed and `ogImage` is missing from the generated `ContentCollectionItem` type, pass your instance explicitly with `defineOgImageSchema({ z })`{lang="ts"}.
+::
 
 To ensure the tags gets rendered you need to ensure you're using the `defineOgImage()`{lang="ts"} composable with the `ogImage` key.
 

--- a/docs/content/4.integrations/1.content.md
+++ b/docs/content/4.integrations/1.content.md
@@ -13,6 +13,8 @@ You can see a demo of this integration in the [Nuxt OG Image & Nuxt Content Play
 
 Add `defineOgImageSchema()`{lang="ts"} to your collection's schema to enable the `ogImage` frontmatter key.
 
+Pass your own `z` instance with `defineOgImageSchema({ z })`{lang="ts"}. Nuxt Content infers collection types from the schema you provide, so the `ogImage` field must be built with the same [Zod](https://zod.dev) version your project uses. Omitting `z` falls back to the module's bundled Zod, which can differ and drop `ogImage` from the generated `ContentCollectionItem` type.
+
 ```ts [content.config.ts]
 import { defineCollection, defineContentConfig } from '@nuxt/content'
 import { defineOgImageSchema } from 'nuxt-og-image/content'
@@ -24,7 +26,7 @@ export default defineContentConfig({
       type: 'page',
       source: '**/*.md',
       schema: z.object({
-        ogImage: defineOgImageSchema(),
+        ogImage: defineOgImageSchema({ z }),
       }),
     }),
   },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "sharp": "^0.34.0",
     "tailwindcss": "^4.0.0",
     "unifont": "^0.7.0",
-    "unstorage": "^1.15.0"
+    "unstorage": "^1.15.0",
+    "zod": ">=3"
   },
   "peerDependenciesMeta": {
     "@resvg/resvg-js": {
@@ -114,6 +115,9 @@
       "optional": true
     },
     "unifont": {
+      "optional": true
+    },
+    "zod": {
       "optional": true
     }
   },
@@ -149,8 +153,7 @@
     "tinyglobby": "catalog:",
     "ufo": "catalog:",
     "ultrahtml": "catalog:",
-    "unplugin": "catalog:",
-    "zod": "catalog:"
+    "unplugin": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -219,6 +222,7 @@
     "vue": "catalog:",
     "vue-tsc": "catalog:",
     "wrangler": "catalog:",
-    "yoga-wasm-web": "catalog:"
+    "yoga-wasm-web": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/playground/content.config.ts
+++ b/playground/content.config.ts
@@ -9,7 +9,7 @@ export default defineContentConfig({
       source: '**/*.md',
       schema: z.object({
         date: z.string().optional(),
-        ogImage: defineOgImageSchema(),
+        ogImage: defineOgImageSchema({ z }),
       }),
     }),
   },

--- a/playground/content.config.ts
+++ b/playground/content.config.ts
@@ -9,7 +9,7 @@ export default defineContentConfig({
       source: '**/*.md',
       schema: z.object({
         date: z.string().optional(),
-        ogImage: defineOgImageSchema({ z }),
+        ogImage: defineOgImageSchema(),
       }),
     }),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,9 +432,6 @@ importers:
       unstorage:
         specifier: ^1.15.0
         version: 1.17.5(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)
-      zod:
-        specifier: 'catalog:'
-        version: 4.4.3
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -634,6 +631,9 @@ importers:
       yoga-wasm-web:
         specifier: 'catalog:'
         version: 0.3.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
 
   devtools:
     devDependencies:


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #622

### ❓ Type of change

- [x] 🐞 Bug fix
- [x] 📖 Documentation

### 📚 Description

`Property 'ogImage' does not exist on type 'ContentCollectionItem'` (regressed in v6.5.1).

**Root cause:** zod was a hard `dependency` pinned to v4, but it's only used by the Content integration (`src/content.ts`). That forced og-image's own zod 4 copy into the user's tree even when `@nuxt/content` resolved zod 3. Content builds each collection's TS type from the schema object (zod → JSON Schema via `zodToJsonSchema` → interface via `json-schema-to-typescript-lite`), and that converter only understands one zod version's internals. A foreign-instance `ogImage` sub-schema fails to convert, so the field drops off the generated `ContentCollectionItem`.

**Fix:** move zod to an optional `peerDependency` (`>=3`), matching the rest of the SEO ecosystem (`@nuxtjs/sitemap`, `@nuxtjs/robots`, `nuxt-schema-org` all do this). og-image now resolves the project's single zod instance, so `defineOgImageSchema()` works by default with no extra config. Kept in `devDependencies` for the repo's own build.

Docs reframed to show the default usage, with `defineOgImageSchema({ z })` documented as a fallback for projects that have multiple zod versions installed.

**Note for the reporter:** the typed access path is `queryCollection('content').path(...).first()` (per-collection types). `useContent()` returns the broad cross-collection base type and may still not surface `ogImage`.