### PR TITLE
fix(fonts): suppress Takumi fallback warning

### DIFF
--- a/src/build/fontless.ts
+++ b/src/build/fontless.ts
@@ -32,6 +32,7 @@ export interface ProcessFontsOptions {
   fontRequirements: FontRequirementsState
   convertedWoff2Files: Map<string, string>
   fontSubsets?: string[]
+  /** Warn when no static fallback is available. Satori requires one; Takumi can use WOFF2. */
   warnOnMissingStaticFonts?: boolean
 }
 
@@ -222,6 +223,7 @@ async function downloadStaticFonts(options: {
   nuxt: Nuxt
   logger: ConsolaInstance
   fontSubsets?: string[]
+  warnOnMissingStaticFonts?: boolean
 }): Promise<DownloadedFont[]> {
   if (options.families.length === 0)
     return []
@@ -310,7 +312,7 @@ async function downloadStaticFonts(options: {
     }
   }
 
-  if (unresolvedFamilies.length > 0) {
+  if (options.warnOnMissingStaticFonts !== false && unresolvedFamilies.length > 0) {
     const providerList = fontlessCtx.providerNames.join(', ') || 'none'
     const localFonts = await listLocalPublicFontFiles(options.nuxt).catch(() => [] as string[])
     const matchedLocal = unresolvedFamilies
@@ -501,6 +503,7 @@ export async function convertWoff2ToTtf(options: ProcessFontsOptions): Promise<v
       nuxt,
       logger,
       fontSubsets,
+      warnOnMissingStaticFonts,
     })
 
     for (const font of downloaded) {

--- a/test/unit/resolve-og-fonts.test.ts
+++ b/test/unit/resolve-og-fonts.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getStaticInterFonts } from '../../src/build/fonts'
 
@@ -10,7 +13,7 @@ vi.mock('../../src/build/fonts', async (importOriginal) => {
   }
 })
 
-const { resolveOgImageFonts } = await import('../../src/build/fontless')
+const { convertWoff2ToTtf, resolveOgImageFonts } = await import('../../src/build/fontless')
 const { parseFontsFromTemplate } = await import('../../src/build/fonts')
 
 const baseFontReqs = { weights: [400, 700], styles: ['normal' as const], families: [] as string[], hasDynamicBindings: false, componentMap: {} }
@@ -90,5 +93,52 @@ describe('resolveOgImageFonts', () => {
     const opts = createOpts({ fontRequirements: { ...baseFontReqs, hasDynamicBindings: true } })
     const result = await resolveOgImageFonts(opts)
     expect(result).toEqual([fonts400, fonts300])
+  })
+})
+
+describe('convertWoff2ToTtf', () => {
+  it('suppresses unresolved fallback warnings when static fonts are optional', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'og-image-fontless-'))
+    const resolver = vi.fn().mockResolvedValue(undefined)
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() } as any
+    const nuxt = {
+      options: {
+        buildDir: join(rootDir, '.nuxt'),
+        rootDir,
+        fonts: {
+          families: [
+            { name: 'Raleway Variable', provider: 'npm', global: true },
+          ],
+        },
+      },
+      _ogImageFontless: {
+        resolver,
+        renderedFontURLs: new Map(),
+        providerNames: ['google', 'bunny', 'fontsource'],
+      },
+    } as any
+
+    vi.mocked(parseFontsFromTemplate).mockResolvedValueOnce([
+      { family: 'Raleway Variable', src: '/_fonts/raleway-variable.woff2', weight: 400, style: 'normal' },
+    ])
+
+    try {
+      await convertWoff2ToTtf({
+        nuxt,
+        logger,
+        fontRequirements: baseFontReqs,
+        convertedWoff2Files: new Map(),
+        warnOnMissingStaticFonts: false,
+      })
+
+      expect(resolver).toHaveBeenCalledWith(
+        'Raleway Variable',
+        expect.objectContaining({ name: 'Raleway Variable' }),
+      )
+      expect(logger.warn).not.toHaveBeenCalled()
+    }
+    finally {
+      rmSync(rootDir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #651

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Takumi-only builds still emitted `Could not resolve font` when an `npm` provider family such as `Raleway Variable` had no static fallback. `downloadStaticFonts()` now honors `warnOnMissingStaticFonts`, which both module call sites set from `hasSatoriRenderer()`, so Satori keeps the warning and Takumi-only builds stay quiet.