### PR TITLE
fix: point Takumi installs at v2 beta

### DIFF
--- a/docs/content/2.renderers/0.index.md
+++ b/docs/content/2.renderers/0.index.md
@@ -26,13 +26,13 @@ All renderers share core features: [Tailwind CSS](https://tailwindcss.com) suppo
 | **Filters** | ✅ | ❌ | ✅ |
 | **Emoji** | ✅ COLR fonts | ✅ 11 families | ✅ |
 | **Fonts** | WOFF2, variable | Google Fonts, local | Any |
-| **Dependencies** | `@takumi-rs/core`<br>`@takumi-rs/wasm` | `satori`<br>`@resvg/resvg-js`<br>`@resvg/resvg-wasm` | `playwright-core` |
+| **Dependencies** | `@takumi-rs/core@beta`<br>`@takumi-rs/wasm@beta` | `satori`<br>`@resvg/resvg-js`<br>`@resvg/resvg-wasm` | `playwright-core` |
 
 ## Environment Compatibility
 
 | Environment | Satori | Takumi | Browser |
 |-------------|--------|--------|----------|
-| [Node.js](https://nodejs.org) | ✅ | ✅ `@takumi-rs/core` | ✅ `playwright-core` |
+| [Node.js](https://nodejs.org) | ✅ | ✅ `@takumi-rs/core@beta` | ✅ `playwright-core` |
 | Prerender / CI | ✅ | ✅ | ✅ Auto-installs |
 | AWS Lambda | ✅ | ✅ | ❌ Binary too large |
 | [Vercel](https://vercel.com) | ✅ | ✅ | ❌ |

--- a/docs/content/2.renderers/1.takumi.md
+++ b/docs/content/2.renderers/1.takumi.md
@@ -15,26 +15,26 @@ Takumi is the **recommended renderer** for Nuxt OG Image. It offers the best com
 
 ```sh [pnpm]
 # Node.js
-pnpm i -D @takumi-rs/core
+pnpm i -D @takumi-rs/core@beta
 
 # Edge runtimes (Cloudflare, Vercel Edge, etc.)
-pnpm i -D @takumi-rs/wasm
+pnpm i -D @takumi-rs/wasm@beta
 ```
 
 ```bash [yarn]
 # Node.js
-yarn add -D @takumi-rs/core
+yarn add -D @takumi-rs/core@beta
 
 # Edge runtimes (Cloudflare, Vercel Edge, etc.)
-yarn add -D @takumi-rs/wasm
+yarn add -D @takumi-rs/wasm@beta
 ```
 
 ```bash [npm]
 # Node.js
-npm install -D @takumi-rs/core
+npm install -D @takumi-rs/core@beta
 
 # Edge runtimes (Cloudflare, Vercel Edge, etc.)
-npm install -D @takumi-rs/wasm
+npm install -D @takumi-rs/wasm@beta
 ```
 
 ::
@@ -155,11 +155,11 @@ Takumi supports both Node.js and Wasm runtimes. The module automatically selects
 
 | Environment | Binding | Notes |
 |-------------|---------|-------|
-| Node.js | `@takumi-rs/core` | Native performance |
-| Cloudflare Workers | `@takumi-rs/wasm` | Wasm bundle |
-| Vercel Edge | `@takumi-rs/wasm` | Wasm bundle |
-| Netlify Edge | `@takumi-rs/wasm` | Wasm bundle |
-| AWS Lambda | `@takumi-rs/core` | Native performance |
+| Node.js | `@takumi-rs/core@beta` | Native performance |
+| Cloudflare Workers | `@takumi-rs/wasm@beta` | Wasm bundle |
+| Vercel Edge | `@takumi-rs/wasm@beta` | Wasm bundle |
+| Netlify Edge | `@takumi-rs/wasm@beta` | Wasm bundle |
+| AWS Lambda | `@takumi-rs/core@beta` | Native performance |
 
 See the [Renderers](/docs/og-image/renderers) overview for more details on runtime support.
 

--- a/docs/content/6.migration-guide/v6.md
+++ b/docs/content/6.migration-guide/v6.md
@@ -42,10 +42,10 @@ See [PR #415](https://github.com/nuxt-modules/og-image/pull/415).
 
 ```bash
 # Node.js
-npm i @takumi-rs/core
+npm i @takumi-rs/core@beta
 
 # Edge runtimes
-npm i @takumi-rs/wasm
+npm i @takumi-rs/wasm@beta
 ```
 
 **Satori:**
@@ -66,7 +66,7 @@ npm i playwright-core
 
 Running `nuxi dev` in an interactive terminal will prompt you to install missing dependencies automatically.
 
-In non-interactive environments (AI coding agents, CI, or any process without a TTY) there is nothing to answer the prompt, so the module skips it: it defaults to the `takumi` renderer and emits a warning. When an AI agent runs the module and cannot install a missing renderer dependency, the module throws a clear error (`npx nypm add @takumi-rs/core`) instead of silently producing broken images. Set `NUXT_OG_IMAGE_SKIP_ONBOARDING=1` to opt out of onboarding entirely.
+In non-interactive environments (AI coding agents, CI, or any process without a TTY) there is nothing to answer the prompt, so the module skips it: it defaults to the `takumi` renderer and emits a warning. When an AI agent runs the module and cannot install a missing renderer dependency, the module throws a clear error (`npx nypm add @takumi-rs/core@beta`) instead of silently producing broken images. Set `NUXT_OG_IMAGE_SKIP_ONBOARDING=1` to opt out of onboarding entirely.
 
 ### Component Renderer Suffix Required
 

--- a/docs/content/7.releases/2.v6.md
+++ b/docs/content/7.releases/2.v6.md
@@ -117,8 +117,8 @@ Renderer dependencies are no longer bundled - install only what you need. Runnin
 **Takumi (recommended):**
 
 ```bash
-npm i @takumi-rs/core # Node.js
-npm i @takumi-rs/wasm # Edge runtimes
+npm i @takumi-rs/core@beta # Node.js
+npm i @takumi-rs/wasm@beta # Edge runtimes
 ```
 
 **Satori:**

--- a/examples/basic-takumi/package.json
+++ b/examples/basic-takumi/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@nuxt/fonts": "^0.14.0",
     "@tailwindcss/vite": "^4.3.1",
-    "@takumi-rs/core": "^1.8.7",
+    "@takumi-rs/core": "^2.0.0-beta.6",
     "nuxt": "^4.4.8",
     "nuxt-og-image": "latest",
     "nuxt-site-config": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
   "peerDependencies": {
     "@resvg/resvg-js": "^2.6.0",
     "@resvg/resvg-wasm": "^2.6.0",
-    "@takumi-rs/core": "^1.0.0-beta.3 || ^2.0.0-beta.1",
-    "@takumi-rs/wasm": "^1.0.0-beta.3 || ^2.0.0-beta.1",
+    "@takumi-rs/core": "^1.0.0-beta.3 || ^2.0.0-beta.6",
+    "@takumi-rs/wasm": "^1.0.0-beta.3 || ^2.0.0-beta.6",
     "@unhead/vue": "^2.0.5 || ^3.0.0",
     "fontless": "^0.2.0",
     "nitropack": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ catalogs:
       specifier: npm:@takumi-rs/core@1.8.7
       version: 1.8.7
     '@takumi-rs/helpers':
-      specifier: ^2.0.0-beta.1
-      version: 2.0.0-beta.1
+      specifier: ^2.0.0-beta.6
+      version: 2.0.0-beta.6
     '@takumi-rs/helpers-v1':
       specifier: npm:@takumi-rs/helpers@1.8.7
       version: 1.8.7
@@ -237,6 +237,9 @@ catalogs:
     playwright:
       specifier: ^1.61.0
       version: 1.61.0
+    playwright-core:
+      specifier: ^1.61.0
+      version: 1.61.0
     radix3:
       specifier: ^1.1.2
       version: 1.1.2
@@ -323,7 +326,7 @@ importers:
         version: 4.4.8(magicast@0.5.3)
       '@unhead/vue':
         specifier: ^3.1.4
-        version: 3.1.4(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.0.0-rc.13)(typescript@6.0.3)(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 3.1.4(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.0.0-rc.13)(typescript@6.0.3)(vite@8.0.6(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@unocss/config':
         specifier: 'catalog:'
         version: 66.7.2
@@ -501,7 +504,7 @@ importers:
         version: '@takumi-rs/core@1.8.7'
       '@takumi-rs/helpers':
         specifier: 'catalog:'
-        version: 2.0.0-beta.1
+        version: 2.0.0-beta.6
       '@takumi-rs/helpers-v1':
         specifier: 'catalog:'
         version: '@takumi-rs/helpers@1.8.7'
@@ -575,7 +578,7 @@ importers:
         specifier: 'catalog:'
         version: 1.61.0
       playwright-core:
-        specifier: ^1.61.0
+        specifier: 'catalog:'
         version: 1.61.0
       sass:
         specifier: 'catalog:'
@@ -4592,17 +4595,6 @@ packages:
 
   '@takumi-rs/helpers@1.8.7':
     resolution: {integrity: sha512-5dSR9W8msQ7Asp4TCvUUB9Bt8yLgIc2ASjWtEG4Jn9xSuAVJLWFZ21Xl8HShW5GE6SV5aCCM9BL0NA9YuBWIJw==}
-    peerDependencies:
-      react: ^19.2.5
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
-  '@takumi-rs/helpers@2.0.0-beta.1':
-    resolution: {integrity: sha512-2bqhJHgiA+klG9DVnQPT/mR2XJy5A3k4Qx630y/EtUyALwD/oUlANJMzVo+GY6JaUZ3UzahRwRl39O0NMg7f/w==}
     peerDependencies:
       react: ^19.2.5
       react-dom: ^18.0.0 || ^19.0.0
@@ -9841,11 +9833,6 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
-  srvx@0.11.16:
-    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
-    engines: {node: '>=20.16.0'}
-    hasBin: true
-
   srvx@0.11.17:
     resolution: {integrity: sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==}
     engines: {node: '>=20.16.0'}
@@ -11349,15 +11336,6 @@ snapshots:
     dependencies:
       birpc: 4.0.0
       devframe: 0.5.4(crossws@0.4.6(srvx@0.11.17))(typescript@6.0.3)
-      nostics: 0.2.0
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      tinyexec: 1.2.4
-
-  '@devframes/hub@0.5.4(devframe@0.5.4(typescript@6.0.3))':
-    dependencies:
-      birpc: 4.0.0
-      devframe: 0.5.4(typescript@6.0.3)
       nostics: 0.2.0
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -14476,8 +14454,6 @@ snapshots:
 
   '@takumi-rs/helpers@1.8.7': {}
 
-  '@takumi-rs/helpers@2.0.0-beta.1': {}
-
   '@takumi-rs/helpers@2.0.0-beta.6': {}
 
   '@takumi-rs/wasm@1.8.7':
@@ -15023,28 +14999,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@unhead/bundler@3.1.4(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.0.0-rc.13)(typescript@6.0.3)(unhead@3.1.4(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
-    dependencies:
-      '@vitejs/devtools-kit': 0.3.1(typescript@6.0.3)(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      magic-string: 0.30.21
-      oxc-parser: 0.135.0
-      oxc-walker: 1.0.0(oxc-parser@0.135.0)(rolldown@1.0.0-rc.13)
-      ufo: 1.6.4
-      unhead: 3.1.4(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      unplugin: 3.0.0
-    optionalDependencies:
-      esbuild: 0.28.1
-      lightningcss: 1.32.0
-      rolldown: 1.0.0-rc.13
-      vite: 8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
-      webpack: 5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - crossws
-      - typescript
-      - utf-8-validate
-
   '@unhead/vue@3.1.4(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.0.0-rc.13)(typescript@6.0.3)(vite@8.0.6(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@unhead/bundler': 3.1.4(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.0.0-rc.13)(typescript@6.0.3)(unhead@3.1.4(vite@8.0.6(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.0.6(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -15054,27 +15008,6 @@ snapshots:
       vue: 3.5.38(typescript@6.0.3)
     optionalDependencies:
       vite: 8.0.6(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
-      webpack: 5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - '@unhead/cli'
-      - bufferutil
-      - crossws
-      - esbuild
-      - lightningcss
-      - rolldown
-      - typescript
-      - utf-8-validate
-
-  '@unhead/vue@3.1.4(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.0.0-rc.13)(typescript@6.0.3)(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
-    dependencies:
-      '@unhead/bundler': 3.1.4(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.0.0-rc.13)(typescript@6.0.3)(unhead@3.1.4(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
-      hookable: 6.1.1
-      unhead: 3.1.4(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      unplugin: 3.0.0
-      vue: 3.5.38(typescript@6.0.3)
-    optionalDependencies:
-      vite: 8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
       webpack: 5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -15359,24 +15292,6 @@ snapshots:
       perfect-debounce: 2.1.0
       tinyexec: 1.2.4
       vite: 8.0.6(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - crossws
-      - typescript
-      - utf-8-validate
-
-  '@vitejs/devtools-kit@0.3.1(typescript@6.0.3)(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))':
-    dependencies:
-      '@devframes/hub': 0.5.4(devframe@0.5.4(typescript@6.0.3))
-      birpc: 4.0.0
-      devframe: 0.5.4(typescript@6.0.3)
-      mlly: 1.8.2
-      nostics: 0.2.0
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      tinyexec: 1.2.4
-      vite: 8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -16658,23 +16573,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  devframe@0.5.4(typescript@6.0.3):
-    dependencies:
-      '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
-      birpc: 4.0.0
-      cac: 7.0.0
-      h3: 2.0.1-rc.22
-      mrmime: 2.0.1
-      nostics: 0.2.0
-      pathe: 2.0.3
-      valibot: 1.4.1(typescript@6.0.3)
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - crossws
-      - typescript
-      - utf-8-validate
-
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -17943,11 +17841,6 @@ snapshots:
       srvx: 0.11.17
     optionalDependencies:
       crossws: 0.4.6(srvx@0.11.17)
-
-  h3@2.0.1-rc.22:
-    dependencies:
-      rou3: 0.8.1
-      srvx: 0.11.16
 
   h3@2.0.1-rc.22(crossws@0.4.6(srvx@0.11.17)):
     dependencies:
@@ -21654,8 +21547,6 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  srvx@0.11.16: {}
-
   srvx@0.11.17: {}
 
   sshpk@1.18.0:
@@ -22117,13 +22008,6 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  unhead@3.1.4(vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)):
-    dependencies:
-      hookable: 6.1.1
-      unplugin: 3.0.0
-    optionalDependencies:
-      vite: 8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
-
   unhead@3.1.4(vite@8.0.6(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       hookable: 6.1.1
@@ -22549,22 +22433,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.3
       esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      sass: 1.101.0
-      terser: 5.48.0
-      yaml: 2.9.0
-
-  vite@8.0.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.0-rc.13
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.9.3
-      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       sass: 1.101.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -106,7 +106,7 @@ catalog:
   '@tailwindcss/vite': ^4.3.1
   '@takumi-rs/core': ^2.0.0-beta.6
   '@takumi-rs/core-v1': npm:@takumi-rs/core@1.8.7
-  '@takumi-rs/helpers': ^2.0.0-beta.1
+  '@takumi-rs/helpers': ^2.0.0-beta.6
   '@takumi-rs/helpers-v1': npm:@takumi-rs/helpers@1.8.7
   '@takumi-rs/wasm': ^2.0.0-beta.6
   '@takumi-rs/wasm-v1': npm:@takumi-rs/wasm@1.8.7

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { parseAndWalk } from 'oxc-walker'
 import { basename, dirname, join, relative, resolve } from 'pathe'
 import { ELEMENT_NODE, parse as parseHtml, walkSync } from 'ultrahtml'
 import { migrateDefaultsComponent, migrateFontsConfig } from './migrations/fonts'
+import { TAKUMI_CORE_INSTALL_SPEC, TAKUMI_WASM_INSTALL_SPEC } from './utils/dependencies'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -245,13 +246,18 @@ const EDGE_PRESETS = ['cloudflare', 'cloudflare-pages', 'cloudflare-module', 've
 
 // Get dependencies based on renderer and deployment target
 // Edge targets need both node (for local dev) and wasm (for production) versions
-function getRendererDeps(renderer: RendererName, isEdge: boolean): string[] {
+function getRendererDeps(renderer: RendererName, isEdge: boolean, options: { installSpec?: boolean } = {}): string[] {
   switch (renderer) {
     case 'satori':
       return isEdge
         ? ['satori', '@resvg/resvg-js', '@resvg/resvg-wasm']
         : ['satori', '@resvg/resvg-js']
     case 'takumi':
+      if (options.installSpec) {
+        return isEdge
+          ? [TAKUMI_CORE_INSTALL_SPEC, TAKUMI_WASM_INSTALL_SPEC]
+          : [TAKUMI_CORE_INSTALL_SPEC]
+      }
       return isEdge
         ? ['@takumi-rs/core', '@takumi-rs/wasm']
         : ['@takumi-rs/core']
@@ -758,7 +764,7 @@ async function installRendererDeps(renderers: RendererName[], isEdge: boolean): 
 
   const allDeps: string[] = []
   for (const renderer of renderers) {
-    allDeps.push(...getRendererDeps(renderer, isEdge))
+    allDeps.push(...getRendererDeps(renderer, isEdge, { installSpec: true }))
   }
 
   // Dedupe

--- a/src/module.ts
+++ b/src/module.ts
@@ -53,7 +53,7 @@ import { onInstall, onUpgrade } from './onboarding'
 import { logger } from './runtime/logger'
 import { registerTypeTemplates } from './templates'
 import { checkLocalChrome, getRegisteredBaseNames, getRendererFromFilename, hasResolvableDependency, isUndefinedOrTruthy, RE_LEGACY_SUFFIX } from './util'
-import { canPromptInteractively, ensureProviderDependencies, getInstalledProviders, getMissingDependencies, getRecommendedBinding, promptForRendererSelection } from './utils/dependencies'
+import { canPromptInteractively, ensureProviderDependencies, getInstalledProviders, getMissingDependencies, getMissingDependencyInstallSpecs, getRecommendedBinding, promptForRendererSelection, TAKUMI_CORE_INSTALL_SPEC } from './utils/dependencies'
 
 export type {
   OgImageComponent,
@@ -1114,7 +1114,7 @@ export default defineNuxtModule<ModuleOptions>({
         // non-interactive (agent, CI, or no TTY) — can't prompt, default to takumi.
         // Warn so the choice is visible and the agent can pin a renderer explicitly.
         ogImageComponentCtx.detectedRenderers.add('takumi')
-        logger.warn('No OG image renderer dependency detected. Defaulting to `takumi` (non-interactive environment). Install `@takumi-rs/core`, or add a renderer component (e.g. components/OgImage/Default.satori.vue) to choose explicitly.')
+        logger.warn(`No OG image renderer dependency detected. Defaulting to \`takumi\` (non-interactive environment). Install \`${TAKUMI_CORE_INSTALL_SPEC}\`, or add a renderer component (e.g. components/OgImage/Default.satori.vue) to choose explicitly.`)
       }
     }
 
@@ -1129,24 +1129,27 @@ export default defineNuxtModule<ModuleOptions>({
             availableRenderers.add(renderer)
           }
           else if (nuxt.options.dev && !nuxt.options._prepare) {
-            logger.warn(`${renderer} renderer requires: ${missing.join(', ')}`)
+            const installSpecs = await getMissingDependencyInstallSpecs(renderer, binding)
+            logger.warn(`${renderer} renderer requires: ${installSpecs.join(', ')}`)
             const { success } = await ensureProviderDependencies(renderer, binding, nuxt)
             if (success) {
               availableRenderers.add(renderer)
             }
             else if (isAgent) {
               // agents can't recover from a half-installed renderer — fail loud and actionable
-              throw new Error(`[nuxt-og-image] Failed to install ${renderer} dependencies: ${missing.join(', ')}. Install manually: npx nypm add ${missing.join(' ')}`)
+              throw new Error(`[nuxt-og-image] Failed to install ${renderer} dependencies: ${missing.join(', ')}. Install manually: npx nypm add ${installSpecs.join(' ')}`)
             }
             else {
               logger.error(`Failed to install ${renderer} dependencies. Templates using this renderer won't work.`)
             }
           }
           else if (isAgent) {
-            throw new Error(`[nuxt-og-image] ${renderer} renderer missing dependencies: ${missing.join(', ')}. Install with: npx nypm add ${missing.join(' ')}`)
+            const installSpecs = await getMissingDependencyInstallSpecs(renderer, binding)
+            throw new Error(`[nuxt-og-image] ${renderer} renderer missing dependencies: ${missing.join(', ')}. Install with: npx nypm add ${installSpecs.join(' ')}`)
           }
           else {
-            logger.error(`${renderer} renderer missing dependencies: ${missing.join(', ')}. Install with: npx nypm add ${missing.join(' ')}`)
+            const installSpecs = await getMissingDependencyInstallSpecs(renderer, binding)
+            logger.error(`${renderer} renderer missing dependencies: ${missing.join(', ')}. Install with: npx nypm add ${installSpecs.join(' ')}`)
           }
           // Set resvg WASM fallback compatibility when satori resolved to wasm binding
           if (renderer === 'satori' && availableRenderers.has(renderer) && binding !== 'node') {
@@ -1307,9 +1310,11 @@ export default defineNuxtModule<ModuleOptions>({
         for (const renderer of ogImageComponentCtx.detectedRenderers) {
           if (!availableRenderers.has(renderer)) {
             const binding = getRecommendedBinding(renderer, targetCompatibility)
-            getMissingDependencies(renderer, binding).then((missing) => {
-              if (missing.length > 0)
-                logger.warn(`New ${renderer} component detected but dependencies missing: ${missing.join(', ')}. Install with: npx nypm add ${missing.join(' ')}`)
+            getMissingDependencies(renderer, binding).then(async (missing) => {
+              if (missing.length > 0) {
+                const installSpecs = await getMissingDependencyInstallSpecs(renderer, binding)
+                logger.warn(`New ${renderer} component detected but dependencies missing: ${missing.join(', ')}. Install with: npx nypm add ${installSpecs.join(' ')}`)
+              }
             })
           }
         }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -13,10 +13,11 @@ import {
   canPromptInteractively,
   ensureProviderDependencies,
   getInstalledProviders,
-  getMissingDependencies,
-  getProviderDependencies,
+  getMissingDependencyInstallSpecs,
+  getProviderDependencyInstallSpecs,
   getRecommendedBindingFromPreset,
   PROVIDER_DEPENDENCIES,
+  TAKUMI_CORE_INSTALL_SPEC,
   validateProviderSetup,
 } from './utils/dependencies'
 
@@ -69,6 +70,7 @@ export async function onInstall(nuxt: Nuxt): Promise<void> {
       throw new Error(
         '[nuxt-og-image] No OG image provider dependencies found. '
         + 'Install a provider before running in CI:\n'
+        + `  npm add ${TAKUMI_CORE_INSTALL_SPEC}                # for takumi\n`
         + '  npm add @resvg/resvg-js satori yoga-wasm-web  # for satori\n'
         + '  npm add playwright-core                       # for browser\n'
         + 'See: https://nuxtseo.com/og-image/getting-started',
@@ -169,11 +171,11 @@ export async function onInstall(nuxt: Nuxt): Promise<void> {
   }
 
   // check and install dependencies
-  const missing = await getMissingDependencies(state.selectedRenderer!, state.selectedBinding!)
+  const missingInstallSpecs = await getMissingDependencyInstallSpecs(state.selectedRenderer!, state.selectedBinding!)
 
-  if (missing.length > 0) {
+  if (missingInstallSpecs.length > 0) {
     logger.info(`Required dependencies for ${state.selectedRenderer} (${state.selectedBinding}):`)
-    for (const pkg of missing) {
+    for (const pkg of missingInstallSpecs) {
       logger.info(`  - ${pkg}`)
     }
 
@@ -194,12 +196,12 @@ export async function onInstall(nuxt: Nuxt): Promise<void> {
       }
       else {
         logger.error('Failed to install some dependencies. Install manually:')
-        const allDeps = getProviderDependencies(state.selectedRenderer!, state.selectedBinding!)
+        const allDeps = getProviderDependencyInstallSpecs(state.selectedRenderer!, state.selectedBinding!)
         logger.info(`  npm add ${allDeps.join(' ')}`)
       }
     }
     else {
-      const allDeps = getProviderDependencies(state.selectedRenderer!, state.selectedBinding!)
+      const allDeps = getProviderDependencyInstallSpecs(state.selectedRenderer!, state.selectedBinding!)
       logger.warn('Dependencies required. Install manually:')
       logger.info(`  npm add ${allDeps.join(' ')}`)
     }

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -12,6 +12,7 @@ export type BindingVariant = 'node' | 'wasm' | 'wasm-fs'
 export interface ProviderDependency {
   name: string
   description: string
+  installSpec?: string
   optional?: boolean
 }
 
@@ -24,6 +25,12 @@ export interface ProviderDefinition {
     'wasm-fs'?: ProviderDependency[]
   }
 }
+
+export const TAKUMI_INSTALL_TAG = 'beta'
+export const TAKUMI_CORE_PACKAGE = '@takumi-rs/core'
+export const TAKUMI_WASM_PACKAGE = '@takumi-rs/wasm'
+export const TAKUMI_CORE_INSTALL_SPEC = `${TAKUMI_CORE_PACKAGE}@${TAKUMI_INSTALL_TAG}`
+export const TAKUMI_WASM_INSTALL_SPEC = `${TAKUMI_WASM_PACKAGE}@${TAKUMI_INSTALL_TAG}`
 
 export const PROVIDER_DEPENDENCIES: ProviderDefinition[] = [
   {
@@ -49,13 +56,13 @@ export const PROVIDER_DEPENDENCIES: ProviderDefinition[] = [
     description: 'Rust-based high-performance renderer (recommended)',
     bindings: {
       'node': [
-        { name: '@takumi-rs/core', description: 'Native Takumi renderer' },
+        { name: TAKUMI_CORE_PACKAGE, installSpec: TAKUMI_CORE_INSTALL_SPEC, description: 'Native Takumi renderer' },
       ],
       'wasm': [
-        { name: '@takumi-rs/wasm', description: 'WASM Takumi renderer' },
+        { name: TAKUMI_WASM_PACKAGE, installSpec: TAKUMI_WASM_INSTALL_SPEC, description: 'WASM Takumi renderer' },
       ],
       'wasm-fs': [
-        { name: '@takumi-rs/wasm', description: 'WASM Takumi renderer' },
+        { name: TAKUMI_WASM_PACKAGE, installSpec: TAKUMI_WASM_INSTALL_SPEC, description: 'WASM Takumi renderer' },
       ],
     },
   },
@@ -106,31 +113,64 @@ export async function getMissingDependencies(
   provider: ProviderName,
   binding: BindingVariant = 'node',
 ): Promise<string[]> {
+  const missing = await getMissingProviderDependencyDefinitions(provider, binding)
+  return missing.map(d => d.name)
+}
+
+async function getMissingProviderDependencyDefinitions(
+  provider: ProviderName,
+  binding: BindingVariant = 'node',
+): Promise<ProviderDependency[]> {
   const providerDef = PROVIDER_DEPENDENCIES.find(p => p.name === provider)
   if (!providerDef)
     return []
 
   const deps = providerDef.bindings[binding] || providerDef.bindings.node || []
-  const missing: string[] = []
+  const missing: ProviderDependency[] = []
 
   for (const dep of deps) {
     if (!await hasResolvableDependency(dep.name))
-      missing.push(dep.name)
+      missing.push(dep)
   }
 
   return missing
+}
+
+function getDependencyDefinitions(
+  provider: ProviderName,
+  binding: BindingVariant = 'node',
+): ProviderDependency[] {
+  const providerDef = PROVIDER_DEPENDENCIES.find(p => p.name === provider)
+  if (!providerDef)
+    return []
+
+  return providerDef.bindings[binding] || providerDef.bindings.node || []
+}
+
+export function getDependencyInstallSpec(dep: ProviderDependency): string {
+  return dep.installSpec || dep.name
+}
+
+export async function getMissingDependencyInstallSpecs(
+  provider: ProviderName,
+  binding: BindingVariant = 'node',
+): Promise<string[]> {
+  const missing = await getMissingProviderDependencyDefinitions(provider, binding)
+  return missing.map(getDependencyInstallSpec)
 }
 
 export function getProviderDependencies(
   provider: ProviderName,
   binding: BindingVariant = 'node',
 ): string[] {
-  const providerDef = PROVIDER_DEPENDENCIES.find(p => p.name === provider)
-  if (!providerDef)
-    return []
+  return getDependencyDefinitions(provider, binding).map(d => d.name)
+}
 
-  const deps = providerDef.bindings[binding] || providerDef.bindings.node || []
-  return deps.map(d => d.name)
+export function getProviderDependencyInstallSpecs(
+  provider: ProviderName,
+  binding: BindingVariant = 'node',
+): string[] {
+  return getDependencyDefinitions(provider, binding).map(getDependencyInstallSpec)
 }
 
 export function getRecommendedBindingFromPreset(provider: ProviderName): BindingVariant {
@@ -170,28 +210,31 @@ export async function ensureProviderDependencies(
   binding: BindingVariant,
   nuxt: Nuxt,
 ): Promise<{ success: boolean, installed: string[] }> {
-  const missing = await getMissingDependencies(provider, binding)
+  const missingDeps = await getMissingProviderDependencyDefinitions(provider, binding)
 
-  if (missing.length === 0)
+  if (missingDeps.length === 0)
     return { success: true, installed: [] }
+
+  const missingInstallSpecs = missingDeps.map(getDependencyInstallSpec)
 
   const pm = await detectPackageManager(nuxt.options.rootDir)
   const pmName = pm?.name || 'npm'
 
-  logger.info(`Installing ${provider} dependencies: ${missing.join(', ')}`)
+  logger.info(`Installing ${provider} dependencies: ${missingInstallSpecs.join(', ')}`)
 
   const installed: string[] = []
-  for (const pkg of missing) {
-    const success = await addDependency(pkg, {
+  for (const dep of missingDeps) {
+    const installSpec = getDependencyInstallSpec(dep)
+    const success = await addDependency(installSpec, {
       cwd: nuxt.options.rootDir,
       dev: false,
     })
       .then(() => {
-        installed.push(pkg)
+        installed.push(installSpec)
         return true
       })
       .catch(() => {
-        logger.error(`Failed to install ${pkg}. Run manually: ${pmName} add ${pkg}`)
+        logger.error(`Failed to install ${installSpec}. Run manually: ${pmName} add ${installSpec}`)
         return false
       })
 
@@ -245,7 +288,7 @@ export async function validateProviderSetup(
 ): Promise<{ valid: boolean, issues: string[] }> {
   const issues: string[] = []
   const binding = getRecommendedBinding(renderer, compatibility)
-  const missing = await getMissingDependencies(renderer, binding)
+  const missing = await getMissingDependencyInstallSpecs(renderer, binding)
 
   if (missing.length > 0) {
     issues.push(`Missing ${renderer} dependencies: ${missing.join(', ')}`)

--- a/test/unit/interactive-env.test.ts
+++ b/test/unit/interactive-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { canPromptInteractively } from '../../src/utils/dependencies'
+import { canPromptInteractively, getProviderDependencyInstallSpecs } from '../../src/utils/dependencies'
 
 describe('canPromptInteractively', () => {
   it('prompts only in a real interactive terminal', () => {
@@ -22,5 +22,12 @@ describe('canPromptInteractively', () => {
 
   it('does not prompt in CI', () => {
     expect(canPromptInteractively({ hasTTY: true, hasStdinTTY: true, isAgent: false, isCI: true })).toBe(false)
+  })
+})
+
+describe('provider install specs', () => {
+  it('points Takumi installs at the v2 beta tag', () => {
+    expect(getProviderDependencyInstallSpecs('takumi', 'node')).toEqual(['@takumi-rs/core@beta'])
+    expect(getProviderDependencyInstallSpecs('takumi', 'wasm')).toEqual(['@takumi-rs/wasm@beta'])
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [x] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Takumi install flows were still asking users to install unqualified npm packages, which resolves to the v1 latest tag. This adds beta install specs for onboarding, CLI migration, and agent-facing errors, then updates docs, examples, peer ranges, and the workspace catalog to the current 2.0.0 beta.