### PR TITLE
fix(types): require Nitro runtime config secret

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -248,8 +248,8 @@ declare module '#og-image-cache' {
           NitroApp: `_ogImageCacheBackendWarned?: boolean
 _ogImageIconsData?: OgImageIconsData`,
           NitroRuntimeConfig: `'nuxt-og-image': OgImageRuntimeConfig
-ogImage?: {
-  secret?: string
+ogImage: {
+  secret: string
 }`,
         },
         routeRules: 'ogImage?: false | OgImageOptions & Record<string, any>',

--- a/test/fixtures/basic/runtime-config-type-test.ts
+++ b/test/fixtures/basic/runtime-config-type-test.ts
@@ -1,0 +1,8 @@
+import type { NitroRuntimeConfig } from 'nitropack'
+import type { RuntimeConfig } from 'nuxt/schema'
+
+declare const nitroRuntimeConfig: NitroRuntimeConfig
+
+const nuxtRuntimeConfig: RuntimeConfig = nitroRuntimeConfig
+
+void nuxtRuntimeConfig

--- a/test/fixtures/basic/tsconfig.typetest.json
+++ b/test/fixtures/basic/tsconfig.typetest.json
@@ -3,6 +3,7 @@
   "include": [
     ".nuxt/nuxt.d.ts",
     ".nuxt/module/nuxt-og-image-components.d.ts",
+    "runtime-config-type-test.ts",
     "type-test.ts"
   ]
 }

--- a/test/unit/defineOgImage-types.test.ts
+++ b/test/unit/defineOgImage-types.test.ts
@@ -72,7 +72,7 @@ describe.skipIf(!fixtureReady)('generated component types (basic fixture)', () =
     expect(readFileSync(tsconfig, 'utf-8')).toContain('nuxt-og-image-components.d.ts')
   })
 
-  it('type-checks valid defineOgImage calls via vue-tsc', () => {
+  it('type-checks valid fixture usage via vue-tsc', () => {
     const result = execSync(
       `pnpm vue-tsc --noEmit --project ${TYPETEST_TSCONFIG}`,
       { encoding: 'utf-8', stdio: 'pipe', cwd: resolve(__dirname, '../..') },

--- a/test/unit/nitro-type-templates.test.ts
+++ b/test/unit/nitro-type-templates.test.ts
@@ -75,6 +75,12 @@ describe('nitro type templates', () => {
     expect(contents).toContain('declare module \'nitro/types\'')
   })
 
+  it('keeps the Nitro runtime secret compatible with Nuxt runtime config', () => {
+    const contents = renderAugmentations(nitroV2)
+
+    expect(contents.match(/ogImage: \{\n\s+secret: string\n\s+\}/g)).toHaveLength(2)
+  })
+
   it('keeps runtime types behind shared compatibility interfaces', () => {
     const runtimeTypes = readFileSync(join(import.meta.dirname, '../../src/runtime/types.ts'), 'utf8')
     const routeRulesPlugin = readFileSync(join(import.meta.dirname, '../../src/runtime/app/utils/plugins.ts'), 'utf8')


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #667

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Generated Nitro augmentations marked `ogImage.secret` optional even though module setup always populates it. Both properties are now required, keeping server-side `useRuntimeConfig()` assignable to Nuxt's `RuntimeConfig`. A vue-tsc fixture reproduces the exact `NitroRuntimeConfig` to `RuntimeConfig` assignment from #667.
