### PR TITLE
fix: use sfc parser to find outer `<template>` bounds

### DIFF
--- a/src/build/vite-asset-transform.ts
+++ b/src/build/vite-asset-transform.ts
@@ -23,7 +23,6 @@ const RE_SVG_ID_ATTR = /\bid="([^"]+)"/g
 const RE_SVG_VIEWBOX = /viewBox="([^"]*)"/
 const RE_SVG_BODY = /<svg[^>]*>([\s\S]*)<\/svg>/
 const RE_OG_IMAGE_QUERY = /\?og-image(?:-depth=\d+)?$/
-const RE_TEMPLATE_CONTENT = /<template>([\s\S]*?)<\/template>/
 const RE_TEXT_BETWEEN_TAGS = />([^<]*)</g
 const RE_SPECIAL_REGEX_CHARS = /[.*+?^${}()|[\]\\]/g
 const RE_WRAPPER_DIV_START = /^<div>/
@@ -276,6 +275,30 @@ export interface AssetTransformOptions {
   onNestedTransform?: (filePath: string) => void
 }
 
+/**
+ * Locate the outer `<template>` block's content offsets in an SFC source.
+ * `templateStart` points just after the opening tag (including any attributes);
+ * `templateEnd` points at the `<` of the closing `</template>`. Uses the SFC
+ * parser so nested `<template v-if>` / `<template #slot>` tags don't fool the
+ * match.
+ */
+function getOuterTemplateBounds(code: string): { templateStart: number, templateEnd: number } | undefined {
+  let descriptor
+  try {
+    descriptor = parseSfc(code).descriptor
+  }
+  catch {
+    return undefined
+  }
+  const template = descriptor.template
+  if (!template)
+    return undefined
+  return {
+    templateStart: template.loc.start.offset,
+    templateEnd: template.loc.end.offset,
+  }
+}
+
 export const AssetTransformPlugin = createUnplugin((options: AssetTransformOptions) => {
   let emojiIcons: IconifyJSON | null = null
 
@@ -302,13 +325,12 @@ export const AssetTransformPlugin = createUnplugin((options: AssetTransformOptio
       if (rawId.includes('?og-image'))
         options.onNestedTransform?.(id)
 
-      const templateMatch = code.match(RE_TEMPLATE_CONTENT)
-      if (!templateMatch)
+      const bounds = getOuterTemplateBounds(code)
+      if (!bounds)
         return
 
       const s = new MagicString(code)
-      const templateStart = code.indexOf('<template>') + '<template>'.length
-      const templateEnd = code.indexOf('</template>')
+      const { templateStart, templateEnd } = bounds
       let template = code.slice(templateStart, templateEnd)
       let hasChanges = false
 
@@ -549,11 +571,11 @@ export const AssetTransformPlugin = createUnplugin((options: AssetTransformOptio
           })
 
           if (result) {
-            // Extract the transformed template
-            const newTemplateStart = result.code.indexOf('<template>') + '<template>'.length
-            const newTemplateEnd = result.code.indexOf('</template>')
-            template = result.code.slice(newTemplateStart, newTemplateEnd)
-            hasChanges = true
+            const newBounds = getOuterTemplateBounds(result.code)
+            if (newBounds) {
+              template = result.code.slice(newBounds.templateStart, newBounds.templateEnd)
+              hasChanges = true
+            }
           }
         }
         catch (err) {

--- a/test/unit/vite-asset-transform.test.ts
+++ b/test/unit/vite-asset-transform.test.ts
@@ -206,6 +206,77 @@ const msg = '👋'
     })
   })
 
+  describe('outer template bounds', () => {
+    const plugin = AssetTransformPlugin.raw({
+      ogComponentPaths,
+      rootDir: '/test',
+      srcDir: '/test',
+      publicDir: '/test/public',
+    }, { framework: 'vite' })
+
+    it('should preserve siblings after nested <template #slot> when transforming', async () => {
+      const code = `<template>
+  <div>
+    <Item v-for="x in items" :key="x">
+      <template #caption>caption-{{ x }}</template>
+    </Item>
+    <Icon name="tabler:star" />
+    <footer>sibling</footer>
+  </div>
+</template>`
+
+      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      expect(result).toBeDefined()
+      expect(result?.code).toContain('caption-{{ x }}')
+      expect(result?.code).toContain('<footer>sibling</footer>')
+      expect(result?.code).toContain('<svg')
+      expect(result?.code.endsWith('</template>')).toBe(true)
+      const nestedClose = (result!.code.match(/<\/template>/g) || []).length
+      expect(nestedClose).toBe(2)
+    })
+
+    it('should preserve siblings after nested <template v-if> when transforming', async () => {
+      const code = `<template>
+  <div>
+    <template v-if="showA">
+      <span>A</span>
+    </template>
+    <template v-else>
+      <span>B</span>
+    </template>
+    <Icon name="tabler:star" />
+    <footer>sibling</footer>
+  </div>
+</template>`
+
+      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      expect(result).toBeDefined()
+      expect(result?.code).toContain('<span>A</span>')
+      expect(result?.code).toContain('<span>B</span>')
+      expect(result?.code).toContain('<footer>sibling</footer>')
+      expect(result?.code).toContain('<svg')
+      expect(result?.code.endsWith('</template>')).toBe(true)
+      const nestedClose = (result!.code.match(/<\/template>/g) || []).length
+      expect(nestedClose).toBe(3)
+    })
+
+    it('should ignore <template lang="..."> attrs on the outer tag', async () => {
+      const code = `<template lang="html">
+  <div>
+    <Icon name="tabler:star" />
+    <footer>sibling</footer>
+  </div>
+</template>`
+
+      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      expect(result).toBeDefined()
+      expect(result?.code).toContain('<template lang="html">')
+      expect(result?.code).toContain('<footer>sibling</footer>')
+      expect(result?.code).toContain('<svg')
+      expect(result?.code.endsWith('</template>')).toBe(true)
+    })
+  })
+
   describe('image transform', () => {
     const plugin = AssetTransformPlugin.raw({
       ogComponentPaths,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

previous regexp would key off inline `<template v-if>` etc. within a component. (hit this when upgrading from v5 -> v6)

using parseSfc seems safer