### PR TITLE
chore: adopt nuxtseo-shared 5.3.4 APIs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ catalogs:
       specifier: ^5.3.3
       version: 5.3.3
     nuxtseo-shared:
-      specifier: ^5.3.3
-      version: 5.3.3
+      specifier: ^5.3.4
+      version: 5.3.4
     nypm:
       specifier: ^0.6.8
       version: 0.6.8
@@ -371,7 +371,7 @@ importers:
         version: 4.1.2(68653ce2847bfbe4597dda0e6f009c9d)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.3.3(cf36c37d578e24d79613e4e8cde3d40a)
+        version: 5.3.4(cf36c37d578e24d79613e4e8cde3d40a)
       nypm:
         specifier: 'catalog:'
         version: 0.6.8
@@ -2254,11 +2254,6 @@ packages:
 
   '@nuxt/devtools-kit@3.2.4':
     resolution: {integrity: sha512-Yxy2Xgmq5hf3dQy983V0xh0OJV2mYwRZz9eVIGc3EaribdFGPDNGMMbYqX9qCty3Pbxn/bCF3J0UyPaNlHVayQ==}
-    peerDependencies:
-      vite: 8.1.5
-
-  '@nuxt/devtools-kit@4.0.0-alpha.3':
-    resolution: {integrity: sha512-ymp4jqS3hFfwRw8uDkv8cpu4kWvhQrX+S4jnA/oOc76s4AXf2HCZZJgrncKxh+txqi1NJj8nsQNBbaqRAo3g4w==}
     peerDependencies:
       vite: 8.1.5
 
@@ -8498,8 +8493,8 @@ packages:
   nuxtseo-layer-devtools@5.3.3:
     resolution: {integrity: sha512-pTdMQVHY8o3YSzxlLrAqy6klao3uk7qdB+lvTTU1KxTbTxPIisaqL8lj2M6kv74aShglR6AjyqfWyqeQ9jCuCg==}
 
-  nuxtseo-shared@5.3.2:
-    resolution: {integrity: sha512-0A+oVQJUvcNKFqB/lzhG5+YhthZmrpzRv2os0LRsPbGNXwj1w3qUbmd0d7SRIP80cto1lKhZfSNZ/HxoCsbI4A==}
+  nuxtseo-shared@5.3.3:
+    resolution: {integrity: sha512-l9iyJh6lFVn4+B7Vb05NjJXs+1vAi0bJIe0Zfu69uoEOPB9MxpmwuNtM3MEzYgCZFLcc43oTMC9uAjByCXbcsA==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0
       nuxt: ^3.16.0 || ^4.0.0
@@ -8512,8 +8507,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@5.3.3:
-    resolution: {integrity: sha512-l9iyJh6lFVn4+B7Vb05NjJXs+1vAi0bJIe0Zfu69uoEOPB9MxpmwuNtM3MEzYgCZFLcc43oTMC9uAjByCXbcsA==}
+  nuxtseo-shared@5.3.4:
+    resolution: {integrity: sha512-y4SYS67WaE8njciQ+orQWi72WYSP78CC9CvkSUIFQY9a4hrcaPVnW/k7UBlLMhrLk8dnFHyFz9OGdlTaRqybJw==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0
       nuxt: ^3.16.0 || ^4.0.0
@@ -12442,18 +12437,6 @@ snapshots:
     dependencies:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19)))
       execa: 8.0.1
-      vite: 8.1.5(@types/node@26.1.1)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@nuxt/devtools-kit@4.0.0-alpha.3(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19)))(vite@8.1.5)':
-    dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19)))
-      tinyexec: 1.2.4
       vite: 8.1.5(@types/node@26.1.1)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - magic-string
@@ -19972,7 +19955,7 @@ snapshots:
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19)))
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.2(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19)))(vue@3.5.40(typescript@6.0.3))
-      nuxtseo-shared: 5.3.2(cf36c37d578e24d79613e4e8cde3d40a)
+      nuxtseo-shared: 5.3.4(cf36c37d578e24d79613e4e8cde3d40a)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.2(vue@3.5.40(typescript@6.0.3))
@@ -20233,10 +20216,10 @@ snapshots:
       - yup
       - zod
 
-  nuxtseo-shared@5.3.2(cf36c37d578e24d79613e4e8cde3d40a):
+  nuxtseo-shared@5.3.3(cf36c37d578e24d79613e4e8cde3d40a):
     dependencies:
       '@clack/prompts': 1.7.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19)))(vite@8.1.5)
+      '@nuxt/devtools-kit': 4.0.0-alpha.7(magicast@0.5.3)(vite@8.1.5)
       '@nuxt/kit': 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19)))
       '@nuxt/schema': 4.5.0
       birpc: 4.0.0
@@ -20263,7 +20246,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.3(cf36c37d578e24d79613e4e8cde3d40a):
+  nuxtseo-shared@5.3.4(cf36c37d578e24d79613e4e8cde3d40a):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magicast@0.5.3)(vite@8.1.5)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -149,7 +149,7 @@ catalog:
   nuxt: ^4.5.0
   nuxt-site-config: ^4.1.2
   nuxtseo-layer-devtools: ^5.3.3
-  nuxtseo-shared: ^5.3.3
+  nuxtseo-shared: ^5.3.4
   nypm: ^0.6.8
   object-identity: ^0.2.3
   ofetch: ^1.5.1

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -1,10 +1,6 @@
-import { createConsola } from 'consola'
 import { colorize } from 'consola/utils'
+import { createModuleLogger } from 'nuxtseo-shared/utils'
 
-export const logger = createConsola({
-  defaults: {
-    tag: '@nuxtjs/og-image',
-  },
-})
+export const logger = createModuleLogger('@nuxtjs/og-image')
 
 export const gray = (s: string) => colorize('gray', s)

--- a/src/runtime/server/util/logger.ts
+++ b/src/runtime/server/util/logger.ts
@@ -1,7 +1,3 @@
-import { createConsola } from 'consola'
+import { createModuleLogger } from 'nuxtseo-shared/utils'
 
-export const logger = createConsola({
-  defaults: {
-    tag: 'Nuxt OG Image',
-  },
-})
+export const logger = createModuleLogger('Nuxt OG Image')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Bumps `nuxtseo-shared` to `^5.3.4` and switches the two runtime consola logger instances over to its new `createModuleLogger` helper.

- `src/runtime/logger.ts` (tag `@nuxtjs/og-image`) and `src/runtime/server/util/logger.ts` (tag `Nuxt OG Image`) now build their consola instance via `createModuleLogger(tag)` from `nuxtseo-shared/utils` instead of a bare `createConsola({...})` call. Tags and default log level (3, matching the current default) are unchanged.
- `module.ts`'s `logger.level = (config.debug || nuxt.options.debug) ? 4 : 3` line is left as-is. It doesn't use `@nuxt/kit`'s `useLogger`, it mutates the module's own shared `logger` singleton (imported across ~10 build-time files), so swapping to `useModuleLogger` from `nuxtseo-shared/kit` would create a second, disconnected logger instance and change behavior.
- No `minimumReleaseAgeExclude` change: the existing entry is a bare `nuxtseo-shared` line (no version), not a versioned entry, so there's nothing to append.

No public API or behavior changes. Verified with `pnpm lint`, `pnpm typecheck`, `pnpm build`, and the full `pnpm test` suite, all green.