### PR TITLE
fix: remove obsolete extreme value clamp

### DIFF
--- a/src/build/css/css-utils.ts
+++ b/src/build/css/css-utils.ts
@@ -29,7 +29,6 @@ const RE_QUOTES = /^['"]|['"]$/g
 const RE_WIDTH_VALUE = /width:([^;}]+)/
 const RE_CALC_VAR_MULTIPLY = /calc\(var\((--[\w-]+)\)\s*\*\s*([\d.]+)\)/
 const RE_NUMERIC_WITH_UNIT = /([\d.]+)(rem|px|em|%)/
-const RE_EXTREME_VALUE = /^(-?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)(px|rem|em|%)$/i
 const RE_CSS_KEYWORD = /^(?:initial|inherit|unset|revert|revert-layer)$/
 const RE_UNRESOLVED_VAR = /var\((--[\w-]+)/g
 const RE_INVALID_CALC = /calc\(\s*[*/]/
@@ -869,22 +868,6 @@ export function convertLogicalProperties(styles: Record<string, string>): void {
   }
 }
 
-/**
- * Clamp extreme CSS values that cause renderer issues.
- * Lightning CSS may evaluate calc(infinity * 1px) to either 3.40282e+38px
- * or 2147483647px, both of which hang Takumi.
- */
-function clampExtremeValues(styles: Record<string, string>): void {
-  for (const [prop, value] of Object.entries(styles)) {
-    const match = value.match(RE_EXTREME_VALUE)
-    if (match?.[1] && match?.[2]) {
-      const num = Number.parseFloat(match[1])
-      if (Math.abs(num) > 9999)
-        styles[prop] = `9999${match[2]}`
-    }
-  }
-}
-
 function stripGradientColorSpace(value: string): string {
   return value.replace(GRADIENT_COLOR_SPACE_RE, '')
 }
@@ -960,7 +943,6 @@ export async function postProcessStyles(
 
   convertIndividualTransforms(styles)
   convertLogicalProperties(styles)
-  clampExtremeValues(styles)
 
   return Object.keys(styles).length ? styles : null
 }

--- a/test/unit/tw4-class-resolution.test.ts
+++ b/test/unit/tw4-class-resolution.test.ts
@@ -221,16 +221,25 @@ describe('css-utils', () => {
   })
 
   describe('postProcessStyles', () => {
-    it('normalizes calc(infinity * 1px) via Lightning CSS', async () => {
-      const raw = { 'border-radius': 'calc(infinity * 1px)' }
+    it.each([
+      'calc(infinity * 1px)',
+      'calc(infinity)',
+    ])('normalizes %s without clamping the result', async (value) => {
+      const raw = { 'border-radius': value }
       const result = await postProcessStyles(raw, new Map())
-      expect(result?.['border-radius']).toBe('9999px')
+      const radius = result?.['border-radius']
+      expect(radius).not.toContain('calc(')
+      expect(Number.parseFloat(radius!)).toBeGreaterThan(9999)
     })
 
-    it('normalizes calc(infinity) via Lightning CSS', async () => {
-      const raw = { 'border-radius': 'calc(infinity)' }
+    it.each([
+      '2147483647px',
+      '3.40282e+38px',
+      '-2147483647px',
+    ])('preserves renderer-safe extreme value %s', async (value) => {
+      const raw = { width: value }
       const result = await postProcessStyles(raw, new Map())
-      expect(result?.['border-radius']).toBe('9999px')
+      expect(result?.width).toBe(value)
     })
 
     it('passes through opacity (normalization handled by simplifyCss)', async () => {
@@ -706,10 +715,12 @@ describe('tw4 class resolution', () => {
       }
     })
 
-    it('normalizes rounded-full calc(infinity) via Lightning CSS', async () => {
+    it('normalizes rounded-full calc(infinity) without clamping it', async () => {
       const result = await resolve(['rounded-full'])
       expect(result['rounded-full'], 'rounded-full should resolve').toBeDefined()
-      expect(result['rounded-full']?.['border-radius']).toBe('9999px')
+      const radius = result['rounded-full']?.['border-radius']
+      expect(radius).not.toContain('calc(')
+      expect(Number.parseFloat(radius!)).toBeGreaterThan(9999)
     })
 
     it('resolves tracking utilities', async () => {

--- a/test/unit/uno-class-resolution.test.ts
+++ b/test/unit/uno-class-resolution.test.ts
@@ -369,7 +369,9 @@ describe('unoCSS preset-wind4 class resolution', () => {
       clearUnoCache()
       const result = await resolve(['rounded-full'])
       expect(result['rounded-full']).toBeDefined()
-      expect(result['rounded-full']['border-radius']).toBe('9999px')
+      const radius = result['rounded-full']['border-radius']
+      expect(radius).not.toContain('calc(')
+      expect(Number.parseFloat(radius)).toBeGreaterThan(9999)
     })
 
     it('resolves positioning utilities', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #644

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Lightning CSS turns `calc(infinity)` into a large finite number. The old post-processing then clamped any value above `9999`, including negative values, even though supported Satori and Takumi versions render those values safely. Remove the clamp and keep calc simplification for renderers that reject raw calc expressions.