### PR TITLE
chore: code cleanup sweep

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "@vue/compiler-sfc": "catalog:",
     "chrome-launcher": "catalog:",
     "consola": "catalog:",
-    "culori": "catalog:",
     "defu": "catalog:",
     "devalue": "catalog:",
     "exsolve": "catalog:",
@@ -154,7 +153,6 @@
     "std-env": "catalog:",
     "strip-literal": "catalog:",
     "tinyexec": "catalog:",
-    "tinyglobby": "catalog:",
     "ufo": "catalog:",
     "ultrahtml": "catalog:",
     "unplugin": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,9 +150,6 @@ catalogs:
     consola:
       specifier: ^3.4.2
       version: 3.4.2
-    culori:
-      specifier: ^4.0.2
-      version: 4.0.2
     defu:
       specifier: ^6.1.7
       version: 6.1.7
@@ -273,9 +270,6 @@ catalogs:
     tinyexec:
       specifier: ^1.2.4
       version: 1.2.4
-    tinyglobby:
-      specifier: ^0.2.17
-      version: 0.2.17
     typescript:
       specifier: 6.0.3
       version: 6.0.3
@@ -348,9 +342,6 @@ importers:
       consola:
         specifier: 'catalog:'
         version: 3.4.2
-      culori:
-        specifier: 'catalog:'
-        version: 4.0.2
       defu:
         specifier: 'catalog:'
         version: 6.1.7
@@ -417,9 +408,6 @@ importers:
       tinyexec:
         specifier: 'catalog:'
         version: 1.2.4
-      tinyglobby:
-        specifier: 'catalog:'
-        version: 0.2.17
       ufo:
         specifier: 'catalog:'
         version: 1.6.4
@@ -6081,10 +6069,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  culori@4.0.2:
-    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cwise-compiler@1.1.3:
     resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
@@ -16721,8 +16705,6 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
-
-  culori@4.0.2: {}
 
   cwise-compiler@1.1.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -128,7 +128,6 @@ catalog:
   bumpp: ^11.1.0
   chrome-launcher: ^1.2.1
   consola: ^3.4.2
-  culori: ^4.0.2
   defu: ^6.1.7
   devalue: ^5.8.1
   eslint: ^10.7.0
@@ -169,7 +168,6 @@ catalog:
   strip-literal: ^3.1.0
   tailwindcss: ^4.3.3
   tinyexec: ^1.2.4
-  tinyglobby: ^0.2.17
   typescript: 6.0.3
   ufo: ^1.6.4
   ultrahtml: ^1.7.0

--- a/src/build/tree-shake-plugin.ts
+++ b/src/build/tree-shake-plugin.ts
@@ -69,13 +69,8 @@ export const TreeShakeComposablesPlugin = createUnplugin(() => {
     },
     transform(code, id) {
       const s = new MagicString(code)
-      if (id.endsWith('components.islands.mjs')) {
-        // TODO re-implement
-        // for (const match of code.matchAll(/"OgImage.*": defineAsyncComponent\(.*\),?/g)) {
-        //   s.overwrite(match.index!, match.index! + match[0].length, '')
-        // }
-      }
-      else {
+      // @todo re-implement composable tree-shaking for island files
+      if (!id.endsWith('components.islands.mjs')) {
         const strippedCode = stripLiteral(code)
         if (!COMPOSABLE_RE.test(code)) {
           return

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1,1 +1,1 @@
-export { detectTarget, getNuxtModuleOptions, isNuxtGenerate, resolveNitroPreset } from 'nuxtseo-shared/kit'
+export { getNuxtModuleOptions, isNuxtGenerate, resolveNitroPreset } from 'nuxtseo-shared/kit'

--- a/src/migrations/warnings.ts
+++ b/src/migrations/warnings.ts
@@ -2,7 +2,7 @@ import { basename } from 'pathe'
 import { logger } from '../runtime/logger'
 
 export interface MigrationWarning {
-  type: 'config' | 'composable' | 'component'
+  type: 'config' | 'component'
   code: string
   message: string
   replacement?: string
@@ -11,14 +11,12 @@ export interface MigrationWarning {
 
 interface WarningCounts {
   config: Map<string, number>
-  composable: Map<string, number>
   component: Map<string, number>
 }
 
 const warnings: MigrationWarning[] = []
 const counts: WarningCounts = {
   config: new Map(),
-  composable: new Map(),
   component: new Map(),
 }
 let hasEmitted = false
@@ -43,18 +41,6 @@ export const REMOVED_CONFIG: Record<string, string> = {
   'defaults.component': 'Removed (rename component to OgImage/Default.{renderer}.vue)',
 }
 
-// Deprecated composables
-export const DEPRECATED_COMPOSABLES: Record<string, string> = {
-  defineOgImageComponent: 'defineOgImage()',
-  defineOgImageStatic: 'defineOgImage()',
-  defineOgImageDynamic: 'defineOgImage()',
-  defineOgImageCached: 'defineOgImage()',
-  defineOgImageWithoutCache: 'defineOgImage()',
-}
-
-// browser: 'node' is deprecated
-export const DEPRECATED_BROWSER_NODE = 'browser: \'node\' binding removed, use \'playwright\''
-
 export function addWarning(warning: MigrationWarning): void {
   const countMap = counts[warning.type]
   const current = countMap.get(warning.code) || 0
@@ -78,19 +64,6 @@ export function addConfigWarning(key: string): void {
   }
 }
 
-export function addComposableWarning(name: string, file?: string): void {
-  const replacement = DEPRECATED_COMPOSABLES[name]
-  if (replacement) {
-    addWarning({
-      type: 'composable',
-      code: name,
-      message: `${name}() is deprecated`,
-      replacement,
-      file,
-    })
-  }
-}
-
 export function addComponentWarning(componentPath: string): void {
   addWarning({
     type: 'component',
@@ -104,7 +77,6 @@ export function addComponentWarning(componentPath: string): void {
 export function hasWarnings(): boolean {
   return warnings.length > 0
     || counts.config.size > 0
-    || counts.composable.size > 0
     || counts.component.size > 0
 }
 
@@ -115,7 +87,6 @@ export function emitWarnings(): void {
   hasEmitted = true
 
   const totalIssues = [...counts.config.values()].reduce((a, b) => a + b, 0)
-    + [...counts.composable.values()].reduce((a, b) => a + b, 0)
     + [...counts.component.values()].reduce((a, b) => a + b, 0)
 
   const body = [
@@ -159,19 +130,6 @@ function formatWarnings(): string {
     lines.push('')
   }
 
-  // Composable warnings
-  if (counts.composable.size > 0) {
-    lines.push('Deprecated composables:')
-    for (const [name, count] of counts.composable) {
-      const replacement = DEPRECATED_COMPOSABLES[name]
-      const suffix = count > 1 ? ` (×${count})` : ''
-      lines.push(`  • ${name}()${suffix}`)
-      if (replacement)
-        lines.push(`    → Use: ${replacement}`)
-    }
-    lines.push('')
-  }
-
   // Component warnings
   if (counts.component.size > 0) {
     const componentCount = [...counts.component.values()].reduce((a, b) => a + b, 0)
@@ -188,12 +146,4 @@ function formatWarnings(): string {
   }
 
   return lines.join('\n')
-}
-
-export function resetWarnings(): void {
-  warnings.length = 0
-  counts.config.clear()
-  counts.composable.clear()
-  counts.component.clear()
-  hasEmitted = false
 }

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,2 +1,0 @@
-// placeholder for pure utility exports
-export {}

--- a/src/runtime/pure.ts
+++ b/src/runtime/pure.ts
@@ -78,9 +78,3 @@ export function toBase64Image(data: string | ArrayBuffer) {
 export function withoutQuery(path: string) {
   return path.split('?')[0]
 }
-
-export function getExtension(path: string) {
-  path = withoutQuery(path)!
-  const lastSegment = (path.split('/').pop() || path)
-  return lastSegment.split('.').pop() || lastSegment
-}

--- a/src/runtime/server/og-image/bindings/browser/cloudflare.ts
+++ b/src/runtime/server/og-image/bindings/browser/cloudflare.ts
@@ -80,13 +80,3 @@ export async function createBrowser(event?: H3Event): Promise<Browser> {
   browserPromise = null
   return browser
 }
-
-export async function disposeBrowser(): Promise<void> {
-  if (browser) {
-    await browser.close().catch((err) => {
-      // Browser disposal is best-effort during worker cleanup.
-      void err
-    })
-    browser = null
-  }
-}

--- a/src/runtime/server/util/encoding.ts
+++ b/src/runtime/server/util/encoding.ts
@@ -38,11 +38,3 @@ export function decodeHtml(html: string) {
     })
     .replace(RE_AMP, '&')
 }
-export function decodeObjectHtmlEntities(obj: Record<string, string | any>) {
-  Object.entries(obj).forEach(([key, value]) => {
-    // unescape all html tokens
-    if (typeof value === 'string')
-      obj[key] = decodeHtml(value)
-  })
-  return obj
-}

--- a/src/runtime/server/util/kit.ts
+++ b/src/runtime/server/util/kit.ts
@@ -7,8 +7,6 @@ import { createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
 import { withoutBase, withoutTrailingSlash } from 'ufo'
 import { getIslandHash } from '#og-image/island-hash'
 
-export { withoutQuery } from 'nuxtseo-shared/utils'
-
 export function fetchIsland(e: H3Event, component: string, props: Record<string, any>, timeout?: number): Promise<NuxtIslandResponse> {
   // The server rejects hash mismatches with `400 Invalid island request hash`, so the
   // hash comes from the installed Nuxt's own implementation (see the

--- a/src/runtime/server/util/timings.ts
+++ b/src/runtime/server/util/timings.ts
@@ -106,7 +106,3 @@ export function createTimings(): Timings {
 }
 
 export const TIMING_CTX_KEY = '_ogImageTimings'
-
-export function getTimingsFromEvent(e: { context: Record<string, any> }): Timings | undefined {
-  return e.context[TIMING_CTX_KEY]
-}


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Routine dead-code sweep of `src/`, no behavior or public API changes.

- trimmed the unused `detectTarget` re-export from `src/kit.ts` (mirrors the same trim already done in `nuxt-robots`)
- deleted `src/pure.ts`, an unreferenced placeholder file
- removed the composable-warning path in `src/migrations/warnings.ts` (`addComposableWarning`, `DEPRECATED_COMPOSABLES`, `DEPRECATED_BROWSER_NODE`, `resetWarnings`) — it was never wired up, the actual deprecated-composable lists live in `cli.ts` and `onboarding.ts`
- dropped a handful of dead exports found to have zero callers: `getExtension` (`runtime/pure.ts`, duplicate of the one actually used in `runtime/shared.ts`), `disposeBrowser` (cloudflare browser binding), `decodeObjectHtmlEntities`, `getTimingsFromEvent`, and a stray `withoutQuery` re-export in `server/util/kit.ts`
- simplified a no-op branch (with stale commented-out code) in `tree-shake-plugin.ts`
- removed two unused dependencies from `package.json`: `culori` and `tinyglobby`

Verified: `pnpm lint`, `pnpm typecheck`, `pnpm build`, and the full `pnpm test` suite all pass. Two different e2e tests timed out under full-suite parallel load during verification (one on `main`, a different one on this branch); both pass cleanly in isolation, confirming pre-existing flakiness rather than a regression.