### PR TITLE
fix: escape `"` when inlining `<style>` rules into `style` attr

### DIFF
--- a/src/build/css/css-utils.ts
+++ b/src/build/css/css-utils.ts
@@ -931,9 +931,10 @@ export async function postProcessStyles(
     }
 
     // Simplify font-family: extract the first custom family name, unwrapped.
-    // OG renderers don't do font fallback — generic families (monospace, sans-serif)
-    // are noise. Also avoids &quot; encoding in HTML style attributes which breaks
-    // parsing when htmlDecodeQuotes() decodes them back to literal " at runtime.
+    // OG renderers don't do font fallback so generic families (monospace,
+    // sans-serif) are noise. Multi-word names are wrapped in single quotes
+    // because double-quoted family names would round-trip through &quot; in
+    // the inline style attribute.
     if (prop === 'font-family') {
       const custom = extractCustomFontFamilies(value)
       if (custom.length) {

--- a/src/build/vite-asset-transform.ts
+++ b/src/build/vite-asset-transform.ts
@@ -15,7 +15,7 @@ import { RE_WHITESPACE } from '../util'
 import { extractFontRequirementsFromVue } from './css/css-classes'
 import { stylesToArbitraryClass } from './css/css-provider'
 import { downlevelColor, extractClassStyles, resolveCssVars, simplifyCss } from './css/css-utils'
-import { transformVueTemplate } from './vue-template-transform'
+import { escapeAttrValue, transformVueTemplate } from './vue-template-transform'
 
 let svgCounter = 0
 
@@ -36,7 +36,6 @@ const RE_DATA_ATTR = /\bdata-([\w-]+)="([^"]*)"/g
 const RE_DYNAMIC_DATA_THEME = /\s:data-theme="[^"]+"/
 const RE_COLOR_ATTR_NAME = /^(?:color|fill|stroke|flood-color|lighting-color|stop-color)$/
 const RE_NON_STYLE_VAR_ATTR = /\b(?!style|class)([a-zA-Z-]+)="([^"]*var\(--[^"]+)"/g
-const RE_QUOTED_ATTR = /^([a-z-]+)="(.*)"$/i
 const RE_COLOR_PROP_NAME = /color|fill|stroke|background|border|outline|shadow|accent|caret/
 const RE_STYLE_VAR_ATTR = /\bstyle="([^"]*var\(--[^"]+)"/g
 const RE_INLINE_STYLE = /\bstyle="([^"]*)"/g
@@ -101,13 +100,13 @@ function buildIconSvg(iconData: { body: string, width?: number, height?: number 
       existingStyle = value
       continue
     }
-    filteredAttrs.push(`${key}="${value}"`)
+    filteredAttrs.push(`${key}="${escapeAttrValue(value)}"`)
   }
   const attrsStr = filteredAttrs.length > 0 ? ` ${filteredAttrs.join(' ')}` : ''
 
   // Keep width/height="100%" — resolved to parent pixel dims by satori svg-size plugin at runtime
   const mergedStyle = existingStyle ? `display:flex; ${existingStyle}` : 'display:flex'
-  let svg = `<span${attrsStr} style="${mergedStyle}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="100%" height="100%" fill="currentColor">${body}</svg></span>`
+  let svg = `<span${attrsStr} style="${escapeAttrValue(mergedStyle)}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="100%" height="100%" fill="currentColor">${body}</svg></span>`
   svg = makeIdsUnique(svg)
   return svg
 }
@@ -648,40 +647,42 @@ export const AssetTransformPlugin = createUnplugin((options: AssetTransformOptio
         }
 
         if (vars.size > 0) {
-          // Non-style, non-class attributes (e.g., SVG fill="var(--bg)")
-          const replacements: Array<{ from: string, to: string }> = []
+          // Non-style, non-class attributes (e.g., SVG fill="var(--bg)").
+          // Track resolved values unescaped so downlevelColor can parse them; escape
+          // for HTML only at the final write.
+          const replacements: Array<{ from: string, to: string, attr: string, value: string }> = []
           RE_NON_STYLE_VAR_ATTR.lastIndex = 0
           template.replace(RE_NON_STYLE_VAR_ATTR, (match, attr, value) => {
             const resolved = resolveCssVars(value, vars)
             if (resolved !== value) {
-              replacements.push({ from: match, to: `${attr}="${resolved}"` })
+              replacements.push({ from: match, to: '', attr, value: resolved })
             }
             return match
           })
           // Downlevel modern colors (oklch, etc.) in color-related attributes
           for (const r of replacements) {
-            const attrMatch = r.to.match(RE_QUOTED_ATTR)
-            if (attrMatch?.[1] && attrMatch[2] !== undefined && RE_COLOR_ATTR_NAME.test(attrMatch[1])) {
-              const downleveled = await downlevelColor(attrMatch[1], attrMatch[2])
-              r.to = `${attrMatch[1]}="${downleveled}"`
+            let value = r.value
+            if (RE_COLOR_ATTR_NAME.test(r.attr)) {
+              value = await downlevelColor(r.attr, value)
             }
+            r.to = `${r.attr}="${escapeAttrValue(value)}"`
             template = template.replace(r.from, r.to)
             hasChanges = true
           }
 
-          // Inline style attributes: resolve var() and downlevel colors per-declaration
-          const styleReplacements: Array<{ from: string, to: string }> = []
+          // Inline style attributes: resolve var() and downlevel colors per-declaration.
+          // Hold resolved style content unescaped so downlevelColor / resolveColorMix can
+          // parse it; escape for HTML only when writing the attribute.
+          const styleReplacements: Array<{ from: string, content: string }> = []
           RE_STYLE_VAR_ATTR.lastIndex = 0
           template.replace(RE_STYLE_VAR_ATTR, (match, styleValue) => {
             const resolved = resolveCssVars(styleValue, vars)
             if (resolved !== styleValue)
-              styleReplacements.push({ from: match, to: `style="${resolved}"` })
+              styleReplacements.push({ from: match, content: resolved })
             return match
           })
           for (const r of styleReplacements) {
-            // Downlevel modern colors in each declaration
-            const styleContent = r.to.slice('style="'.length, -1)
-            const declarations = styleContent.split(';').filter(Boolean)
+            const declarations = r.content.split(';').filter(Boolean)
             const downleveled: string[] = []
             for (const decl of declarations) {
               const colonIdx = decl.indexOf(':')
@@ -698,8 +699,8 @@ export const AssetTransformPlugin = createUnplugin((options: AssetTransformOptio
               }
               downleveled.push(`${prop}: ${value}`)
             }
-            r.to = `style="${downleveled.join('; ')}"`
-            template = template.replace(r.from, r.to)
+            const to = `style="${escapeAttrValue(downleveled.join('; '))}"`
+            template = template.replace(r.from, to)
             hasChanges = true
           }
 
@@ -832,9 +833,14 @@ export const AssetTransformPlugin = createUnplugin((options: AssetTransformOptio
                 }
 
                 const merged = { ...matchedStyles, ...existingProps }
-                el.attributes.style = Object.entries(merged)
-                  .map(([p, v]) => `${p}:${v}`)
-                  .join(';')
+                // ultrahtml's serializer does not escape attribute values, so any literal
+                // `"` in a CSS value (e.g. `background-image: url("data:...")`) would close
+                // the `style="..."` attribute early and produce invalid HTML.
+                el.attributes.style = escapeAttrValue(
+                  Object.entries(merged)
+                    .map(([p, v]) => `${p}:${v}`)
+                    .join(';'),
+                )
 
                 // Remove consumed classes
                 const remaining = elClasses.filter(c => !consumedClasses.has(c))

--- a/src/build/vue-template-transform.ts
+++ b/src/build/vue-template-transform.ts
@@ -157,7 +157,7 @@ function parseStyleEntry(entry: string): [string, string] | undefined {
 }
 
 // Escape quotes for HTML attribute values
-function escapeAttrValue(value: string): string {
+export function escapeAttrValue(value: string): string {
   return value.replace(RE_DOUBLE_QUOTE, '&quot;')
 }
 

--- a/src/runtime/server/og-image/core/style-attr.ts
+++ b/src/runtime/server/og-image/core/style-attr.ts
@@ -1,0 +1,58 @@
+import { splitCssDeclarations } from '../utils/css'
+
+const RE_KEBAB_SEGMENT = /-([a-z])/g
+const RE_CSS_QUOTES = /^['"](.+)['"]$/
+const RE_IMPORTANT = /\s*!important\s*$/
+
+// Single-pass decode of the HTML entities that survive the ultrahtml
+// attribute-value parser. Matching all entities in one regex avoids the
+// double-unescape pitfall where `&amp;quot;` (a literal `&quot;`) would
+// otherwise become `"` after sequential `&amp;` -> `&` then `&quot;` -> `"`.
+const RE_HTML_ENTITY = /&(?:amp|quot|#39|#x27);/g
+const HTML_ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&',
+  '&quot;': '"',
+  '&#39;': '\'',
+  '&#x27;': '\'',
+}
+
+function camelCase(str: string): string {
+  return str.replace(RE_KEBAB_SEGMENT, (_, c) => c.toUpperCase())
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(RE_HTML_ENTITY, m => HTML_ENTITY_MAP[m] ?? m)
+}
+
+/**
+ * Parse an inline `style="..."` attribute value into a camelCase property map
+ * suitable for handing to Satori / Takumi.
+ *
+ * Kept in a leaf module (no nitro / h3 imports) so it can be unit-tested
+ * directly without pulling the full runtime bundle.
+ */
+export function parseStyleAttr(style: string | null | undefined): Record<string, any> | undefined {
+  if (!style)
+    return undefined
+  const result: Record<string, any> = {}
+  // Decode `&amp;`, `&quot;`, `&#39;`, `&#x27;` so quoted CSS strings
+  // (e.g. `url("data:...")`, `font-family: 'Inter'`) and `&`-containing URLs
+  // reach the renderer in their decoded form.
+  for (const decl of splitCssDeclarations(decodeHtmlEntities(style))) {
+    const colonIdx = decl.indexOf(':')
+    if (colonIdx === -1)
+      continue
+    const prop = decl.slice(0, colonIdx).trim()
+    const val = decl.slice(colonIdx + 1).trim()
+    if (prop && val) {
+      // Strip !important; Satori/Takumi don't support CSS specificity.
+      // Strip CSS quotes from font-family; Satori matches font names as plain
+      // strings (e.g. `JetBrains Mono`), not CSS-quoted values (`'JetBrains Mono'`).
+      const cleanVal = val.replace(RE_IMPORTANT, '')
+      result[camelCase(prop)] = prop === 'font-family'
+        ? cleanVal.replace(RE_CSS_QUOTES, '$1')
+        : cleanVal
+    }
+  }
+  return Object.keys(result).length ? result : undefined
+}

--- a/src/runtime/server/og-image/core/vnodes.ts
+++ b/src/runtime/server/og-image/core/vnodes.ts
@@ -2,25 +2,19 @@ import type { ElementNode, TextNode } from 'ultrahtml'
 import type { OgImageRenderEventContext, VNode } from '../../../types'
 import { ELEMENT_NODE, parse, TEXT_NODE } from 'ultrahtml'
 import { querySelector } from 'ultrahtml/selector'
-import { decodeHtml, htmlDecodeQuotes } from '../../util/encoding'
+import { decodeHtml } from '../../util/encoding'
 import { fetchIsland } from '../../util/kit'
 import { logger } from '../../util/logger'
-import { splitCssDeclarations } from '../utils/css'
 import { walkTree } from './plugins'
 import encoding from './plugins/encoding'
 import imageSrc from './plugins/imageSrc'
 import styleDirectives from './plugins/styleDirectives'
+import { parseStyleAttr } from './style-attr'
 import { applyEmojis } from './transforms/emojis'
 
-const RE_KEBAB_SEGMENT = /-([a-z])/g
-const RE_AMP_ENTITY = /&amp;/g
-const RE_CSS_QUOTES = /^['"](.+)['"]$/
-const RE_IMPORTANT = /\s*!important\s*$/
-const RE_BODY_CONTENT = /<body>([\s\S]*)<\/body>/
+export { parseStyleAttr }
 
-function camelCase(str: string): string {
-  return str.replace(RE_KEBAB_SEGMENT, (_, c) => c.toUpperCase())
-}
+const RE_BODY_CONTENT = /<body>([\s\S]*)<\/body>/
 
 // SVG attributes that must preserve their camelCase form.
 // HTML parsers lowercase all attributes, but SVG is case-sensitive.
@@ -121,31 +115,6 @@ export function resolveSvgDimension(
   }
 }
 
-export function parseStyleAttr(style: string | null | undefined): Record<string, any> | undefined {
-  if (!style)
-    return undefined
-  const result: Record<string, any> = {}
-  // Decode &amp; before splitting — the `;` in `&amp;` would otherwise act as
-  // a CSS declaration separator and truncate values containing `&` (e.g. URLs).
-  for (const decl of splitCssDeclarations(style.replace(RE_AMP_ENTITY, '&'))) {
-    const colonIdx = decl.indexOf(':')
-    if (colonIdx === -1)
-      continue
-    const prop = decl.slice(0, colonIdx).trim()
-    const val = decl.slice(colonIdx + 1).trim()
-    if (prop && val) {
-      // Strip !important — Satori/Takumi don't support CSS specificity
-      // Strip CSS quotes from font-family — Satori matches font names as plain
-      // strings (e.g. "JetBrains Mono"), not CSS-quoted values ("'JetBrains Mono'")
-      const cleanVal = val.replace(RE_IMPORTANT, '')
-      result[camelCase(prop)] = prop === 'font-family'
-        ? cleanVal.replace(RE_CSS_QUOTES, '$1')
-        : cleanVal
-    }
-  }
-  return Object.keys(result).length ? result : undefined
-}
-
 export function elementToVNode(el: ElementNode): VNode {
   const props: VNode['props'] = {}
 
@@ -231,9 +200,6 @@ export async function createVNodes(ctx: OgImageRenderEventContext, options?: Cre
   if (!html) {
     const islandTimeout = ctx.runtimeConfig.security?.renderTimeout ?? 15_000
     const island = await ctx.timings.measure('island-fetch', () => fetchIsland(ctx.e, ctx.options.component!, typeof ctx.options.props !== 'undefined' ? ctx.options.props as Record<string, any> : ctx.options, islandTimeout))
-    // this fixes any inline style props that need to be wrapped in single quotes, such as:
-    // background image, fonts, etc
-    island.html = htmlDecodeQuotes(island.html)
     // pre-transform HTML - apply emoji replacements
     await applyEmojis(ctx, island)
     html = island.html

--- a/test/unit/style-ampersand.test.ts
+++ b/test/unit/style-ampersand.test.ts
@@ -1,31 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { parseStyleAttr } from '../../src/runtime/server/og-image/core/style-attr'
 import { splitCssDeclarations } from '../../src/runtime/server/og-image/utils/css'
-
-function camelCase(str: string): string {
-  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
-}
-
-/**
- * Mirrors parseStyleAttr from src/runtime/server/og-image/core/vnodes.ts
- */
-function parseStyleAttr(style: string | null | undefined): Record<string, any> | undefined {
-  if (!style)
-    return undefined
-  const result: Record<string, any> = {}
-  for (const decl of splitCssDeclarations(style.replace(/&amp;/g, '&'))) {
-    const colonIdx = decl.indexOf(':')
-    if (colonIdx === -1)
-      continue
-    const prop = decl.slice(0, colonIdx).trim()
-    const val = decl.slice(colonIdx + 1).trim()
-    if (prop && val) {
-      result[camelCase(prop)] = prop === 'font-family'
-        ? val.replace(/^['"](.+)['"]$/, '$1')
-        : val
-    }
-  }
-  return Object.keys(result).length ? result : undefined
-}
 
 describe('parseStyleAttr &amp; decoding', () => {
   it('decodes &amp; in URL values', () => {
@@ -48,6 +23,35 @@ describe('parseStyleAttr &amp; decoding', () => {
     expect(result?.display).toBe('flex')
     expect(result?.backgroundImage).toBe('url(https://example.com?w=1200&q=80)')
     expect(result?.color).toBe('red')
+  })
+
+  it('decodes &quot; inside url() so the renderer sees real quotes', () => {
+    const style = 'background-image: url(&quot;data:image/svg+xml,%3Csvg/%3E&quot;)'
+    expect(parseStyleAttr(style)?.backgroundImage)
+      .toBe('url("data:image/svg+xml,%3Csvg/%3E")')
+  })
+
+  it('decodes &#39; (single-quote entity) inside CSS values', () => {
+    const style = 'font-family: &#39;Inter&#39;'
+    expect(parseStyleAttr(style)?.fontFamily).toBe('Inter')
+  })
+
+  it('does not split declarations on a ; inside a &quot;-quoted url()', () => {
+    const style = `background-image: url(&quot;data:image/svg+xml;utf8,%3Csvg/%3E&quot;); color: red`
+    const result = parseStyleAttr(style)
+    expect(result?.backgroundImage).toBe('url("data:image/svg+xml;utf8,%3Csvg/%3E")')
+    expect(result?.color).toBe('red')
+  })
+
+  it('does not double-unescape `&amp;quot;` into a real `"`', () => {
+    // Single-pass entity decode: `&amp;` and `&quot;` are matched in one regex
+    // so the literal `&` from `&amp;` cannot combine with following `quot;` to
+    // form a spurious `&quot;` match. This is the CodeQL `js/double-escaping`
+    // shape, even though realistic Vue SSR output never produces `&amp;quot;`.
+    const decoded = parseStyleAttr('color: red &amp;quot;')
+    // The decoded payload starts with the literal `&` we wanted, not `"`.
+    expect(decoded?.color).toMatch(/^red &/)
+    expect(decoded?.color).not.toMatch(/^red "/)
   })
 })
 

--- a/test/unit/vite-asset-transform.test.ts
+++ b/test/unit/vite-asset-transform.test.ts
@@ -306,4 +306,61 @@ const msg = '👋'
       expect(base64Count).toBe(2)
     })
   })
+
+  describe('<style> block inlining', () => {
+    const plugin = AssetTransformPlugin.raw({
+      ogComponentPaths,
+      rootDir: '/test',
+      srcDir: '/test',
+      publicDir: '/test/public',
+    }, { framework: 'vite' })
+
+    it('should escape inner double-quotes when inlining CSS values into style="..."', async () => {
+      const code = `<template>
+  <div class="bg-confetti" />
+</template>
+
+<style scoped>
+.bg-confetti {
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='10'%3E%3Crect width='5' height='5'/%3E%3C/svg%3E");
+}
+</style>`
+
+      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      expect(result).toBeDefined()
+      const out = result!.code
+
+      const styleAttrMatch = out.match(/style="([^"]*)"/)
+      expect(styleAttrMatch, 'expected a style="..." attribute in the inlined output').not.toBeNull()
+      expect(styleAttrMatch![1]).toContain('background-image')
+      expect(styleAttrMatch![1]).toContain('&quot;data:image/svg+xml')
+      expect(out).not.toContain('url("data:image/svg+xml')
+      expect(out).not.toContain('<style')
+    })
+
+    it('should round-trip the escaped style back to real quotes for the renderer', async () => {
+      const code = `<template>
+  <div class="bg-confetti" />
+</template>
+
+<style scoped>
+.bg-confetti {
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='10'%3E%3Crect/%3E%3C/svg%3E");
+}
+</style>`
+
+      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      expect(result).toBeDefined()
+
+      const styleAttrMatch = result!.code.match(/style="([^"]*)"/)
+      expect(styleAttrMatch).not.toBeNull()
+
+      // The serialised attribute holds &quot; to keep the HTML attribute well-formed;
+      // the runtime parser decodes the entities before the renderer sees the CSS string.
+      const { parseStyleAttr } = await import('../../src/runtime/server/og-image/core/style-attr')
+      expect(parseStyleAttr(styleAttrMatch![1])?.backgroundImage).toBe(
+        `url("data:image/svg+xml,%3Csvg width='10' height='10'%3E%3Crect/%3E%3C/svg%3E")`,
+      )
+    })
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A `<style scoped>` rule whose value contains a `"`, like a background-image with a url, currently produces invalid HTML when the asset transform inlines it. (the inner `"` closes the `style="` attribute and Vue fails the build with `Illegal '/' in tags`.)

Repro:

```vue
<template>
  <div class="bg-confetti" />
</template>

<style scoped>
.bg-confetti {
  background-image: url("data:image/svg+xml,%3Csvg width='10' height='10'%3E%3Crect width='5' height='5'/%3E%3C/svg%3E");
}
</style>
```