### PR TITLE
refactor(cli)!: move CLI to standalone package

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,5 @@
+# Context
+
+## Glossary
+
+**CLI support**: `nuxt-og-image-cli` imports the `nuxt-og-image/cli-support` subpath to access migrations and the packaged community template directory. Its interface lives in `src/cli-support.ts`.

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import('../dist/cli.mjs')

--- a/build.config.ts
+++ b/build.config.ts
@@ -7,7 +7,7 @@ export default defineBuildConfig({
   },
   entries: [
     { input: 'src/content', name: 'content' },
-    { input: 'src/cli', name: 'cli' },
+    { input: 'src/cli-support', name: 'cli-support' },
   ],
   externals: [
     'h3',

--- a/docs/content/0.getting-started/1.installation.md
+++ b/docs/content/0.getting-started/1.installation.md
@@ -50,17 +50,17 @@ to provide a Site URL.
 
 ## Install a Renderer
 
-Use the CLI to install renderer dependencies:
+The CLI ships as a separate package, so its dependencies are not installed with the Nuxt module. Run it with `npx` to install renderer dependencies:
 
 ```bash
 # Takumi (recommended) - 2-10x faster with full CSS support
-npx nuxt-og-image enable takumi
+npx nuxt-og-image-cli enable takumi
 
 # Satori - SVG-based renderer
-npx nuxt-og-image enable satori
+npx nuxt-og-image-cli enable satori
 
 # Browser - full CSS via screenshots (prerender only)
-npx nuxt-og-image enable browser
+npx nuxt-og-image-cli enable browser
 ```
 
 For edge runtimes (Cloudflare, Vercel Edge), the CLI auto-detects your deployment target and installs Wasm variants. You can also pass `--edge` explicitly.
@@ -74,5 +74,5 @@ All renderers support [Tailwind CSS](https://tailwindcss.com), [UnoCSS](https://
 You've successfully installed Nuxt OG Image. Here's the recommended reading path:
 
 1. **[Getting Familiar with Nuxt OG Image](/docs/og-image/getting-started/getting-familiar-with-nuxt-og-image)** - Walk through building your first OG image template
-2. **[CLI](/docs/og-image/guides/cli)** - Scaffold a starter component with `npx nuxt-og-image create`, auto-detecting your CSS framework and renderer
+2. **[CLI](/docs/og-image/guides/cli)** - Scaffold a starter component with `npx nuxt-og-image-cli create`, auto-detecting your CSS framework and renderer
 3. **[Renderers](/docs/og-image/renderers)** - Compare Takumi, Satori, and Browser

--- a/docs/content/0.getting-started/5.getting-familiar-with-nuxt-og-image.md
+++ b/docs/content/0.getting-started/5.getting-familiar-with-nuxt-og-image.md
@@ -78,7 +78,7 @@ Going further, we can even try using one of the other community templates availa
 Nuxt DevTools.
 
 ::tip
-Community templates are for development only. Before deploying, eject them with `npx nuxt-og-image eject <template>`{lang="html"} or create your own.
+Community templates are for development only. Before deploying, eject them with `npx nuxt-og-image-cli eject <template>`{lang="html"} or create your own.
 ::
 
 ```vue [pages/index.vue]
@@ -106,7 +106,7 @@ they will always be limited in what you can do with them.
 For production builds, you **must** eject any community template you're using. The easiest way is with the CLI:
 
 ```bash
-npx nuxt-og-image eject SimpleBlog
+npx nuxt-og-image-cli eject SimpleBlog
 ```
 
 Or copy and paste the template manually from the `Community` tab in Nuxt DevTools or [GitHub](https://github.com/nuxt-modules/og-image/tree/main/src/runtime/app/components/Templates/Community).

--- a/docs/content/3.guides/13.community-templates.md
+++ b/docs/content/3.guides/13.community-templates.md
@@ -19,7 +19,7 @@ Use this guide only when you are using a named community template such as `NuxtS
 Community templates are only available in development mode. To use them in production, you must eject them to your project:
 
 ```bash
-npx nuxt-og-image eject NuxtSeo
+npx nuxt-og-image-cli eject NuxtSeo
 ```
 
 This copies the template to `components/OgImage/NuxtSeo.vue` (or `app/components/OgImage/` for Nuxt v4).
@@ -27,7 +27,7 @@ This copies the template to `components/OgImage/NuxtSeo.vue` (or `app/components
 You can list all available templates:
 
 ```bash
-npx nuxt-og-image list
+npx nuxt-og-image-cli list
 ```
 
 Alternatively, use the **Eject** button in Nuxt DevTools under the OG Image Community tab.

--- a/docs/content/3.guides/17.cli.md
+++ b/docs/content/3.guides/17.cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: Use the nuxt-og-image CLI to scaffold, manage, and migrate OG image components.
+description: Use nuxt-og-image-cli to scaffold, manage, and migrate OG image components.
 relatedPages:
   - path: /docs/og-image/getting-started/installation
     title: Install Nuxt OG Image
@@ -10,10 +10,17 @@ relatedPages:
     title: Security
 ---
 
-The `nuxt-og-image` CLI provides commands for scaffolding components, switching renderers, managing templates, and migrating between versions.
+The `nuxt-og-image-cli` package contains the CLI. Run a command without installing it:
 
 ```bash
-npx nuxt-og-image --help
+npx nuxt-og-image-cli --help
+```
+
+For regular use, install it as a development dependency. The installed executable remains `nuxt-og-image`:
+
+```bash
+pnpm add -D nuxt-og-image-cli
+pnpm exec nuxt-og-image --help
 ```
 
 ## `create`
@@ -21,7 +28,7 @@ npx nuxt-og-image --help
 Scaffold a new OG image component with a starter template.
 
 ```bash
-npx nuxt-og-image create [name] [--renderer <renderer>] [--path <dir>]
+npx nuxt-og-image-cli create [name] [--renderer <renderer>] [--path <dir>]
 ```
 
 The command auto-detects your CSS framework (Tailwind CSS, [UnoCSS](https://unocss.dev), or plain CSS) and generates an appropriate template. The renderer is inferred from existing components or installed packages when `--renderer` is omitted.
@@ -39,16 +46,16 @@ After creating the component, you'll be prompted to insert `defineOgImage()`{lan
 
 ```bash
 # Interactive - prompts for name and renderer
-npx nuxt-og-image create
+npx nuxt-og-image-cli create
 
 # Create a component with inferred renderer
-npx nuxt-og-image create BlogPost
+npx nuxt-og-image-cli create BlogPost
 
 # Specify renderer explicitly
-npx nuxt-og-image create BlogPost --renderer satori
+npx nuxt-og-image-cli create BlogPost --renderer satori
 
 # Custom output path
-npx nuxt-og-image create BlogPost --path components/custom
+npx nuxt-og-image-cli create BlogPost --path components/custom
 ```
 
 ## `switch`
@@ -56,7 +63,7 @@ npx nuxt-og-image create BlogPost --path components/custom
 Migrate OG image components from one renderer to another. Renames file suffixes, installs the target renderer's dependencies, and removes the old renderer's dependencies when no components remain using it.
 
 ```bash
-npx nuxt-og-image switch [--from <renderer>] [--to <renderer>] [--dry-run] [--yes]
+npx nuxt-og-image-cli switch [--from <renderer>] [--to <renderer>] [--dry-run] [--yes]
 ```
 
 ### Options
@@ -72,16 +79,16 @@ npx nuxt-og-image switch [--from <renderer>] [--to <renderer>] [--dry-run] [--ye
 
 ```bash
 # Interactive - prompts for source and target
-npx nuxt-og-image switch
+npx nuxt-og-image-cli switch
 
 # Migrate all satori components to takumi
-npx nuxt-og-image switch --from satori --to takumi
+npx nuxt-og-image-cli switch --from satori --to takumi
 
 # Preview what would change
-npx nuxt-og-image switch --from satori --to takumi --dry-run
+npx nuxt-og-image-cli switch --from satori --to takumi --dry-run
 
 # Non-interactive (CI)
-npx nuxt-og-image switch --from satori --to takumi --yes
+npx nuxt-og-image-cli switch --from satori --to takumi --yes
 ```
 
 ## `enable`
@@ -89,7 +96,7 @@ npx nuxt-og-image switch --from satori --to takumi --yes
 Install dependencies for a specific renderer.
 
 ```bash
-npx nuxt-og-image enable <renderer> [--edge]
+npx nuxt-og-image-cli enable <renderer> [--edge]
 ```
 
 ### Options
@@ -102,10 +109,10 @@ npx nuxt-og-image enable <renderer> [--edge]
 
 ```bash
 # Install takumi dependencies
-npx nuxt-og-image enable takumi
+npx nuxt-og-image-cli enable takumi
 
 # Install satori dependencies for edge runtime
-npx nuxt-og-image enable satori --edge
+npx nuxt-og-image-cli enable satori --edge
 ```
 
 ## `list`
@@ -113,7 +120,7 @@ npx nuxt-og-image enable satori --edge
 List available community templates.
 
 ```bash
-npx nuxt-og-image list
+npx nuxt-og-image-cli list
 ```
 
 ## `eject`
@@ -121,7 +128,7 @@ npx nuxt-og-image list
 Copy a community template into your project for customization. Community templates are only available in development; you must eject before production builds.
 
 ```bash
-npx nuxt-og-image eject <name>
+npx nuxt-og-image-cli eject <name>
 ```
 
 The template is copied to `components/OgImage/` (or `app/components/OgImage/` for Nuxt v4).
@@ -129,8 +136,8 @@ The template is copied to `components/OgImage/` (or `app/components/OgImage/` fo
 ### Examples
 
 ```bash
-npx nuxt-og-image eject NuxtSeo
-npx nuxt-og-image eject BlogPost
+npx nuxt-og-image-cli eject NuxtSeo
+npx nuxt-og-image-cli eject BlogPost
 ```
 
 ## `generate-secret`
@@ -138,7 +145,7 @@ npx nuxt-og-image eject BlogPost
 Generate a cryptographically secure signing secret for URL tamper protection.
 
 ```bash
-npx nuxt-og-image generate-secret
+npx nuxt-og-image-cli generate-secret
 ```
 
 This generates a 64-character hex string that should be set as the `NUXT_OG_IMAGE_SECRET` environment variable. See the [Security Guide](/docs/og-image/guides/security#url-signing) for details.
@@ -148,7 +155,7 @@ This generates a 64-character hex string that should be set as the `NUXT_OG_IMAG
 Automate migration from v5 to v6. See the [Migration Guide](/docs/og-image/migration-guide/v6) for details.
 
 ```bash
-npx nuxt-og-image migrate v6 [--dry-run] [--yes] [--renderer <renderer>]
+npx nuxt-og-image-cli migrate v6 [--dry-run] [--yes] [--renderer <renderer>]
 ```
 
 ### Options

--- a/docs/content/3.guides/18.security.md
+++ b/docs/content/3.guides/18.security.md
@@ -46,7 +46,7 @@ Any of these can still be overridden explicitly. Strict mode only changes the de
 The build will fail if you enable `strict` without a `secret`. Generate one with:
 
 ```bash
-npx nuxt-og-image generate-secret
+npx nuxt-og-image-cli generate-secret
 ```
 
 ## URL Signing
@@ -84,7 +84,7 @@ V7 will **require URL signing** whenever you enable runtime image generation.
 1. Generate a secret:
 
 ```bash
-npx nuxt-og-image generate-secret
+npx nuxt-og-image-cli generate-secret
 ```
 
 2. Set the environment variable:

--- a/docs/content/4.api/2.define-og-image-component.md
+++ b/docs/content/4.api/2.define-og-image-component.md
@@ -18,7 +18,7 @@ defineOgImageComponent('NuxtSeo', { title: 'Hello' })
 // After
 defineOgImage('NuxtSeo', { title: 'Hello' })
 ```
-Run `npx nuxt-og-image migrate v6` to auto-migrate.
+Run `npx nuxt-og-image-cli migrate v6` to auto-migrate.
 ::
 
 The `defineOgImageComponent()`{lang="ts"} composable allows you to define an og:image using a custom template for the current page

--- a/docs/content/4.api/3.config.md
+++ b/docs/content/4.api/3.config.md
@@ -217,7 +217,7 @@ See the [Browser Renderer](/docs/og-image/renderers/browser) guide for more deta
 
 Security limits for image generation. See the [Security Guide](/docs/og-image/guides/security) for full details.
 
-- **`secret`**: Signing secret for URL tamper protection. Runtime OG image URLs are signed by default; unsigned requests are rejected with `403`. Leave unset to auto-generate a per-build secret, set an explicit stable string for rolling/multi-instance deploys, or `false` to disable signing. Generate one with `npx nuxt-og-image generate-secret`. See the [Security Guide](/docs/og-image/guides/security#url-signing) for details.
+- **`secret`**: Signing secret for URL tamper protection. Runtime OG image URLs are signed by default; unsigned requests are rejected with `403`. Leave unset to auto-generate a per-build secret, set an explicit stable string for rolling/multi-instance deploys, or `false` to disable signing. Generate one with `npx nuxt-og-image-cli generate-secret`. See the [Security Guide](/docs/og-image/guides/security#url-signing) for details.
 - **`maxDimension`**: Maximum width or height in pixels. Default `2048`.
 - **`maxDpr`**: Maximum device pixel ratio (Takumi renderer). Default `2`.
 - **`renderTimeout`**: Milliseconds before the render is aborted with a `408` response. Default `15000`.

--- a/docs/content/6.migration-guide/v6.md
+++ b/docs/content/6.migration-guide/v6.md
@@ -16,10 +16,10 @@ Run the migration CLI to automate most changes:
 
 ```bash
 # Rename components and migrate API calls
-npx nuxt-og-image migrate v6
+npx nuxt-og-image-cli migrate v6
 
 # Preview changes without applying (dry run)
-npx nuxt-og-image migrate v6 --dry-run
+npx nuxt-og-image-cli migrate v6 --dry-run
 ```
 
 This will:
@@ -99,7 +99,7 @@ This change enables:
 The CLI migration command will rename your components automatically:
 
 ```bash
-npx nuxt-og-image migrate v6
+npx nuxt-og-image-cli migrate v6
 ```
 
 ### Multiple Renderers Per Component
@@ -126,10 +126,10 @@ See [PR #426](https://github.com/nuxt-modules/og-image/pull/426).
 
 ```bash
 # List available templates
-npx nuxt-og-image list
+npx nuxt-og-image-cli list
 
 # Eject a specific template
-npx nuxt-og-image eject NuxtSeo
+npx nuxt-og-image-cli eject NuxtSeo
 ```
 
 This copies the template to your `components/OgImage/` directory where it will be included in your build.

--- a/docs/content/7.releases/2.v6.md
+++ b/docs/content/7.releases/2.v6.md
@@ -28,7 +28,7 @@ See the full [migration guide](/docs/og-image/migration-guide/v6) for upgrade in
 **Quick migration:**
 
 ```bash
-npx nuxt-og-image migrate v6
+npx nuxt-og-image-cli migrate v6
 ```
 
 ## :icon{name="i-noto-rocket"} Features
@@ -104,7 +104,7 @@ components/OgImage/MyTemplate.satori.vue
 Run the migration CLI to rename automatically:
 
 ```bash
-npx nuxt-og-image migrate v6
+npx nuxt-og-image-cli migrate v6
 ```
 
 ### Community Templates Must Be Ejected
@@ -112,7 +112,7 @@ npx nuxt-og-image migrate v6
 [Community templates](/docs/og-image/guides/community-templates) (`NuxtSeo`, `SimpleBlog`, etc.) are no longer bundled in production. Eject them to your project before building. ([#426](https://github.com/nuxt-modules/og-image/pull/426))
 
 ```bash
-npx nuxt-og-image eject NuxtSeo
+npx nuxt-og-image-cli eject NuxtSeo
 ```
 
 Templates continue to work in development without ejecting.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
       "types": "./dist/types.d.mts",
       "import": "./dist/module.mjs"
     },
-    "./content": "./dist/content.mjs"
+    "./content": "./dist/content.mjs",
+    "./cli-support": {
+      "types": "./dist/cli-support.d.mts",
+      "import": "./dist/cli-support.mjs"
+    }
   },
   "main": "./dist/module.mjs",
   "typesVersions": {
@@ -34,14 +38,13 @@
       ],
       "content": [
         "./dist/content.d.mts"
+      ],
+      "cli-support": [
+        "./dist/cli-support.d.mts"
       ]
     }
   },
-  "bin": {
-    "nuxt-og-image": "./bin/cli.mjs"
-  },
   "files": [
-    "bin",
     "dist",
     "types/virtual.d.ts"
   ],
@@ -51,8 +54,9 @@
   "scripts": {
     "snapshots": "node --import jiti/register scripts/generate-template-snapshots.ts",
     "stub": "nuxt-build-module build --stub && nuxt-module-build prepare",
-    "build": "pnpm stub && nuxt-module-build build && pnpm run build:client",
+    "build": "pnpm stub && nuxt-module-build build && pnpm run build:client && pnpm run build:cli",
     "build:client": "node -e \"require('fs').cpSync('devtools','dist/devtools',{recursive:true})\"",
+    "build:cli": "pnpm --filter nuxt-og-image-cli build",
     "build:module": "nuxt-build-module build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -60,9 +64,9 @@
     "dev:build": "nuxt build playground",
     "prepack": "pnpm run build",
     "prepare:fixtures": "node scripts/prepare-fixtures.mjs",
-    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt prepare playground && nuxt prepare client && pnpm run prepare:fixtures && pnpm run build:client",
-    "release": "pnpm build && bumpp -x \"npx changelogen --output=CHANGELOG.md\"",
-    "typecheck": "pnpm stub && nuxt typecheck",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt prepare playground && nuxt prepare client && pnpm run prepare:fixtures && pnpm run build:client && pnpm run build:cli",
+    "release": "pnpm build && bumpp package.json packages/cli/package.json -x \"npx changelogen --output=CHANGELOG.md\"",
+    "typecheck": "pnpm stub && nuxt typecheck && pnpm --filter nuxt-og-image-cli typecheck",
     "test": "pnpm run prepare:fixtures && vitest",
     "test:run": "pnpm test -- --run && pnpm test:nuxt5",
     "test:nuxt5": "pnpm pack --out test/fixtures/nuxt5/nuxt-og-image.tgz && pnpm --dir test/fixtures/nuxt5 install --frozen-lockfile && pnpm --dir test/fixtures/nuxt5 test",
@@ -135,7 +139,6 @@
     }
   },
   "dependencies": {
-    "@clack/prompts": "catalog:",
     "@nuxt/kit": "catalog:",
     "@vue/compiler-sfc": "catalog:",
     "chrome-launcher": "catalog:",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,9 @@
+# Nuxt OG Image CLI
+
+Run Nuxt OG Image migrations and manage OG image components from the command line.
+
+```bash
+npx nuxt-og-image-cli --help
+```
+
+See the [CLI guide](https://nuxtseo.com/og-image/guides/cli) for every command.

--- a/packages/cli/bin/cli.mjs
+++ b/packages/cli/bin/cli.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/cli.mjs'

--- a/packages/cli/build.config.ts
+++ b/packages/cli/build.config.ts
@@ -1,0 +1,11 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  declaration: false,
+  entries: [
+    { input: 'src/cli', name: 'cli' },
+  ],
+  rollup: {
+    emitCJS: false,
+  },
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "nuxt-og-image-cli",
+  "type": "module",
+  "version": "6.7.6",
+  "description": "Command-line tools for Nuxt OG Image.",
+  "author": {
+    "website": "https://harlanzw.com",
+    "name": "Harlan Wilton",
+    "url": "harlan@harlanzw.com"
+  },
+  "license": "MIT",
+  "funding": "https://github.com/sponsors/harlan-zw",
+  "homepage": "https://nuxtseo.com/og-image/guides/cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nuxt-modules/og-image.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/nuxt-modules/og-image/issues"
+  },
+  "bin": {
+    "nuxt-og-image": "./bin/cli.mjs"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "unbuild",
+    "lint": "eslint .",
+    "prepack": "pnpm build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "nuxt-og-image": "workspace:^"
+  },
+  "dependencies": {
+    "@clack/prompts": "catalog:",
+    "@nuxt/kit": "catalog:",
+    "magicast": "catalog:",
+    "nypm": "catalog:",
+    "oxc-walker": "catalog:",
+    "pathe": "catalog:",
+    "tinyexec": "catalog:",
+    "ultrahtml": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "nuxt-og-image": "workspace:^",
+    "typescript": "catalog:",
+    "unbuild": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,18 +1,17 @@
 #!/usr/bin/env node
 import { randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import * as p from '@clack/prompts'
 import { loadNuxtConfig } from '@nuxt/kit'
+import { loadFile, writeFile } from 'magicast'
+import { migrateDefaultsComponent, migrateFontsConfig, resolveCommunityTemplateDir } from 'nuxt-og-image/cli-support'
 import { addDependency, detectPackageManager, removeDependency } from 'nypm'
 import { parseAndWalk } from 'oxc-walker'
 import { basename, dirname, join, relative, resolve } from 'pathe'
+import { exec } from 'tinyexec'
 import { ELEMENT_NODE, parse as parseHtml, walkSync } from 'ultrahtml'
-import { migrateDefaultsComponent, migrateFontsConfig } from './migrations/fonts'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-const communityDir = resolve(__dirname, 'runtime/app/components/Templates/Community')
+const communityDir = resolveCommunityTemplateDir()
 
 // Module-scope regex constants
 const RE_RENDERER_SUFFIX = /\.(satori|browser|takumi)\.vue$/
@@ -48,6 +47,23 @@ interface AstReplacement {
   start: number
   end: number
   text: string
+}
+
+interface CliOgImageConfig {
+  defaults?: {
+    component?: unknown
+    renderer?: unknown
+  }
+  fonts?: unknown
+  [key: string]: unknown
+}
+
+interface CliNuxtConfig {
+  modules?: Array<string | [string, ...unknown[]]>
+  nitro?: {
+    preset?: string
+  }
+  ogImage?: CliOgImageConfig
 }
 
 /**
@@ -282,7 +298,7 @@ function listTemplates() {
   )]
   p.intro('Community Templates')
   p.note(templates.map(t => `• ${t}`).join('\n'), 'Available')
-  p.log.info('Usage: npx nuxt-og-image eject <template-name>')
+  p.log.info('Usage: npx nuxt-og-image-cli eject <template-name>')
   p.outro('')
 }
 
@@ -398,7 +414,6 @@ async function removeDeprecatedConfigKeys(rootDir: string, keys: Array<{ key: st
   if (!configPath)
     return { removed: [], failed: keys.map(k => k.key) }
 
-  const { loadFile, writeFile } = await import('magicast')
   const mod = await loadFile(configPath)
   const config = mod.exports.default
   const ogImageConfig = config?.ogImage as any
@@ -478,20 +493,21 @@ async function checkNuxtConfig(rootDir: string): Promise<{
     hasNuxtFontsInPkg = !!(pkg.dependencies?.['@nuxt/fonts'] || pkg.devDependencies?.['@nuxt/fonts'])
   }
 
-  const config = await loadNuxtConfig({ cwd: rootDir }).catch((error: Error) => {
-    p.log.warn(`Could not inspect Nuxt config: ${error.message}`)
-    return null
-  })
+  const config: CliNuxtConfig | null = await loadNuxtConfig({ cwd: rootDir })
+    .then(config => config as CliNuxtConfig)
+    .catch((error: Error) => {
+      p.log.warn(`Could not inspect Nuxt config: ${error.message}`)
+      return null
+    })
   if (!config)
     return { hasDeprecatedFonts: false, hasNuxtFonts: hasNuxtFontsInPkg, hasDefaultsComponent: false, defaultComponentName: null, nitroPreset: null, deprecatedConfigKeys: [] }
 
-  const ogImageConfig = config.ogImage as any
+  const ogImageConfig = config.ogImage
   const hasDeprecatedFonts = !!ogImageConfig?.fonts
   const hasDefaultsComponent = !!ogImageConfig?.defaults?.component
-  const defaultComponentName = hasDefaultsComponent ? String(ogImageConfig.defaults.component) : null
+  const defaultComponentName = hasDefaultsComponent ? String(ogImageConfig?.defaults?.component) : null
   const modules = config.modules || []
-  // @ts-expect-error untyped
-  const hasNuxtFontsInConfig = modules.some((m: string | string[]) =>
+  const hasNuxtFontsInConfig = modules.some(m =>
     (typeof m === 'string' && m === '@nuxt/fonts')
     || (Array.isArray(m) && m[0] === '@nuxt/fonts'),
   )
@@ -576,7 +592,7 @@ async function checkMigrationNeeded(rootDir: string): Promise<MigrationCheck> {
   // Check config
   const configCheck = await checkNuxtConfig(rootDir)
   result.needsFontsMigration = configCheck.hasDeprecatedFonts
-  result.needsNuxtFonts = !configCheck.hasNuxtFonts
+  result.needsNuxtFonts = configCheck.hasDeprecatedFonts && !configCheck.hasNuxtFonts
   result.needsDefaultsComponentMigration = configCheck.hasDefaultsComponent
   result.defaultComponentName = configCheck.defaultComponentName
   // Exclude 'fonts' from deprecated keys since it's handled by needsFontsMigration
@@ -749,10 +765,12 @@ function migrateV6Components(
 
 // Detect deployment target from nuxt.config
 async function detectDeploymentTarget(rootDir: string): Promise<string | null> {
-  const config = await loadNuxtConfig({ cwd: rootDir }).catch((error: Error) => {
-    p.log.warn(`Could not detect deployment target: ${error.message}`)
-    return null
-  })
+  const config: CliNuxtConfig | null = await loadNuxtConfig({ cwd: rootDir })
+    .then(config => config as CliNuxtConfig)
+    .catch((error: Error) => {
+      p.log.warn(`Could not detect deployment target: ${error.message}`)
+      return null
+    })
   return config?.nitro?.preset || null
 }
 
@@ -795,12 +813,12 @@ async function installNuxtFonts(): Promise<void> {
   spinner.start('Adding @nuxt/fonts module...')
 
   // Use nuxi module add
-  const { exec } = await import('tinyexec')
-  try {
-    await exec('npx', ['nuxi', 'module', 'add', '@nuxt/fonts'], { nodeOptions: { cwd } })
+  const installed = await exec('npx', ['nuxi', 'module', 'add', '@nuxt/fonts'], { nodeOptions: { cwd } })
+    .then(() => true, () => false)
+  if (installed) {
     spinner.stop('@nuxt/fonts module added')
   }
-  catch {
+  else {
     spinner.stop('Failed to add @nuxt/fonts')
     p.log.warn('Run manually: npx nuxi module add @nuxt/fonts')
   }
@@ -825,19 +843,6 @@ async function runMigrate(args: string[]): Promise<void> {
 
   // Check what needs migration
   const migrationCheck = await checkMigrationNeeded(cwd)
-
-  // When nothing needs migration
-  const noComponentWork = !migrationCheck.needsComponentRename
-  const noFontsWork = !migrationCheck.needsFontsMigration && !migrationCheck.needsNuxtFonts
-  const noDefaultsWork = !migrationCheck.needsDefaultsComponentMigration
-  const noConfigWork = migrationCheck.deprecatedConfigKeys.length === 0
-  const noCommunityWork = migrationCheck.usedCommunityTemplates.length === 0
-
-  if (noComponentWork && noFontsWork && noDefaultsWork && noConfigWork && noCommunityWork) {
-    console.log('✓ All OG Image components already have renderer suffixes.')
-    p.outro('Done')
-    return
-  }
 
   // Show what will be migrated
   const tasks: string[] = []
@@ -972,7 +977,7 @@ async function runMigrate(args: string[]): Promise<void> {
       p.log.info(`Would remove defaults.component: '${migrationCheck.defaultComponentName}'`)
     }
     else {
-      const result = await migrateDefaultsComponent(cwd).catch((err) => {
+      const result = await migrateDefaultsComponent(cwd).catch((err: Error) => {
         p.log.warn(`Failed to migrate defaults.component: ${err.message}`)
         return { migrated: false, componentName: null, message: err.message }
       })
@@ -989,7 +994,7 @@ async function runMigrate(args: string[]): Promise<void> {
       p.log.info('Would migrate ogImage.fonts to @nuxt/fonts config')
     }
     else {
-      const result = await migrateFontsConfig(cwd).catch((err) => {
+      const result = await migrateFontsConfig(cwd).catch((err: Error) => {
         p.log.warn(`Failed to migrate fonts config: ${err.message}`)
         return { migrated: false, message: err.message }
       })
@@ -1048,7 +1053,7 @@ async function runMigrate(args: string[]): Promise<void> {
       else {
         p.log.info('Run manually before building for production:')
         for (const name of migrationCheck.usedCommunityTemplates) {
-          p.log.info(`  npx nuxt-og-image eject ${name}`)
+          p.log.info(`  npx nuxt-og-image-cli eject ${name}`)
         }
       }
     }
@@ -1081,12 +1086,12 @@ async function runMigrate(args: string[]): Promise<void> {
   else {
     const spinner = p.spinner()
     spinner.start('Running nuxt prepare to update types...')
-    const { exec } = await import('tinyexec')
-    try {
-      await exec('npx', ['nuxi', 'prepare'], { nodeOptions: { cwd } })
+    const prepared = await exec('npx', ['nuxi', 'prepare'], { nodeOptions: { cwd } })
+      .then(() => true, () => false)
+    if (prepared) {
       spinner.stop('Types updated')
     }
-    catch {
+    else {
       spinner.stop('Failed to run nuxt prepare')
       p.log.warn('Run manually: npx nuxt prepare')
     }
@@ -1307,12 +1312,12 @@ async function runSwitch(args: string[]): Promise<void> {
     // Run nuxt prepare
     const spinner = p.spinner()
     spinner.start('Running nuxt prepare to update types...')
-    const { exec } = await import('tinyexec')
-    try {
-      await exec('npx', ['nuxi', 'prepare'], { nodeOptions: { cwd } })
+    const prepared = await exec('npx', ['nuxi', 'prepare'], { nodeOptions: { cwd } })
+      .then(() => true, () => false)
+    if (prepared) {
       spinner.stop('Types updated')
     }
-    catch {
+    else {
       spinner.stop('Failed to run nuxt prepare')
       p.log.warn('Run manually: npx nuxt prepare')
     }
@@ -1328,7 +1333,8 @@ function readPackageJson(cwd: string): Record<string, any> | null {
   try {
     return JSON.parse(readFileSync(pkgPath, 'utf-8'))
   }
-  catch {
+  catch (error) {
+    p.log.warn(`Could not parse ${pkgPath}: ${error instanceof Error ? error.message : String(error)}`)
     return null
   }
 }
@@ -1726,7 +1732,7 @@ else if (command === 'list') {
 else if (command === 'migrate') {
   const version = args[1]
   if (version !== 'v6') {
-    p.log.error('Usage: npx nuxt-og-image migrate v6 [--dry-run] [--yes] [--renderer <satori|browser|takumi>]')
+    p.log.error('Usage: npx nuxt-og-image-cli migrate v6 [--dry-run] [--yes] [--renderer <satori|browser|takumi>]')
     process.exit(1)
   }
   runMigrate(args)
@@ -1740,7 +1746,7 @@ else if (command === 'generate-secret') {
 else if (command === 'enable') {
   const renderer = args[1]
   if (!renderer) {
-    p.log.error('Usage: npx nuxt-og-image enable <renderer> [--edge]')
+    p.log.error('Usage: npx nuxt-og-image-cli enable <renderer> [--edge]')
     p.log.info(`Available: ${RENDERERS.map(r => r.name).join(', ')}`)
     process.exit(1)
   }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { join } from 'pathe'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const cliPath = join(__dirname, '../../dist/cli.mjs')
+const cliPath = join(__dirname, '../dist/cli.mjs')
 const tmpDir = join(__dirname, '../.tmp-cli-test')
 
 function runCli(args: string, cwd = tmpDir) {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["build.config.ts", "src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ catalogs:
     '@takumi-rs/wasm-v1':
       specifier: npm:@takumi-rs/wasm@1.8.7
       version: 1.8.7
+    '@types/node':
+      specifier: ^26.0.0
+      version: 26.1.2
     '@unocss/config':
       specifier: ^66.7.5
       version: 66.7.5
@@ -318,9 +321,6 @@ importers:
 
   .:
     dependencies:
-      '@clack/prompts':
-        specifier: 'catalog:'
-        version: 1.7.0
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))
@@ -625,6 +625,52 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+
+  packages/cli:
+    dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.7.0
+      '@nuxt/kit':
+        specifier: 'catalog:'
+        version: 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))
+      magicast:
+        specifier: 'catalog:'
+        version: 0.5.4
+      nypm:
+        specifier: 'catalog:'
+        version: 0.6.9
+      oxc-walker:
+        specifier: 'catalog:'
+        version: 1.1.1(@oxc-project/types@0.142.0)(oxc-parser@0.142.0)(rolldown@1.2.1)
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
+      tinyexec:
+        specifier: 'catalog:'
+        version: 1.3.0
+      ultrahtml:
+        specifier: 'catalog:'
+        version: 1.7.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.2
+      eslint:
+        specifier: 'catalog:'
+        version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      nuxt-og-image:
+        specifier: workspace:^
+        version: link:../..
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.102.0)(typescript@6.0.3)(vue-sfc-transformer@0.2.5(@volar/typescript@2.4.28(typescript@6.0.3))(@vue/compiler-core@3.5.40)(@vue/language-core@3.3.9)(esbuild@0.28.1)(rolldown@1.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
 
   playground:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 catalogMode: prefer
 cleanupUnusedCatalogs: true
+includeWorkspaceRoot: true
 minimumReleaseAgeExclude:
   - nuxt-site-config@4.1.4
   - nuxt-site-config-kit@4.1.4
@@ -75,6 +76,7 @@ trustPolicyExclude:
   - '@nuxtjs/tailwindcss@7.0.0-beta.1'
   - tinyexec@1.2.2
 packages:
+  - packages/*
   - playground
   - '!examples/**'
 overrides:
@@ -117,6 +119,7 @@ catalog:
   '@takumi-rs/helpers-v1': npm:@takumi-rs/helpers@1.8.7
   '@takumi-rs/wasm': ^2.5.4
   '@takumi-rs/wasm-v1': npm:@takumi-rs/wasm@1.8.7
+  '@types/node': ^26.0.0
   '@unocss/config': ^66.7.5
   '@unocss/core': ^66.7.5
   '@unocss/nuxt': ^66.7.5

--- a/scripts/smoke-packed-install.mjs
+++ b/scripts/smoke-packed-install.mjs
@@ -115,6 +115,15 @@ async function packModule() {
   return join(tempRoot, tarball)
 }
 
+async function packCli() {
+  log('packing nuxt-og-image-cli')
+  await run(join(root, 'packages/cli'), 'pnpm', ['pack', '--json', '--pack-destination', tempRoot], { capture: true })
+  const files = await readdir(tempRoot)
+  const tarball = files.find(file => /^nuxt-og-image-cli-.+\.tgz$/.test(file))
+  assert(tarball, 'pnpm pack did not produce a nuxt-og-image-cli tarball')
+  return join(tempRoot, tarball)
+}
+
 async function getPackageManagerField(pm) {
   if (pm === 'pnpm')
     return rootPackage.packageManager
@@ -174,6 +183,9 @@ async function readInstalledPackage(appDir) {
 }
 
 function assertPackageMetadata(pkg) {
+  assert(!pkg.bin, 'nuxt-og-image should not publish a CLI binary')
+  assert(!pkg.dependencies?.['@clack/prompts'], 'nuxt-og-image should not depend on @clack/prompts')
+
   for (const name of ['culori', 'tinyglobby']) {
     assert(!pkg.dependencies?.[name], `${name} should not be a runtime dependency`)
     assert(!pkg.peerDependencies?.[name], `${name} should not be a peer dependency`)
@@ -189,10 +201,19 @@ function assertPackageMetadata(pkg) {
   assert(!pkg.peerDependencies?.lightningcss, 'lightningcss should not be a peer dependency')
 }
 
+function assertCliPackageMetadata(pkg) {
+  assert(pkg.name === 'nuxt-og-image-cli', 'expected the CLI package name')
+  assert(pkg.bin?.['nuxt-og-image'] === './bin/cli.mjs', 'expected the nuxt-og-image executable')
+  assert(pkg.dependencies?.['@clack/prompts'], 'CLI should depend on @clack/prompts')
+  assert(pkg.peerDependencies?.['nuxt-og-image'], 'CLI should declare nuxt-og-image as a peer')
+}
+
 async function assertNoDirectDistImports(appDir) {
   const distDir = join(appDir, 'node_modules/nuxt-og-image/dist')
   const files = (await listFiles(distDir))
     .filter(file => /\.(?:cjs|mjs|js)$/.test(file))
+
+  assert(!files.some(file => /[/\\]cli\.(?:cjs|mjs|js)$/.test(file)), 'nuxt-og-image should not publish CLI output')
 
   for (const file of files) {
     const source = await readFile(file, 'utf8')
@@ -221,6 +242,23 @@ async function assertNuxtOnlyApp(pm, tarball) {
   assertPackageMetadata(await readInstalledPackage(appDir))
   await assertNoDirectDistImports(appDir)
   await execPackage(pm, appDir, ['nuxi', 'prepare'], `${pm} nuxi prepare`)
+}
+
+async function assertCliApp(pm, moduleTarball, cliTarball) {
+  log(`checking CLI package with ${pm}`)
+  const appDir = await createApp(pm, `${pm}-cli`, {
+    'nuxt': '4.4.8',
+    'nuxt-og-image': `file:${moduleTarball}`,
+    'nuxt-og-image-cli': `file:${cliTarball}`,
+  }, `
+    export default defineNuxtConfig({
+      modules: ['nuxt-og-image'],
+    })
+  `)
+
+  await install(pm, appDir)
+  const pkg = JSON.parse(await readFile(join(appDir, 'node_modules/nuxt-og-image-cli/package.json'), 'utf8'))
+  assertCliPackageMetadata(pkg)
   await execPackage(pm, appDir, ['nuxt-og-image', 'migrate', 'v6', '--dry-run', '--yes'], `${pm} nuxt-og-image migrate`)
 }
 
@@ -276,10 +314,12 @@ async function assertUnoApp(pm, tarball) {
 }
 
 try {
-  const tarball = await packModule()
+  const moduleTarball = await packModule()
+  const cliTarball = await packCli()
   for (const pm of packageManagers) {
-    await assertNuxtOnlyApp(pm, tarball)
-    await assertUnoApp(pm, tarball)
+    await assertNuxtOnlyApp(pm, moduleTarball)
+    await assertCliApp(pm, moduleTarball, cliTarball)
+    await assertUnoApp(pm, moduleTarball)
   }
   log('passed')
 }

--- a/src/cli-support.ts
+++ b/src/cli-support.ts
@@ -1,0 +1,8 @@
+import { fileURLToPath } from 'node:url'
+import { migrateDefaultsComponent, migrateFontsConfig } from './migrations/fonts'
+
+export { migrateDefaultsComponent, migrateFontsConfig }
+
+export function resolveCommunityTemplateDir(): string {
+  return fileURLToPath(new URL('./runtime/app/components/Templates/Community', import.meta.url))
+}

--- a/src/migrations/warnings.ts
+++ b/src/migrations/warnings.ts
@@ -96,11 +96,11 @@ export function emitWarnings(): void {
     '',
     'Run the migration command to fix automatically:',
     '',
-    '  npx nuxt-og-image migrate v6',
+    '  npx nuxt-og-image-cli migrate v6',
     '',
     'Or preview changes first:',
     '',
-    '  npx nuxt-og-image migrate v6 --dry-run',
+    '  npx nuxt-og-image-cli migrate v6 --dry-run',
     '',
     `Migration guide: https://nuxtseo.com/og-image/migration-guide/v6`,
   ].join('\n')

--- a/src/module.ts
+++ b/src/module.ts
@@ -312,7 +312,7 @@ export interface ModuleOptions {
      * Leave unset to auto-generate a per-build secret (signing on by default).
      * Set an explicit, stable string for rolling or multi-instance deploys, or
      * `false` to disable signing entirely. Generate one with:
-     * `npx nuxt-og-image generate-secret`
+     * `npx nuxt-og-image-cli generate-secret`
      *
      * Required (explicitly) when `strict` is enabled.
      */
@@ -449,7 +449,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Strict still requires an explicit, stable secret — the auto value's
     // per-build rotation isn't a strong enough guarantee for strict mode.
     if (config.security?.strict && !signing.hasExplicit) {
-      throw new Error('[nuxt-og-image] `security.strict` requires a signing secret. Generate one with: npx nuxt-og-image generate-secret')
+      throw new Error('[nuxt-og-image] `security.strict` requires a signing secret. Generate one with: npx nuxt-og-image-cli generate-secret')
     }
 
     // Signing only happens at runtime, so the secret warnings are irrelevant for
@@ -465,7 +465,7 @@ export default defineNuxtModule<ModuleOptions>({
           'Attackers can craft image requests and poison the cache so your real OG image URLs serve attacker-controlled content (content spoofing).',
           'Signing will be required in v7 whenever runtime image generation is enabled. Leave signing on, or set an explicit secret:',
           '  NUXT_OG_IMAGE_SECRET=<secret>',
-          '  Generate one with: npx nuxt-og-image generate-secret',
+          '  Generate one with: npx nuxt-og-image-cli generate-secret',
         ].join('\n'))
       }
       else if (signing.generated) {
@@ -473,7 +473,7 @@ export default defineNuxtModule<ModuleOptions>({
           'OG image URLs are signed with an auto-generated secret that changes every build.',
           'This is fine for single-instance deploys; for rolling or multi-instance deploys set a stable secret:',
           '  NUXT_OG_IMAGE_SECRET=<secret>',
-          '  Generate one with: npx nuxt-og-image generate-secret',
+          '  Generate one with: npx nuxt-og-image-cli generate-secret',
         ].join('\n'))
       }
     })
@@ -1380,7 +1380,7 @@ export default defineNuxtModule<ModuleOptions>({
         else if (!nuxt.options._prepare) {
           const message = `OG Image components missing renderer suffix (.satori.vue, .browser.vue, .takumi.vue):\n${
             invalidComponents.map(c => `  ${c}`).join('\n')
-          }\n\nRun: npx nuxt-og-image migrate v6`
+          }\n\nRun: npx nuxt-og-image-cli migrate v6`
           throw new Error(message)
         }
       }

--- a/src/runtime/app/composables/defineOgImageComponent.ts
+++ b/src/runtime/app/composables/defineOgImageComponent.ts
@@ -13,7 +13,7 @@ export function defineOgImageComponent<T extends keyof OgImageComponents>(
   options: OgImageOptions = {},
 ): string[] {
   if (import.meta.dev) {
-    logger.warn('`defineOgImageComponent()` is deprecated. Use `defineOgImage()` instead. Run `npx nuxt-og-image migrate v6` to auto-migrate.')
+    logger.warn('`defineOgImageComponent()` is deprecated. Use `defineOgImage()` instead. Run `npx nuxt-og-image-cli migrate v6` to auto-migrate.')
   }
   return defineOgImage(component, props, options)
 }

--- a/src/runtime/app/composables/mock.ts
+++ b/src/runtime/app/composables/mock.ts
@@ -14,7 +14,7 @@ export function defineOgImage<T extends keyof OgImageComponents>(_component: T, 
  */
 export function defineOgImageComponent<T extends keyof OgImageComponents>(_component: T, _props: ReactiveComponentProps<OgImageComponents[T]> = {}, _options: OgImageOptions = {}) {
   if (import.meta.dev) {
-    logger.warn('`defineOgImageComponent()` is deprecated. Use `defineOgImage()` instead. Run `npx nuxt-og-image migrate v6` to auto-migrate.')
+    logger.warn('`defineOgImageComponent()` is deprecated. Use `defineOgImage()` instead. Run `npx nuxt-og-image-cli migrate v6` to auto-migrate.')
   }
 }
 

--- a/src/runtime/server/util/options.ts
+++ b/src/runtime/server/util/options.ts
@@ -195,7 +195,7 @@ export function normaliseOptions(_options: DefineOgImageInput): NormalisedOption
       else {
         throw createError({
           statusCode: 500,
-          message: `Community template "${resolved.pascalName}" must be ejected before production use. Run: npx nuxt-og-image eject ${resolved.pascalName}\n  No app components found — create one in components/OgImage/`,
+          message: `Community template "${resolved.pascalName}" must be ejected before production use. Run: npx nuxt-og-image-cli eject ${resolved.pascalName}\n  No app components found — create one in components/OgImage/`,
         })
       }
     }

--- a/test/unit/cli-package.test.ts
+++ b/test/unit/cli-package.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'pathe'
+import { describe, expect, it } from 'vitest'
+
+interface PackageManifest {
+  bin?: Record<string, string>
+  dependencies?: Record<string, string>
+  name?: string
+  peerDependencies?: Record<string, string>
+}
+
+function readPackageJson(path: string): PackageManifest {
+  return JSON.parse(readFileSync(path, 'utf8')) as PackageManifest
+}
+
+describe('cli package', () => {
+  const rootDir = join(__dirname, '../..')
+  const modulePackage = readPackageJson(join(rootDir, 'package.json'))
+  const cliPackage = readPackageJson(join(rootDir, 'packages/cli/package.json'))
+
+  it('keeps CLI metadata out of nuxt-og-image', () => {
+    expect(modulePackage.bin).toBeUndefined()
+    expect(modulePackage.dependencies?.['@clack/prompts']).toBeUndefined()
+  })
+
+  it('publishes the CLI from nuxt-og-image-cli', () => {
+    expect(cliPackage.name).toBe('nuxt-og-image-cli')
+    expect(cliPackage.bin).toEqual({ 'nuxt-og-image': './bin/cli.mjs' })
+    expect(cliPackage.peerDependencies?.['nuxt-og-image']).toBe('workspace:^')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [x] ⚠️ Breaking change

### 📚 Description

Moves the `nuxt-og-image` binary and command tests into the new `nuxt-og-image-cli` workspace package. The root package no longer ships CLI output or `@clack/prompts`; its unpacked tarball is about 100 KB smaller.

Install or run commands with `npx nuxt-og-image-cli`. Installed projects still expose the `nuxt-og-image` executable.

### ⚠️ Breaking Changes

`nuxt-og-image` no longer includes the CLI binary.

### 📝 Migration

Replace `npx nuxt-og-image <command>` with `npx nuxt-og-image-cli <command>`.