### PR TITLE
fix: encode asterisks in OG image URLs

### DIFF
--- a/src/runtime/shared/urlEncoding.ts
+++ b/src/runtime/shared/urlEncoding.ts
@@ -234,11 +234,12 @@ export function encodeOgImageParams(options: Record<string, any>, defaults?: Rec
         // ASCII-safe value: try URL encoding first, then check for problematic percent-encoding.
         // Characters like #, ?, /, \, =, & produce %XX sequences that get decoded by
         // proxies, CDNs, and prerender crawlers in unpredictable ways (#528, #529).
-        // If percent-encoding is needed, use b64 instead to avoid these issues entirely.
+        // encodeURIComponent leaves * unescaped, but it is invalid in Windows and
+        // GitHub Artifact filenames. Use b64 for either case.
         const escaped = str.startsWith('~') ? `~${str}` : str
         const encoded = encodeURIComponent(escaped.replace(RE_UNDERSCORE, '__'))
           .replace(RE_PERCENT20, '+') // spaces as +
-        if (encoded.includes('%')) {
+        if (encoded.includes('%') || encoded.includes('*')) {
           // Value contains URL-sensitive chars; b64 encode to prevent intermediary decoding
           parts.push(`${alias}_~${b64Encode(str)}`)
         }

--- a/src/runtime/shared/urlEncoding.ts
+++ b/src/runtime/shared/urlEncoding.ts
@@ -36,6 +36,8 @@ const RE_COMMA_PARAM_SEPARATOR = /,(?=\w+_)/
 const RE_SIGNATURE_SUFFIX = /,s_[^,]+$/
 // eslint-disable-next-line no-control-regex
 const RE_NON_ASCII = /[^\u0000-\u007F]/
+// eslint-disable-next-line no-control-regex
+const RE_WINDOWS_RESERVED_FILENAME_CHARACTERS = /[<>:"/\\|?*\u0000-\u001F]/
 
 // Short aliases for OgImageOptions params
 const PARAM_ALIASES: Record<string, string> = {
@@ -234,12 +236,11 @@ export function encodeOgImageParams(options: Record<string, any>, defaults?: Rec
         // ASCII-safe value: try URL encoding first, then check for problematic percent-encoding.
         // Characters like #, ?, /, \, =, & produce %XX sequences that get decoded by
         // proxies, CDNs, and prerender crawlers in unpredictable ways (#528, #529).
-        // encodeURIComponent leaves * unescaped, but it is invalid in Windows and
-        // GitHub Artifact filenames. Use b64 for either case.
+        // Win32 also reserves < > : " / \ | ? *, NUL, and ASCII controls in filenames.
         const escaped = str.startsWith('~') ? `~${str}` : str
         const encoded = encodeURIComponent(escaped.replace(RE_UNDERSCORE, '__'))
           .replace(RE_PERCENT20, '+') // spaces as +
-        if (encoded.includes('%') || encoded.includes('*')) {
+        if (encoded.includes('%') || RE_WINDOWS_RESERVED_FILENAME_CHARACTERS.test(str)) {
           // Value contains URL-sensitive chars; b64 encode to prevent intermediary decoding
           parts.push(`${alias}_~${b64Encode(str)}`)
         }

--- a/test/unit/urlEncoding.test.ts
+++ b/test/unit/urlEncoding.test.ts
@@ -54,12 +54,27 @@ describe('urlEncoding', () => {
       expect(decoded).toEqual({ props: { title: 'Hello, World' } })
     })
 
-    it('b64 encodes filesystem-unsafe characters', () => {
-      const description = 'whoopsies *deletes public folder*'
-      const encoded = encodeOgImageParams({ props: { description } })
+    it('b64 encodes Win32-reserved filename characters', () => {
+      const reservedCharacters = [
+        '<',
+        '>',
+        ':',
+        '"',
+        '/',
+        '\\',
+        '|',
+        '?',
+        '*',
+        ...Array.from({ length: 32 }, (_, charCode) => String.fromCharCode(charCode)),
+      ]
 
-      expect(encoded).not.toContain('*')
-      expect(decodeOgImageParams(encoded)).toEqual({ props: { description } })
+      for (const character of reservedCharacters) {
+        const description = `before${character}after`
+        const encoded = encodeOgImageParams({ props: { description } })
+
+        expect(encoded, JSON.stringify(character)).toMatch(/^description_~/)
+        expect(decodeOgImageParams(encoded)).toEqual({ props: { description } })
+      }
     })
 
     it('base64 encodes complex objects', () => {

--- a/test/unit/urlEncoding.test.ts
+++ b/test/unit/urlEncoding.test.ts
@@ -54,6 +54,14 @@ describe('urlEncoding', () => {
       expect(decoded).toEqual({ props: { title: 'Hello, World' } })
     })
 
+    it('b64 encodes filesystem-unsafe characters', () => {
+      const description = 'whoopsies *deletes public folder*'
+      const encoded = encodeOgImageParams({ props: { description } })
+
+      expect(encoded).not.toContain('*')
+      expect(decodeOgImageParams(encoded)).toEqual({ props: { description } })
+    })
+
     it('base64 encodes complex objects', () => {
       const encoded = encodeOgImageParams({
         satori: { fonts: [] },


### PR DESCRIPTION
### 🔗 Linked issue

Related to #602

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`encodeURIComponent` leaves `*` unescaped, which put asterisks from OG image props into prerendered filenames. The codec now checks the [Win32 reserved filename characters](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file) before choosing base64 encoding, with round-trip tests for every reserved character and ASCII control.