### PR TITLE
fix: skip runtime buffer cache during prerender (#613)

### DIFF
--- a/src/runtime/server/util/cache.ts
+++ b/src/runtime/server/util/cache.ts
@@ -45,7 +45,11 @@ export async function useOgImageBufferCache(ctx: OgImageRenderEventContext, opti
   secret?: string
 }): Promise<void | H3Error | { cachedItem: false | BufferSource, enabled: boolean, update: (image: BufferSource | Buffer | Uint8Array) => Promise<void> }> {
   const maxAge = Number(options.cacheMaxAgeSeconds)
-  const intentionallyEnabled = !import.meta.dev && maxAge > 0
+  // Skip the runtime buffer cache during prerender. The output is written to a static
+  // file served via the `/_og/s/**` route rule (which sets its own immutable caching),
+  // and the configured backend may not exist in the Node build environment — e.g. a
+  // Cloudflare KV binding is only bound at runtime in the Worker, not during prerender (#613).
+  const intentionallyEnabled = !import.meta.dev && !import.meta.prerender && maxAge > 0
   let enabled = intentionallyEnabled
   const cache = prefixStorage(useStorage(), withTrailingSlash(options.baseCacheKey || '/'))
   const key = ctx.key
@@ -111,8 +115,9 @@ export async function useOgImageBufferCache(ctx: OgImageRenderEventContext, opti
       }
     }
   }
-  if (!enabled) {
-    // add http headers so the file isn't cached
+  if (!enabled && !import.meta.prerender) {
+    // add http headers so the file isn't cached — but not during prerender, where the
+    // static output is meant to be cached and its headers come from the route rule.
     setHeader(ctx.e, 'Cache-Control', 'no-cache, no-store, must-revalidate')
     setHeader(ctx.e, 'Pragma', 'no-cache')
     setHeader(ctx.e, 'Expires', '0')


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #619 / #613.

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

#619 made the cache degrade gracefully when the backend is unreachable, which stops the build from failing. This is the cleaner companion fix: don't use the runtime buffer cache during prerender at all.

The `Invalid binding KV: undefined` in #613 fires during **prerender** because the buffer cache reaches for the configured backend, but a Cloudflare KV binding only exists at runtime in the Worker, not in the Node build environment doing the prerender. Beyond Cloudflare, this is correct for every preset: prerendered images are written to static files served by the `/_og/s/**` route rule (`immutable, max-age=1yr`), so the runtime buffer cache is irrelevant to serving them.

- Exclude `import.meta.prerender` from `intentionallyEnabled`, so prerender never touches the runtime cache backend.
- Skip the `no-store` header block during prerender, so the static output keeps the route rule's long-cache policy instead of being marked uncacheable.

This got left out of #619 when it merged (PR head-ref lag merged the prior commit), hence the standalone PR. With this, the reporter's `runtimeCacheStorage: false` workaround is no longer needed.