### PR TITLE
chore(devtools): drop redundant shiki/carbon devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@fontsource/noto-sans-sc": "catalog:",
-    "@iconify-json/carbon": "catalog:",
     "@iconify-json/logos": "catalog:",
     "@iconify-json/noto": "catalog:",
     "@iconify-json/ri": "catalog:",
@@ -179,8 +178,6 @@
     "@nuxtjs/tailwindcss": "catalog:",
     "@resvg/resvg-js": "catalog:",
     "@resvg/resvg-wasm": "catalog:",
-    "@shikijs/langs": "catalog:",
-    "@shikijs/themes": "catalog:",
     "@tailwindcss/vite": "catalog:",
     "@takumi-rs/core": "catalog:",
     "@takumi-rs/helpers": "catalog:",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@fontsource/noto-sans-sc": "catalog:",
+    "@iconify-json/carbon": "catalog:",
     "@iconify-json/logos": "catalog:",
     "@iconify-json/noto": "catalog:",
     "@iconify-json/ri": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     '@fontsource/noto-sans-sc':
       specifier: ^5.2.9
       version: 5.2.9
-    '@iconify-json/carbon':
-      specifier: ^1.2.23
-      version: 1.2.23
     '@iconify-json/logos':
       specifier: ^1.2.11
       version: 1.2.11
@@ -84,12 +81,6 @@ catalogs:
     '@resvg/resvg-wasm':
       specifier: ^2.6.2
       version: 2.6.2
-    '@shikijs/langs':
-      specifier: ^4.2.0
-      version: 4.2.0
-    '@shikijs/themes':
-      specifier: ^4.2.0
-      version: 4.2.0
     '@tailwindcss/vite':
       specifier: ^4.3.0
       version: 4.3.0
@@ -426,9 +417,6 @@ importers:
       '@fontsource/noto-sans-sc':
         specifier: 'catalog:'
         version: 5.2.9
-      '@iconify-json/carbon':
-        specifier: 'catalog:'
-        version: 1.2.23
       '@iconify-json/logos':
         specifier: 'catalog:'
         version: 1.2.11
@@ -492,12 +480,6 @@ importers:
       '@resvg/resvg-wasm':
         specifier: 'catalog:'
         version: 2.6.2
-      '@shikijs/langs':
-        specifier: 'catalog:'
-        version: 4.2.0
-      '@shikijs/themes':
-        specifier: 'catalog:'
-        version: 4.2.0
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.0(vite@8.0.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@fontsource/noto-sans-sc':
       specifier: ^5.2.9
       version: 5.2.9
+    '@iconify-json/carbon':
+      specifier: ^1.2.23
+      version: 1.2.23
     '@iconify-json/logos':
       specifier: ^1.2.11
       version: 1.2.11
@@ -417,6 +420,9 @@ importers:
       '@fontsource/noto-sans-sc':
         specifier: 'catalog:'
         version: 5.2.9
+      '@iconify-json/carbon':
+        specifier: 'catalog:'
+        version: 1.2.23
       '@iconify-json/logos':
         specifier: 'catalog:'
         version: 1.2.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,8 +81,6 @@ catalog:
   '@nuxtjs/tailwindcss': 7.0.0-beta.1
   '@resvg/resvg-js': ^2.6.2
   '@resvg/resvg-wasm': ^2.6.2
-  '@shikijs/langs': ^4.2.0
-  '@shikijs/themes': ^4.2.0
   '@tailwindcss/vite': ^4.3.0
   '@takumi-rs/core': ^1.8.1
   '@takumi-rs/helpers': ^1.8.1


### PR DESCRIPTION
### 📚 Description

`@shikijs/langs`, `@shikijs/themes` and `@iconify-json/carbon` are already provided by `nuxtseo-layer-devtools` (a devDependency) for the assembled DevTools client. og-image's devtools panel uses the layer's `loadShiki` (base langs) and never imports these directly, so declaring them again is redundant and risks cross-repo catalog drift.

`@nuxt/ui` and `tailwindcss` are **kept** — they're used in `src/` (CSS providers / tw4 transform), not just devtools.

devDep-only, so no effect on what ships to consumers. Companion to harlan-zw/nuxt-seo#578.