### PR TITLE
fix(devtools): send refresh broadcasts as events

### DIFF
--- a/src/build/devtools.ts
+++ b/src/build/devtools.ts
@@ -214,19 +214,19 @@ export function setupDevToolsUI(options: ModuleOptions, resolve: Resolver['resol
       if (isCssChange || normalizedPath.includes('uno.config')) {
         clearTimeout(cssRefreshTimer)
         cssRefreshTimer = setTimeout(() => {
-          safeBroadcast(() => rpc.broadcast.refresh())
+          safeBroadcast(() => rpc.broadcast.refresh.asEvent())
         }, 200)
         return
       }
 
       if ((e === 'change' || e.includes('link')) && (normalizedPath.startsWith('pages') || normalizedPath.startsWith('content'))) {
-        safeBroadcast(() => rpc.broadcast.refreshRouteData(normalizedPath))
+        safeBroadcast(() => rpc.broadcast.refreshRouteData.asEvent(normalizedPath))
       }
       if (options.componentDirs.some(dir => normalizedPath.includes(dir))) {
         if (e === 'change')
-          safeBroadcast(() => rpc.broadcast.refresh())
+          safeBroadcast(() => rpc.broadcast.refresh.asEvent())
         else
-          safeBroadcast(() => rpc.broadcast.refreshGlobalData())
+          safeBroadcast(() => rpc.broadcast.refreshGlobalData.asEvent())
       }
     })
   })

--- a/test/unit/devtools-rpc.test.ts
+++ b/test/unit/devtools-rpc.test.ts
@@ -1,0 +1,66 @@
+import type { Nuxt } from 'nuxt/schema'
+import type { ModuleOptions } from '../../src/module'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupDevToolsUI } from '../../src/build/devtools'
+
+const { refreshRouteData, setupDevToolsRpc } = vi.hoisted(() => {
+  const refreshRouteData = Object.assign(
+    vi.fn().mockRejectedValue(new Error('RPC timeout')),
+    { asEvent: vi.fn().mockResolvedValue(undefined) },
+  )
+
+  return {
+    refreshRouteData,
+    setupDevToolsRpc: vi.fn().mockResolvedValue({
+      broadcast: {
+        refresh: Object.assign(vi.fn(), { asEvent: vi.fn() }),
+        refreshGlobalData: Object.assign(vi.fn(), { asEvent: vi.fn() }),
+        refreshRouteData,
+      },
+    }),
+  }
+})
+
+vi.mock('@nuxt/kit', () => ({
+  updateTemplates: vi.fn(),
+  useNuxt: vi.fn(),
+}))
+
+vi.mock('nuxtseo-shared/devtools', () => ({
+  setupDevToolsRpc,
+  setupDevToolsUI: vi.fn(),
+}))
+
+describe('devtools RPC broadcasts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends route refreshes as events without waiting for a response', async () => {
+    const callbacks = new Map<string, (...args: any[]) => unknown>()
+    const hook = vi.fn((name: string, callback: (...args: any[]) => unknown) => {
+      callbacks.set(name, callback)
+    })
+    const nuxt = {
+      hook,
+      hooks: { hook },
+      options: {
+        css: [],
+        rootDir: '/project',
+        srcDir: '/project/app',
+      },
+    } as unknown as Nuxt
+
+    setupDevToolsUI(
+      { componentDirs: [] } as unknown as ModuleOptions,
+      path => path,
+      nuxt,
+    )
+
+    await vi.waitFor(() => expect(callbacks.has('builder:watch')).toBe(true))
+    callbacks.get('builder:watch')!('change', 'pages/index.vue')
+
+    expect(refreshRouteData).not.toHaveBeenCalled()
+    expect(refreshRouteData.asEvent).toHaveBeenCalledWith('pages/index.vue')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #658

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

DevTools refresh broadcasts used request and response RPC calls, so disconnected clients logged a `birpc` timeout for `refreshRouteData` when pages changed. Send these one-way notifications with `asEvent()` and cover route refresh behavior with a unit test.