### PR TITLE
fix: defer WASM init in bindings to first use

### DIFF
--- a/src/runtime/server/og-image/bindings/resvg/wasm-fs.ts
+++ b/src/runtime/server/og-image/bindings/resvg/wasm-fs.ts
@@ -1,7 +1,14 @@
 import { Resvg as _Resvg, initWasm } from '@resvg/resvg-wasm'
 import { readWasmFile } from '../../../util/wasm'
 
+let initPromise: Promise<void> | undefined
+
 export default {
-  initWasmPromise: initWasm(readWasmFile('@resvg/resvg-wasm/index_bg.wasm')),
+  // Lazily created on first access so module evaluation stays free of file
+  // reads and WASM compilation (see bindings/resvg/wasm.ts).
+  get initWasmPromise(): Promise<void> {
+    initPromise ??= initWasm(readWasmFile('@resvg/resvg-wasm/index_bg.wasm'))
+    return initPromise
+  },
   Resvg: _Resvg,
 }

--- a/src/runtime/server/og-image/bindings/resvg/wasm.ts
+++ b/src/runtime/server/og-image/bindings/resvg/wasm.ts
@@ -1,8 +1,17 @@
 import { Resvg as _Resvg, initWasm } from '@resvg/resvg-wasm'
 import { importWasm } from '../../../util/wasm'
 
+let initPromise: Promise<void> | undefined
+
 export default {
-  initWasmPromise: importWasm(import('@resvg/resvg-wasm/index_bg.wasm?module' as string))
-    .then(wasm => initWasm(wasm)),
+  // Lazily created on first access: bundlers targeting single-file workers
+  // (e.g. Nitro presets with `inlineDynamicImports`) evaluate this module at
+  // isolate boot, so an eagerly created promise would compile the WASM on
+  // every cold start even for requests that never render an OG image.
+  get initWasmPromise(): Promise<void> {
+    initPromise ??= importWasm(import('@resvg/resvg-wasm/index_bg.wasm?module' as string))
+      .then(wasm => initWasm(wasm))
+    return initPromise
+  },
   Resvg: _Resvg,
 }

--- a/src/runtime/server/og-image/bindings/satori/wasm-fs.ts
+++ b/src/runtime/server/og-image/bindings/satori/wasm-fs.ts
@@ -1,12 +1,18 @@
 import _satori, { init } from 'satori/standalone'
 import { readWasmFile } from '../../../util/wasm'
 
-// satori 0.16+ ships its own yoga.wasm (from yoga-layout, not yoga-wasm-web)
-const wasmBinary = readWasmFile('satori/yoga.wasm')
+let initPromise: Promise<void> | undefined
 
 export default {
-  initWasmPromise: wasmBinary.then(async (wasm) => {
-    await init(wasm)
-  }),
+  // satori 0.16+ ships its own yoga.wasm (from yoga-layout, not yoga-wasm-web)
+  //
+  // Lazily created on first access so module evaluation stays free of file
+  // reads and WASM compilation (see bindings/satori/wasm.ts).
+  get initWasmPromise(): Promise<void> {
+    initPromise ??= readWasmFile('satori/yoga.wasm').then(async (wasm) => {
+      await init(wasm)
+    })
+    return initPromise
+  },
   satori: _satori,
 }

--- a/src/runtime/server/og-image/bindings/satori/wasm.ts
+++ b/src/runtime/server/og-image/bindings/satori/wasm.ts
@@ -1,10 +1,20 @@
 import _satori, { init } from 'satori/standalone'
 import { importWasm } from '../../../util/wasm'
 
-// satori 0.16+ ships its own yoga.wasm (from yoga-layout, not yoga-wasm-web)
-// Aliased via #og-image/yoga-wasm in compatibility.ts to the correct file path
+let initPromise: Promise<void> | undefined
+
 export default {
-  initWasmPromise: importWasm(import('#og-image/yoga-wasm' as string))
-    .then(wasm => init(wasm)),
+  // satori 0.16+ ships its own yoga.wasm (from yoga-layout, not yoga-wasm-web)
+  // Aliased via #og-image/yoga-wasm in compatibility.ts to the correct file path
+  //
+  // Lazily created on first access: bundlers targeting single-file workers
+  // (e.g. Nitro presets with `inlineDynamicImports`) evaluate this module at
+  // isolate boot, so an eagerly created promise would compile the WASM on
+  // every cold start even for requests that never render an OG image.
+  get initWasmPromise(): Promise<void> {
+    initPromise ??= importWasm(import('#og-image/yoga-wasm' as string))
+      .then(wasm => init(wasm))
+    return initPromise
+  },
   satori: _satori,
 }

--- a/src/runtime/server/og-image/bindings/takumi/wasm.ts
+++ b/src/runtime/server/og-image/bindings/takumi/wasm.ts
@@ -1,11 +1,19 @@
 import init, { Renderer } from '@takumi-rs/wasm/no-bundler'
 import { extractResourceUrls } from './resource-urls'
 
-const wasmBinary = import('@takumi-rs/wasm/takumi_wasm_bg.wasm?module' as string)
-  .then(m => m.default || m)
+let initPromise: ReturnType<typeof init> | undefined
 
 export default {
-  initWasmPromise: wasmBinary.then(wasm => init({ module_or_path: wasm })),
+  // Lazily created on first access: bundlers targeting single-file workers
+  // (e.g. Nitro presets with `inlineDynamicImports`) evaluate this module at
+  // isolate boot, so an eagerly created promise would compile the WASM on
+  // every cold start even for requests that never render an OG image.
+  get initWasmPromise(): ReturnType<typeof init> {
+    initPromise ??= import('@takumi-rs/wasm/takumi_wasm_bg.wasm?module' as string)
+      .then(m => m.default || m)
+      .then(wasm => init({ module_or_path: wasm }))
+    return initPromise
+  },
   Renderer,
   extractResourceUrls,
 }


### PR DESCRIPTION
### What

The wasm bindings for resvg, satori and takumi start their init chain at module-evaluation time:

```ts
export default {
  initWasmPromise: importWasm(import('@resvg/resvg-wasm/index_bg.wasm?module' as string))
    .then(wasm => initWasm(wasm)),
  Resvg: _Resvg,
}
```

This PR exposes `initWasmPromise` as a lazy, memoized getter instead. The object shape consumed by `getResvg` / `getSatori` / `getTakumi` is unchanged; the init chain now only starts on the first property access, which happens inside the render path.

### Why

The bindings were written to be lazy at the module level - `import('#og-image/bindings/resvg')` inside `getResvg()` - which works when the bundler keeps dynamic imports as separate chunks. But several deployment targets bundle the server as a single file: Nitro's `base-worker` family sets `inlineDynamicImports: true` (netlify-edge, and others inherit it). Rollup then inlines the "lazy" binding module into the entry chunk, and since ESM top-level code runs at module-link time, the WASM fetch + `WebAssembly.instantiate` fires as soon as the isolate boots.

Net effect on those targets: every cold start pays WASM compilation for resvg (and yoga for satori), including plain page loads that never render an OG image. On edge runtimes with per-request CPU budgets and frequent cold starts, this dominates cold-start latency. We measured this in production on Netlify Edge Functions, where the built `server.js` contained the resvg `initWasmPromise` as a top-level const whose init chain ran unconditionally at boot.

With this change, single-file bundles still contain the WASM, but compilation is deferred to the first OG-image render on that isolate.

### Changes

- `bindings/resvg/wasm.ts`, `bindings/resvg/wasm-fs.ts`
- `bindings/satori/wasm.ts`, `bindings/satori/wasm-fs.ts`
- `bindings/takumi/wasm.ts`

Each replaces the eagerly-created `initWasmPromise` property with a `get initWasmPromise()` that creates the promise on first access and memoizes it. The `node` / `node-dev` bindings (`Promise.resolve()`) are untouched.

### Verification

- `pnpm lint` and `pnpm typecheck` pass.
- Behavioral check: importing `bindings/resvg/wasm.ts` no longer triggers any WASM loading; the load attempt happens exactly on first `initWasmPromise` access (verified by importing the module in isolation and observing the resolution attempt only fires on property access).
- Complementary Nitro-side fix (allowing code-splitting in the netlify-edge preset) is being proposed separately, but this change fixes the eager init for every bundler/provider that produces single-file worker output, independent of that.
