### PR TITLE
chore(lint): adopt shared eslint base config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,9 +2,11 @@ import antfu from '@antfu/eslint-config'
 import harlanzw from 'eslint-plugin-harlanzw'
 
 export default antfu(
-  {},
+  // og-image lints its playground on purpose, so the shared ignore set is off and
+  // this repo keeps its own list. A global ignore cannot be undone downstream.
+  { ignores: ['.claude'] },
   ...harlanzw({
-    base: { type: 'app', ignores: ['.claude'] },
+    base: { type: 'app', ignores: false },
     link: true,
     nuxt: true,
     vue: true,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,29 +1,20 @@
 import antfu from '@antfu/eslint-config'
 import harlanzw from 'eslint-plugin-harlanzw'
 
-export default antfu({
-  ignores: ['.claude'],
-  rules: {
-    'node/prefer-global/process': 'off',
-    'node/prefer-global/buffer': 'off',
-    'no-use-before-define': 'off',
+export default antfu(
+  {},
+  ...harlanzw({
+    base: { type: 'app', ignores: ['.claude'] },
+    link: true,
+    nuxt: true,
+    vue: true,
+    content: true,
+  }),
+  {
+    rules: {
+      'harlanzw/link-no-underscores': 'off',
+      'harlanzw/link-trailing-slash': 'off',
+      'harlanzw/link-lowercase': 'off',
+    },
   },
-}, ...harlanzw({ link: true, nuxt: true, vue: true, content: true }), {
-  files: ['test/**/*.ts', 'test/**/*.mjs'],
-  rules: {
-    'e18e/prefer-static-regex': 'off',
-  },
-}, {
-  rules: {
-    'harlanzw/link-no-underscores': 'off',
-    'harlanzw/link-trailing-slash': 'off',
-    'harlanzw/link-lowercase': 'off',
-  },
-}, {
-  files: ['examples/**/package.json'],
-  rules: {
-    'pnpm/json-enforce-catalog': 'off',
-    'pnpm/json-valid-catalog': 'off',
-    'pnpm/json-prefer-workspace-settings': 'off',
-  },
-})
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.17.1
-      version: 0.17.1
+      specifier: ^0.18.1
+      version: 0.18.1
     exsolve:
       specifier: ^1.1.1
       version: 1.1.1
@@ -543,7 +543,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       fontless:
         specifier: 'catalog:'
         version: 0.2.1(db0@0.3.4(better-sqlite3@13.0.3))(ioredis@5.11.1(supports-color@10.2.2))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(yaml@2.9.0))
@@ -6273,8 +6273,8 @@ packages:
     peerDependencies:
       eslint: '>=4.19.1'
 
-  eslint-plugin-harlanzw@0.17.1:
-    resolution: {integrity: sha512-JTqWyTYDdMGvo5RDQ1ugq8Y2hGhcSL432WZX3ls52Ie5e+L2MncacI5OrArWB6/8pO7pK3qdm+hgiaFVXmmHxw==}
+  eslint-plugin-harlanzw@0.18.1:
+    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -16486,7 +16486,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-harlanzw@0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.18.1
-      version: 0.18.1
+      specifier: ^0.19.0
+      version: 0.19.0
     exsolve:
       specifier: ^1.1.1
       version: 1.1.1
@@ -543,7 +543,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       fontless:
         specifier: 'catalog:'
         version: 0.2.1(db0@0.3.4(better-sqlite3@13.0.3))(ioredis@5.11.1(supports-color@10.2.2))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(yaml@2.9.0))
@@ -6273,8 +6273,8 @@ packages:
     peerDependencies:
       eslint: '>=4.19.1'
 
-  eslint-plugin-harlanzw@0.18.1:
-    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
+  eslint-plugin-harlanzw@0.19.0:
+    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -16486,7 +16486,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.19.0
-      version: 0.19.0
+      specifier: ^0.19.2
+      version: 0.19.2
     exsolve:
       specifier: ^1.1.1
       version: 1.1.1
@@ -543,7 +543,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       fontless:
         specifier: 'catalog:'
         version: 0.2.1(db0@0.3.4(better-sqlite3@13.0.3))(ioredis@5.11.1(supports-color@10.2.2))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(yaml@2.9.0))
@@ -6273,8 +6273,8 @@ packages:
     peerDependencies:
       eslint: '>=4.19.1'
 
-  eslint-plugin-harlanzw@0.19.0:
-    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
+  eslint-plugin-harlanzw@0.19.2:
+    resolution: {integrity: sha512-aXVG5dupBlq2Nn94ffBcxw6iSK7OoFoPriWQW2RlE2FHP8PiQt2hfOU1AxuYk0GqgNMIL9c3cKwdhw1RgyeRcw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -16486,7 +16486,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,6 +62,7 @@ minimumReleaseAgeExclude:
   - '@unhead/vue@3.2.1'
   - unhead@3.2.1
   - satori@0.28.2
+  - eslint-plugin-harlanzw@0.18.1
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -135,7 +136,7 @@ catalog:
   defu: ^6.1.7
   devalue: ^5.9.0
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.17.1
+  eslint-plugin-harlanzw: ^0.18.1
   exsolve: ^1.1.1
   fnv1a-64: ^0.1.2
   fontless: ^0.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ minimumReleaseAgeExclude:
   - '@unhead/vue@3.2.1'
   - unhead@3.2.1
   - satori@0.28.2
-  - eslint-plugin-harlanzw@0.18.1
+  - eslint-plugin-harlanzw@0.19.0
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -136,7 +136,7 @@ catalog:
   defu: ^6.1.7
   devalue: ^5.9.0
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.18.1
+  eslint-plugin-harlanzw: ^0.19.0
   exsolve: ^1.1.1
   fnv1a-64: ^0.1.2
   fontless: ^0.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ minimumReleaseAgeExclude:
   - '@unhead/vue@3.2.1'
   - unhead@3.2.1
   - satori@0.28.2
-  - eslint-plugin-harlanzw@0.19.0
+  - eslint-plugin-harlanzw@0.19.2
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -136,7 +136,7 @@ catalog:
   defu: ^6.1.7
   devalue: ^5.9.0
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.19.0
+  eslint-plugin-harlanzw: ^0.19.2
   exsolve: ^1.1.1
   fnv1a-64: ^0.1.2
   fontless: ^0.2.1

--- a/src/build/css/providers/tw4.ts
+++ b/src/build/css/providers/tw4.ts
@@ -485,7 +485,7 @@ function buildThemeVars(
     buildNuxtUiVars(vars, nuxtUiColors, theme)
 
   if (extracted) {
-    const themeRootAttrs: Record<string, string> = { 'data-theme': theme }
+    const themeRootAttrs = { 'data-theme': theme } satisfies Record<string, string>
     const themeVars = resolveExtractedVars(extracted, themeRootAttrs)
     for (const [n, v] of themeVars)
       vars.set(n, v)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -445,7 +445,7 @@ async function removeDeprecatedConfigKeys(rootDir: string, keys: Array<{ key: st
 }
 
 // Deprecated ogImage config keys and their replacements
-const DEPRECATED_CONFIG_KEYS: Record<string, string> = {
+const DEPRECATED_CONFIG_KEYS = {
   fonts: '@nuxt/fonts module (migrated automatically)',
   strictNuxtContentPaths: 'Removed (no effect in Content v3)',
   playground: 'Removed (use Nuxt DevTools)',
@@ -459,7 +459,7 @@ const DEPRECATED_CONFIG_KEYS: Record<string, string> = {
   cacheKey: 'Removed',
   static: 'zeroRuntime',
   componentOptions: 'Removed (use defineOgImage())',
-}
+} satisfies Record<string, string>
 
 // Check if nuxt config has deprecated options
 async function checkNuxtConfig(rootDir: string): Promise<{

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -21,7 +21,7 @@ import {
   validateProviderSetup,
 } from './utils/dependencies'
 
-const DEPRECATED_CONFIG: Record<string, string> = {
+const DEPRECATED_CONFIG = {
   playground: 'Removed - use Nuxt DevTools',
   host: 'Use site.url or NUXT_SITE_URL',
   siteUrl: 'Use site.url or NUXT_SITE_URL',
@@ -33,7 +33,7 @@ const DEPRECATED_CONFIG: Record<string, string> = {
   cacheKey: 'Removed',
   static: 'Removed - use zeroRuntime',
   fonts: 'Use @nuxt/fonts module instead',
-}
+} satisfies Record<string, string>
 
 const DEPRECATED_COMPOSABLES = [
   'defineOgImageStatic',

--- a/test/e2e-not-nuxt/zeroRuntimeBuild.test.ts
+++ b/test/e2e-not-nuxt/zeroRuntimeBuild.test.ts
@@ -28,7 +28,7 @@ describe('zeroRuntime', () => {
     await exec('nuxt', ['build'], { nodeOptions: { cwd: fixtureDir } })
     const serverOutputPath = resolve('../fixtures/zero-runtime/.output/server')
     const { stdout } = await exec('du', ['-sh', serverOutputPath])
-    // eslint-disable-next-line no-console,style/no-tabs
+    // eslint-disable-next-line style/no-tabs
     console.log(`Size: ${stdout.split('	')[0]}`)
     const imagePath = resolve('../fixtures/zero-runtime/.output/public/_og')
     const images = await globby('**/*.png', { cwd: imagePath }).then((r: string[]) => r.sort())

--- a/test/e2e/multi-font-families.test.ts
+++ b/test/e2e/multi-font-families.test.ts
@@ -29,7 +29,7 @@ describe('multi-font-families', () => {
       '/font-black-takumi',
     )
 
-    const snapshotIds: Record<string, string> = {
+    const snapshotIds = {
       '/': 'multi-font-lobster',
       '/playfair': 'multi-font-playfair',
       '/roboto': 'multi-font-jetbrains',
@@ -43,7 +43,7 @@ describe('multi-font-families', () => {
       '/biz-udp-bold': 'multi-font-biz-udp-bold-takumi',
       '/font-black': 'multi-font-font-black',
       '/font-black-takumi': 'multi-font-font-black-takumi',
-    }
+    } satisfies Record<string, string>
 
     for (const [path, id] of Object.entries(snapshotIds)) {
       // Use tighter threshold for biz-udp-bold: the font-weight regression

--- a/test/unit/font-requirements.test.ts
+++ b/test/unit/font-requirements.test.ts
@@ -9,7 +9,7 @@ describe('font-requirements', () => {
   })
 
   describe('font weight class mapping', () => {
-    const FONT_WEIGHT_CLASSES: Record<string, number> = {
+    const FONT_WEIGHT_CLASSES = {
       'font-thin': 100,
       'font-extralight': 200,
       'font-light': 300,
@@ -19,7 +19,7 @@ describe('font-requirements', () => {
       'font-bold': 700,
       'font-extrabold': 800,
       'font-black': 900,
-    }
+    } satisfies Record<string, number>
 
     it('should have correct weight mappings', () => {
       expect(FONT_WEIGHT_CLASSES['font-thin']).toBe(100)

--- a/test/unit/fonts.test.ts
+++ b/test/unit/fonts.test.ts
@@ -82,11 +82,11 @@ describe('extractCustomFontFamilies', () => {
 })
 
 describe('resolveFontFamilies', () => {
-  const fontVars: Record<string, string> = {
+  const fontVars = {
     'font-sans': 'Inter, sans-serif',
     'font-serif': '\'Playfair Display\', Georgia, serif',
     'font-mono': '\'JetBrains Mono\', monospace',
-  }
+  } satisfies Record<string, string>
 
   it('returns empty when no classes or names', () => {
     expect(resolveFontFamilies([], [], fontVars)).toEqual([])

--- a/test/unit/icon-class-resolution.test.ts
+++ b/test/unit/icon-class-resolution.test.ts
@@ -7,10 +7,10 @@ import { AssetTransformPlugin } from '../../src/build/vite-asset-transform'
 // ============================================================================
 
 describe('unoCSS resolveIcon', () => {
-  const customIcons: Record<string, string> = {
+  const customIcons = {
     'agent-skills': '<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 0.5L29.4234 8.25V23.75L16 31.5L2.57661 23.75V8.25L16 0.5Z" fill="currentColor"/></svg>',
     'star': '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z" fill="currentColor"/></svg>',
-  }
+  } satisfies Record<string, string>
 
   let resolveIcon: (prefix: string, name: string) => Promise<{ body: string, width: number, height: number } | null>
 

--- a/test/unit/tw4-class-resolution.test.ts
+++ b/test/unit/tw4-class-resolution.test.ts
@@ -736,7 +736,7 @@ describe('tw4 class resolution', () => {
   // ============================================================================
 
   describe('community template classes', () => {
-    const templateClasses: Record<string, string[]> = {
+    const templateClasses = {
       Brutalist: [
         'h-full',
         'w-full',
@@ -829,7 +829,7 @@ describe('tw4 class resolution', () => {
         // Note: from-[#3b82f6] is a gradient color modifier — doesn't resolve standalone
         // (sets --tw-gradient-from which is a CSS var skipped by postProcessStyles)
       ],
-    }
+    } satisfies Record<string, string[]>
 
     for (const [template, classes] of Object.entries(templateClasses)) {
       it(`${template}: all classes resolve`, async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

`eslint-plugin-harlanzw` 0.19.2 ships a `base()` config holding the override blocks I had copy-pasted into every repo: the ignore set, node globals, a test-file relaxation, markdown code fences, and the pnpm catalog exemption for `examples/**/package.json`. Same adoption as harlan-zw/nuxt-seo#619.

```js
export default antfu(
  { ignores: ['.claude'] },
  ...harlanzw({
    base: { type: 'app', ignores: false },
    link: true,
    nuxt: true,
    vue: true,
    content: true,
  }),
  { rules: { /* the three link rules that stay off here */ } },
)
```

Two option choices worth a look:

`type: 'app'`, not the `'lib'` default. antfu was never given `type: 'lib'` in this repo, so `ts/explicit-function-return-type` was never registered. Taking the default would have `base` switch off a rule nothing turned on.

`ignores: false` drops the shared ignore block, so this repo keeps its own list. This repo lints its playground on purpose. A global ignore beats any later config and cannot be undone, so taking the shared set removed `playground/**` and `test/fixtures/**` from the run, 320 of 702 files. 0.19.2 added the option for exactly this case. File count is 702 both before and after this PR.

The `{ ignores: ['.claude'] }` block preserves what the old config did. `CLAUDE.md` keeps being linted, as it is today.

Behaviour that does change:

- `ts/no-use-before-define` goes from error to off. The old config only switched off the base `no-use-before-define` and left the TS variant on.
- Test files pick up `no-console`, `ts/no-unsafe-function-type` and `antfu/no-top-level-await` off, where the old block only had `e18e/prefer-static-regex`.

One orphan: `base`'s test relaxation made the `no-console` half of an `eslint-disable-next-line` in `test/e2e-not-nuxt/zeroRuntimeBuild.test.ts` unused, so ESLint reported the directive. Dropped that half, kept `style/no-tabs`.

`harlanzw/prefer-satisfies` warned 25 times when this PR opened. Two plugin
releases cut that to 10 by teaching the rule to skip lookup maps, which are read
by a computed key and cannot be narrowed. I took the 8 remaining suggestions in a
separate commit: they are object literals only ever read by a static key, so
`satisfies` keeps their keys for `keyof typeof` and autocomplete.

Two are deliberately left: `emoji-names-minimal.ts` is indexed from another file,
and `styleDirectives.ts` spreads its map into `BREAKPOINTS`, which is then
indexed. The rule cannot see either without type information, and narrowing them
breaks the build.

`pnpm typecheck` is clean and 933 unit tests pass.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).




