### PR TITLE
fix: wrap plugin entrypoints

### DIFF
--- a/src/runtime/app/plugins/og-image-canonical-urls.server.ts
+++ b/src/runtime/app/plugins/og-image-canonical-urls.server.ts
@@ -1,1 +1,4 @@
-export { ogImageCanonicalUrls as default } from '../utils/plugins'
+import { defineNuxtPlugin } from '#app'
+import { ogImageCanonicalUrls } from '../utils/plugins'
+
+export default defineNuxtPlugin(nuxtApp => ogImageCanonicalUrls(nuxtApp))

--- a/src/runtime/app/plugins/route-rule-og-image.server.ts
+++ b/src/runtime/app/plugins/route-rule-og-image.server.ts
@@ -1,1 +1,4 @@
-export { routeRuleOgImage as default } from '../utils/plugins'
+import { defineNuxtPlugin } from '#app'
+import { routeRuleOgImage } from '../utils/plugins'
+
+export default defineNuxtPlugin(nuxtApp => routeRuleOgImage(nuxtApp))

--- a/test/unit/nuxt-plugin-wrappers.test.ts
+++ b/test/unit/nuxt-plugin-wrappers.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'pathe'
+import { parseAndWalk } from 'oxc-walker'
+import { describe, expect, it } from 'vitest'
+
+const pluginPaths = [
+  'og-image-canonical-urls.server.ts',
+  'route-rule-og-image.server.ts',
+]
+
+describe('nuxt plugin entrypoints', () => {
+  it.each(pluginPaths)('wraps %s with defineNuxtPlugin', (pluginPath) => {
+    const path = join(__dirname, '../../src/runtime/app/plugins', pluginPath)
+    const code = readFileSync(path, 'utf8')
+    let wrapped = false
+
+    parseAndWalk(code, path, (node) => {
+      if (
+        node.type === 'CallExpression'
+        && node.callee.type === 'Identifier'
+        && node.callee.name === 'defineNuxtPlugin'
+      ) {
+        wrapped = true
+      }
+    })
+
+    expect(wrapped).toBe(true)
+  })
+})

--- a/test/unit/nuxt-plugin-wrappers.test.ts
+++ b/test/unit/nuxt-plugin-wrappers.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
-import { join } from 'pathe'
 import { parseAndWalk } from 'oxc-walker'
+import { join } from 'pathe'
 import { describe, expect, it } from 'vitest'
 
 const pluginPaths = [


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #649

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt 4.5 reports `NUXT_B2007` because the two server plugin entrypoints re-export wrapped functions from another file. Wrap each entrypoint locally with `defineNuxtPlugin` and cover both files with a regression test matching Nuxt's static scan.