### PR TITLE
perf: let the bundler filter the build plugins

### DIFF
--- a/src/build/tree-shake-plugin.ts
+++ b/src/build/tree-shake-plugin.ts
@@ -37,13 +37,16 @@ export function isVue(id: string, opts: { type?: Array<'template' | 'script' | '
   return true
 }
 
-const JS_RE = /\.(?:[cm]?j|t)sx?$/
-
-export function isJS(id: string) {
-  // JavaScript files
-  const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-  return JS_RE.test(pathname)
-}
+// Ids carry a query in dev and for SFC blocks, so every extension match allows one.
+const VUE_RE = /\.vue(?:\?|$)/
+const JS_RE = /\.[cm]?[jt]sx?(?:\?|$)/
+// Nuxt's island component registry re-exports every island component. Rewriting a call
+// there would break the manifest, so the plugin has always skipped the file.
+const ISLANDS_RE = /components\.islands\.mjs(?:\?|$)/
+// Every composable this plugin rewrites starts with `defineOgImage`, so a module without
+// that substring can never need the transform. unplugin hands the test to the bundler
+// natively where supported, so the hook is not called at all for the rest of the graph.
+const COMPOSABLE_CODE_MARKER = 'defineOgImage'
 
 export const TreeShakeComposablesPlugin = createUnplugin(() => {
   /**
@@ -64,29 +67,35 @@ export const TreeShakeComposablesPlugin = createUnplugin(() => {
   return {
     name: 'nuxt-og-image:zero-runtime:transform',
     enforce: 'pre',
-    transformInclude(id) {
-      return isVue(id, { type: ['script'] }) || isJS(id)
-    },
-    transform(code, id) {
-      const s = new MagicString(code)
-      // @todo re-implement composable tree-shaking for island files
-      if (!id.endsWith('components.islands.mjs')) {
-        const strippedCode = stripLiteral(code)
+    transform: {
+      filter: {
+        // @todo re-implement composable tree-shaking for island files
+        id: { include: [VUE_RE, JS_RE], exclude: [ISLANDS_RE] },
+        code: COMPOSABLE_CODE_MARKER,
+      },
+      handler(code, id) {
+        // A `.vue` id reaches us once per SFC block. Only the script block is ours.
+        if (VUE_RE.test(id) && !isVue(id, { type: ['script'] })) {
+          return
+        }
+        // `stripLiteral` parses the whole module, so run the cheap test first.
         if (!COMPOSABLE_RE.test(code)) {
           return
         }
 
-        for (const match of strippedCode.matchAll(COMPOSABLE_RE_GLOBAL)) {
+        const s = new MagicString(code)
+        for (const match of stripLiteral(code).matchAll(COMPOSABLE_RE_GLOBAL)) {
           s.overwrite(match.index!, match.index! + match[0].length, `${match[1]} import.meta.prerender && ${match[2]}`)
         }
-      }
 
-      if (s.hasChanged()) {
+        if (!s.hasChanged()) {
+          return
+        }
         return {
           code: s.toString(),
           map: s.generateMap({ hires: true }),
         }
-      }
+      },
     },
   }
 })

--- a/src/build/vite-asset-transform.ts
+++ b/src/build/vite-asset-transform.ts
@@ -24,6 +24,9 @@ const RE_SVG_ID_ATTR = /\bid="([^"]+)"/g
 const RE_SVG_VIEWBOX = /viewBox="([^"]*)"/
 const RE_SVG_BODY = /<svg[^>]*>([\s\S]*)<\/svg>/
 const RE_OG_IMAGE_QUERY = /\?og-image(?:-depth=\d+)?$/
+// Ids carry a query in dev and for SFC blocks, so the extension match allows one. The
+// bundler applies this before the hook runs, which keeps the rest of the graph out.
+const RE_VUE_ID = /\.vue(?:\?|$)/
 const RE_TEXT_BETWEEN_TAGS = />([^<]*)</g
 const RE_SPECIAL_REGEX_CHARS = /[.*+?^${}()|[\]\\]/g
 const RE_WRAPPER_DIV_START = /^<div>/
@@ -359,568 +362,576 @@ export const AssetTransformPlugin = createUnplugin((options: AssetTransformOptio
     name: 'nuxt-og-image:asset-transform',
     enforce: 'pre',
 
-    transformInclude(id) {
-      // Accept ?og-image query param (nested components rewritten by ComponentImportRewritePlugin)
-      if (id.includes('?og-image'))
-        return true
-      if (!id.endsWith('.vue'))
-        return false
-      // Check if file is inside any of the resolved OG component directories
-      // Note: don't exclude node_modules - built-in community templates live there when installed as a dependency
-      return options.ogComponentPaths.some(dir => id.startsWith(`${dir}/`) || id.startsWith(`${dir}\\`))
-    },
-
-    async transform(code, rawId) {
-      // Strip ?og-image query param for path operations (nested component imports)
-      const id = rawId.replace(RE_OG_IMAGE_QUERY, '')
-
-      // Track nested component files for HMR
-      if (rawId.includes('?og-image'))
-        options.onNestedTransform?.(id)
-
-      const bounds = getOuterTemplateBounds(code)
-      if (!bounds)
-        return
-
-      const s = new MagicString(code)
-      const { templateStart, templateEnd } = bounds
-      let template = code.slice(templateStart, templateEnd)
-      let hasChanges = false
-
-      // Transform emojis in text content
-      if (options.emojiSet && RE_MATCH_EMOJIS.test(template)) {
-        // Try local icons first, fallback to fetch
-        if (!emojiIcons) {
-          emojiIcons = options.emojiIcons ?? await import(`@iconify-json/${options.emojiSet}/icons.json`, {
-            with: { type: 'json' },
-          }).then(m => m.default).catch(() => {
-            // Missing optional emoji packages fall back to remote icon resolution.
-            return null
-          })
+    transform: {
+      filter: {
+        id: RE_VUE_ID,
+      },
+      async handler(code, rawId) {
+        // Accept the ?og-image query param (nested components rewritten by
+        // ComponentImportRewritePlugin). Anchored, so the id the handler strips below is
+        // always the file path.
+        const isNested = RE_OG_IMAGE_QUERY.test(rawId)
+        if (!isNested) {
+          // `RE_VUE_ID` also admits SFC block ids, which are not files we own.
+          if (!rawId.endsWith('.vue'))
+            return
+          // Check if file is inside any of the resolved OG component directories
+          // Note: don't exclude node_modules - built-in community templates live there when installed as a dependency
+          if (!options.ogComponentPaths.some(dir => rawId.startsWith(`${dir}/`) || rawId.startsWith(`${dir}\\`)))
+            return
         }
 
-        // Collect all unique emojis in template
-        RE_MATCH_EMOJIS.lastIndex = 0
-        const allEmojis = new Set<string>()
-        for (const match of template.matchAll(RE_MATCH_EMOJIS)) {
-          allEmojis.add(match[0])
-        }
+        // Strip ?og-image query param for path operations (nested component imports)
+        const id = rawId.replace(RE_OG_IMAGE_QUERY, '')
 
-        // Resolve emoji SVGs in parallel (local first, fetch fallback)
-        const emojiSvgMap = new Map<string, string>()
-        await Promise.all(Array.from(allEmojis, async (emoji) => {
-          let svg: string | null = null
-          if (emojiIcons) {
-            svg = buildEmojiSvg(emoji, emojiIcons, options.emojiSet!)
-          }
-          if (!svg) {
-            svg = await fetchEmojiSvg(emoji, options.emojiSet!)
-          }
-          if (svg) {
-            emojiSvgMap.set(emoji, svg)
-          }
-        }))
+        // Track nested component files for HMR
+        if (isNested)
+          options.onNestedTransform?.(id)
 
-        // Replace emojis with resolved SVGs
-        if (emojiSvgMap.size > 0) {
-          RE_TEXT_BETWEEN_TAGS.lastIndex = 0
-          template = template.replace(RE_TEXT_BETWEEN_TAGS, (fullMatch, textContent) => {
-            if (!textContent)
-              return fullMatch
+        const bounds = getOuterTemplateBounds(code)
+        if (!bounds)
+          return
 
-            RE_MATCH_EMOJIS.lastIndex = 0
-            const emojiMatches = [...textContent.matchAll(RE_MATCH_EMOJIS)]
-            if (!emojiMatches.length)
-              return fullMatch
+        const s = new MagicString(code)
+        const { templateStart, templateEnd } = bounds
+        let template = code.slice(templateStart, templateEnd)
+        let hasChanges = false
 
-            let newTextContent = textContent
-            for (const match of emojiMatches) {
-              const emoji = match[0]
-              const svg = emojiSvgMap.get(emoji)
-              if (svg) {
-                hasChanges = true
-                const escaped = emoji.replace(RE_SPECIAL_REGEX_CHARS, '\\$&')
-                newTextContent = newTextContent.replace(new RegExp(escaped, 'g'), svg)
-              }
-            }
-            return `>${newTextContent}<`
-          })
-        }
-      }
-
-      // Transform icons: <Icon name="..." /> or <UIcon name="..." />
-      // Use ultrahtml to parse and transform - avoids complex regex patterns
-      if (template.includes('<Icon') || template.includes('<UIcon')) {
-        // First pass: collect icon prefixes from AST
-        const prefixes = new Set<string>()
-        const iconElements: Array<{ node: ElementNode, parent: Node, index: number }> = []
-
-        // Wrap in div for parsing (ultrahtml needs a root)
-        const wrappedTemplate = `<div>${template}</div>`
-        const doc = parseHtml(wrappedTemplate)
-
-        walkSync(doc, (node, parent, index) => {
-          if (node.type === ELEMENT_NODE) {
-            const el = node as ElementNode
-            if (el.name === 'Icon' || el.name === 'UIcon') {
-              const iconName = el.attributes.name
-              if (iconName && !iconName.includes('{')) {
-                const [prefix] = iconName.split(':')
-                if (prefix)
-                  prefixes.add(prefix)
-                iconElements.push({ node: el, parent: parent!, index: index! })
-              }
-            }
-          }
-        })
-
-        // Load icon sets
-        const iconSets = new Map<string, IconifyJSON>()
-        for (const prefix of prefixes) {
-          const icons = await loadIconSet(prefix)
-          if (icons)
-            iconSets.set(prefix, icons)
-        }
-
-        // Second pass: replace icon elements with SVG
-        if (iconElements.length > 0) {
-          let anyReplaced = false
-          for (const { node: el, parent, index } of iconElements) {
-            const iconName = el.attributes.name
-            if (!iconName)
-              continue
-
-            const [prefix, name] = iconName.split(':')
-            if (!prefix || !name)
-              continue
-
-            // Try @iconify-json package first
-            const icons = iconSets.get(prefix)
-            const iconData = icons?.icons?.[name]
-
-            let svgHtml: string | undefined
-            if (iconData) {
-              svgHtml = buildIconSvg(iconData, icons!.width || 24, icons!.height || 24, el.attributes)
-            }
-            // Fallback: resolve from CSS provider (e.g. UnoCSS presetIcons custom collections)
-            else if (options.cssProvider?.resolveIcon) {
-              const resolved = await options.cssProvider.resolveIcon(prefix, name)
-              if (resolved)
-                svgHtml = buildIconSvg(resolved, resolved.width, resolved.height, el.attributes)
-            }
-
-            if (!svgHtml)
-              continue
-
-            anyReplaced = true
-            hasChanges = true
-            const svgDoc = parseHtml(svgHtml)
-            if ('children' in parent && Array.isArray(parent.children)) {
-              parent.children[index] = svgDoc.children[0]
-            }
-          }
-
-          if (anyReplaced) {
-            // Render back to HTML, removing the wrapper div
-            const rendered = renderSync(doc)
-            // Remove wrapper div
-            template = rendered.replace(RE_WRAPPER_DIV_START, '').replace(RE_WRAPPER_DIV_END, '')
-          }
-        }
-      }
-
-      // Transform UnoCSS icon classes (i-{collection}-{name}) to inline SVGs
-      // Uses targeted string replacement (not ultrahtml renderSync) to preserve Vue directives like v-if
-      if (options.cssProvider?.resolveIcon) {
-        // Match elements with icon classes — self-closing or empty paired tags only
-        const replacements: Array<{ from: string, to: string }> = []
-
-        RE_ICON_ELEMENT.lastIndex = 0
-        let elMatch
-        // eslint-disable-next-line no-cond-assign
-        while ((elMatch = RE_ICON_ELEMENT.exec(template)) !== null) {
-          const [fullMatch, , attrsStr, classValue] = elMatch
-          if (!classValue)
-            continue
-
-          // Check if class contains an icon pattern
-          const classes = classValue.split(RE_WHITESPACE).filter(Boolean)
-          let iconPrefix: string | undefined
-          let iconName: string | undefined
-          for (const cls of classes) {
-            const im = cls.match(ICON_CLASS_RE)
-            if (im?.[1] && im[2]) {
-              iconPrefix = im[1]
-              iconName = im[2]
-              break
-            }
-          }
-          if (!iconPrefix || !iconName)
-            continue
-
-          const resolved = await options.cssProvider.resolveIcon!(iconPrefix, iconName)
-          if (!resolved)
-            continue
-
-          // Parse attributes from raw string, excluding class (rebuilt below), name,
-          // and Vue dynamic bindings for style (:style/v-bind:style — the element is
-          // replaced with a static SVG wrapper so dynamic bindings can't be evaluated)
-          const attrs: Record<string, string> = {}
-          RE_HTML_ATTR.lastIndex = 0
-          let am
-          // eslint-disable-next-line no-cond-assign
-          while ((am = RE_HTML_ATTR.exec(attrsStr!)) !== null) {
-            if (am[1] && am[1] !== 'class' && am[1] !== ':style' && am[1] !== 'v-bind:style')
-              attrs[am[1]] = am[2] ?? ''
-          }
-
-          // Keep non-icon classes
-          const otherClasses = classes.filter(c => !isIconClass(c))
-          if (otherClasses.length > 0)
-            attrs.class = otherClasses.join(' ')
-
-          const svgHtml = buildIconSvg(resolved, resolved.width, resolved.height, attrs)
-          replacements.push({ from: fullMatch, to: svgHtml })
-        }
-
-        for (const { from, to } of replacements) {
-          template = template.replace(from, to)
-          hasChanges = true
-        }
-      }
-
-      // Extract data-* attrs from the template root element for CSS var resolution
-      const rootAttrs: Record<string, string> = {}
-      const rootAttrMatch = template.match(RE_ROOT_ELEMENT)
-      if (rootAttrMatch?.[2]) {
-        RE_DATA_ATTR.lastIndex = 0
-        for (const m of rootAttrMatch[2].matchAll(RE_DATA_ATTR)) {
-          if (m[1] && m[2])
-            rootAttrs[`data-${m[1]}`] = m[2]
-        }
-      }
-      // Fallback: if no data-theme on root, use colorPreference from module config
-      if (!rootAttrs['data-theme'] && options.colorPreference)
-        rootAttrs['data-theme'] = options.colorPreference
-
-      // Detect dynamic :data-theme="<expr>" binding on root element. When present,
-      // resolve classes for both light and dark themes and emit paired rewrites so
-      // the runtime styleDirectives plugin can swap based on the colorMode prop.
-      const hasDynamicDataTheme = !!(rootAttrMatch?.[2] && RE_DYNAMIC_DATA_THEME.test(` ${rootAttrMatch[2]}`))
-
-      // Transform CSS utility classes to inline styles
-      if (options.cssProvider) {
-        options.beforeCssResolve?.()
-        try {
-          // Wrap current template back into full SFC for AST parsing
-          const fullCode = code.slice(0, templateStart) + template + code.slice(templateEnd)
-
-          const result = await transformVueTemplate(fullCode, {
-            resolveStyles: async (classes) => {
-              // Filter unsupported classes and icon classes (handled via SVG replacement)
-              const supported = classes.filter(cls => !isUnsupportedClass(cls) && !isIconClass(cls))
-              const unsupported = classes.filter(cls => isUnsupportedClass(cls))
-
-              if (unsupported.length > 0) {
-                const componentName = id.split('/').pop()
-                logger.warn(`[nuxt-og-image] ${componentName}: Filtered unsupported classes: ${unsupported.join(', ')}`)
-              }
-
-              const componentName = id.split('/').pop()?.replace(RE_FILE_EXTENSION, '')
-
-              if (hasDynamicDataTheme) {
-                const lightAttrs = { ...rootAttrs, 'data-theme': 'light' }
-                const darkAttrs = { ...rootAttrs, 'data-theme': 'dark' }
-                const [lightResolved, darkResolved] = await Promise.all([
-                  options.cssProvider!.resolveClassesToStyles(supported, componentName, lightAttrs),
-                  options.cssProvider!.resolveClassesToStyles(supported, componentName, darkAttrs),
-                ])
-                return mergeThemePairs(supported, lightResolved, darkResolved)
-              }
-
-              return options.cssProvider!.resolveClassesToStyles(supported, componentName, rootAttrs)
-            },
-          })
-
-          if (result) {
-            const newBounds = getOuterTemplateBounds(result.code)
-            if (newBounds) {
-              template = result.code.slice(newBounds.templateStart, newBounds.templateEnd)
-              hasChanges = true
-            }
-          }
-        }
-        catch (err) {
-          const componentName = id.split('/').pop()
-          logger.warn(`[nuxt-og-image] ${componentName}: CSS template transform failed, using original template`, (err as Error).message)
-          // Continue without CSS transforms - Satori will try to handle classes via tw prop
-        }
-      }
-
-      // Resolve var() in HTML attributes and inline styles
-      if (template.includes('var(')) {
-        const vars = options.cssProvider?.getVars
-          ? await options.cssProvider.getVars(rootAttrs)
-          : new Map<string, string>()
-
-        // Extract inline CSS custom property definitions from static style attributes
-        RE_INLINE_STYLE.lastIndex = 0
-        for (const m of template.matchAll(RE_INLINE_STYLE)) {
-          RE_CSS_VAR_DEF.lastIndex = 0
-          for (const def of m[1]!.matchAll(RE_CSS_VAR_DEF)) {
-            const name = `--${def[1]}`
-            if (!vars.has(name))
-              vars.set(name, def[2]!.trim())
-          }
-        }
-
-        if (vars.size > 0) {
-          // Non-style, non-class attributes (e.g., SVG fill="var(--bg)").
-          // Track resolved values unescaped so downlevelColor can parse them; escape
-          // for HTML only at the final write.
-          const replacements: Array<{ from: string, to: string, attr: string, value: string }> = []
-          RE_NON_STYLE_VAR_ATTR.lastIndex = 0
-          template.replace(RE_NON_STYLE_VAR_ATTR, (match, attr, value) => {
-            const resolved = resolveCssVars(value, vars)
-            if (resolved !== value) {
-              replacements.push({ from: match, to: '', attr, value: resolved })
-            }
-            return match
-          })
-          // Downlevel modern colors (oklch, etc.) in color-related attributes
-          for (const r of replacements) {
-            let value = r.value
-            if (RE_COLOR_ATTR_NAME.test(r.attr)) {
-              value = await downlevelColor(r.attr, value)
-            }
-            r.to = `${r.attr}="${escapeAttrValue(value)}"`
-            template = template.replace(r.from, r.to)
-            hasChanges = true
-          }
-
-          // Inline style attributes: resolve var() and downlevel colors per-declaration.
-          // Hold resolved style content unescaped so downlevelColor / resolveColorMix can
-          // parse it; escape for HTML only when writing the attribute.
-          const styleReplacements: Array<{ from: string, content: string }> = []
-          RE_STYLE_VAR_ATTR.lastIndex = 0
-          template.replace(RE_STYLE_VAR_ATTR, (match, styleValue) => {
-            const resolved = resolveCssVars(styleValue, vars)
-            if (resolved !== styleValue)
-              styleReplacements.push({ from: match, content: resolved })
-            return match
-          })
-          for (const r of styleReplacements) {
-            const declarations = r.content.split(';').filter(Boolean)
-            const downleveled: string[] = []
-            for (const decl of declarations) {
-              const colonIdx = decl.indexOf(':')
-              if (colonIdx === -1) {
-                downleveled.push(decl)
-                continue
-              }
-              const prop = decl.slice(0, colonIdx).trim()
-              let value = decl.slice(colonIdx + 1).trim()
-              if (RE_COLOR_PROP_NAME.test(prop) && !value.includes('var(')) {
-                value = await downlevelColor(prop, value)
-                if (value.includes('color-mix('))
-                  value = resolveColorMix(value)
-              }
-              downleveled.push(`${prop}: ${value}`)
-            }
-            const to = `style="${escapeAttrValue(downleveled.join('; '))}"`
-            template = template.replace(r.from, to)
-            hasChanges = true
-          }
-
-          // Dynamic :style bindings: resolve var() in Vue :style="..." attributes
-          RE_DYNAMIC_STYLE_VAR.lastIndex = 0
-          const dynamicReplacements: Array<{ from: string, to: string }> = []
-          template.replace(RE_DYNAMIC_STYLE_VAR, (match, styleExpr) => {
-            const resolved = resolveCssVars(styleExpr, vars)
-            if (resolved !== styleExpr)
-              dynamicReplacements.push({ from: match, to: `:style="${resolved}"` })
-            return match
-          })
-          for (const r of dynamicReplacements) {
-            template = template.replace(r.from, r.to)
-            hasChanges = true
-          }
-        }
-      }
-
-      // Transform images: src="/path" or src="~/path" or src="@/path"
-      if (!template.includes('data-no-inline')) {
-        RE_IMAGE_SRC.lastIndex = 0
-        if (RE_IMAGE_SRC.test(template)) {
-          RE_IMAGE_SRC.lastIndex = 0
-
-          const componentDir = dirname(id)
-          const replacements: Array<{ from: string, to: string }> = []
-
-          let match
-          // eslint-disable-next-line no-cond-assign
-          while ((match = RE_IMAGE_SRC.exec(template)) !== null) {
-            const [fullMatch, srcPath, ext] = match
-            if (!srcPath || !ext)
-              continue
-
-            if (srcPath.startsWith('data:') || srcPath.startsWith('http'))
-              continue
-
-            let resolvedPath: string
-            if (srcPath.startsWith('/')) {
-              resolvedPath = join(options.publicDir, srcPath)
-            }
-            else if (srcPath.startsWith('~/') || srcPath.startsWith('@/')) {
-              resolvedPath = join(options.srcDir, srcPath.slice(2))
-            }
-            else if (!isAbsolute(srcPath)) {
-              resolvedPath = resolve(componentDir, srcPath)
-            }
-            else {
-              continue
-            }
-
-            const fileBuffer = await readFile(resolvedPath).catch(() => {
-              // Missing component assets remain unchanged in the transformed template.
+        // Transform emojis in text content
+        if (options.emojiSet && RE_MATCH_EMOJIS.test(template)) {
+          // Try local icons first, fallback to fetch
+          if (!emojiIcons) {
+            emojiIcons = options.emojiIcons ?? await import(`@iconify-json/${options.emojiSet}/icons.json`, {
+              with: { type: 'json' },
+            }).then(m => m.default).catch(() => {
+              // Missing optional emoji packages fall back to remote icon resolution.
               return null
             })
-            if (!fileBuffer)
+          }
+
+          // Collect all unique emojis in template
+          RE_MATCH_EMOJIS.lastIndex = 0
+          const allEmojis = new Set<string>()
+          for (const match of template.matchAll(RE_MATCH_EMOJIS)) {
+            allEmojis.add(match[0])
+          }
+
+          // Resolve emoji SVGs in parallel (local first, fetch fallback)
+          const emojiSvgMap = new Map<string, string>()
+          await Promise.all(Array.from(allEmojis, async (emoji) => {
+            let svg: string | null = null
+            if (emojiIcons) {
+              svg = buildEmojiSvg(emoji, emojiIcons, options.emojiSet!)
+            }
+            if (!svg) {
+              svg = await fetchEmojiSvg(emoji, options.emojiSet!)
+            }
+            if (svg) {
+              emojiSvgMap.set(emoji, svg)
+            }
+          }))
+
+          // Replace emojis with resolved SVGs
+          if (emojiSvgMap.size > 0) {
+            RE_TEXT_BETWEEN_TAGS.lastIndex = 0
+            template = template.replace(RE_TEXT_BETWEEN_TAGS, (fullMatch, textContent) => {
+              if (!textContent)
+                return fullMatch
+
+              RE_MATCH_EMOJIS.lastIndex = 0
+              const emojiMatches = [...textContent.matchAll(RE_MATCH_EMOJIS)]
+              if (!emojiMatches.length)
+                return fullMatch
+
+              let newTextContent = textContent
+              for (const match of emojiMatches) {
+                const emoji = match[0]
+                const svg = emojiSvgMap.get(emoji)
+                if (svg) {
+                  hasChanges = true
+                  const escaped = emoji.replace(RE_SPECIAL_REGEX_CHARS, '\\$&')
+                  newTextContent = newTextContent.replace(new RegExp(escaped, 'g'), svg)
+                }
+              }
+              return `>${newTextContent}<`
+            })
+          }
+        }
+
+        // Transform icons: <Icon name="..." /> or <UIcon name="..." />
+        // Use ultrahtml to parse and transform - avoids complex regex patterns
+        if (template.includes('<Icon') || template.includes('<UIcon')) {
+          // First pass: collect icon prefixes from AST
+          const prefixes = new Set<string>()
+          const iconElements: Array<{ node: ElementNode, parent: Node, index: number }> = []
+
+          // Wrap in div for parsing (ultrahtml needs a root)
+          const wrappedTemplate = `<div>${template}</div>`
+          const doc = parseHtml(wrappedTemplate)
+
+          walkSync(doc, (node, parent, index) => {
+            if (node.type === ELEMENT_NODE) {
+              const el = node as ElementNode
+              if (el.name === 'Icon' || el.name === 'UIcon') {
+                const iconName = el.attributes.name
+                if (iconName && !iconName.includes('{')) {
+                  const [prefix] = iconName.split(':')
+                  if (prefix)
+                    prefixes.add(prefix)
+                  iconElements.push({ node: el, parent: parent!, index: index! })
+                }
+              }
+            }
+          })
+
+          // Load icon sets
+          const iconSets = new Map<string, IconifyJSON>()
+          for (const prefix of prefixes) {
+            const icons = await loadIconSet(prefix)
+            if (icons)
+              iconSets.set(prefix, icons)
+          }
+
+          // Second pass: replace icon elements with SVG
+          if (iconElements.length > 0) {
+            let anyReplaced = false
+            for (const { node: el, parent, index } of iconElements) {
+              const iconName = el.attributes.name
+              if (!iconName)
+                continue
+
+              const [prefix, name] = iconName.split(':')
+              if (!prefix || !name)
+                continue
+
+              // Try @iconify-json package first
+              const icons = iconSets.get(prefix)
+              const iconData = icons?.icons?.[name]
+
+              let svgHtml: string | undefined
+              if (iconData) {
+                svgHtml = buildIconSvg(iconData, icons!.width || 24, icons!.height || 24, el.attributes)
+              }
+              // Fallback: resolve from CSS provider (e.g. UnoCSS presetIcons custom collections)
+              else if (options.cssProvider?.resolveIcon) {
+                const resolved = await options.cssProvider.resolveIcon(prefix, name)
+                if (resolved)
+                  svgHtml = buildIconSvg(resolved, resolved.width, resolved.height, el.attributes)
+              }
+
+              if (!svgHtml)
+                continue
+
+              anyReplaced = true
+              hasChanges = true
+              const svgDoc = parseHtml(svgHtml)
+              if ('children' in parent && Array.isArray(parent.children)) {
+                parent.children[index] = svgDoc.children[0]
+              }
+            }
+
+            if (anyReplaced) {
+              // Render back to HTML, removing the wrapper div
+              const rendered = renderSync(doc)
+              // Remove wrapper div
+              template = rendered.replace(RE_WRAPPER_DIV_START, '').replace(RE_WRAPPER_DIV_END, '')
+            }
+          }
+        }
+
+        // Transform UnoCSS icon classes (i-{collection}-{name}) to inline SVGs
+        // Uses targeted string replacement (not ultrahtml renderSync) to preserve Vue directives like v-if
+        if (options.cssProvider?.resolveIcon) {
+          // Match elements with icon classes — self-closing or empty paired tags only
+          const replacements: Array<{ from: string, to: string }> = []
+
+          RE_ICON_ELEMENT.lastIndex = 0
+          let elMatch
+          // eslint-disable-next-line no-cond-assign
+          while ((elMatch = RE_ICON_ELEMENT.exec(template)) !== null) {
+            const [fullMatch, , attrsStr, classValue] = elMatch
+            if (!classValue)
               continue
 
-            const mimeType = getMimeType(ext)
-            let dataUri: string
-            if (ext === 'svg') {
-              const svgContent = fileBuffer.toString('utf-8')
-              dataUri = `data:${mimeType},${encodeURIComponent(svgContent)}`
+            // Check if class contains an icon pattern
+            const classes = classValue.split(RE_WHITESPACE).filter(Boolean)
+            let iconPrefix: string | undefined
+            let iconName: string | undefined
+            for (const cls of classes) {
+              const im = cls.match(ICON_CLASS_RE)
+              if (im?.[1] && im[2]) {
+                iconPrefix = im[1]
+                iconName = im[2]
+                break
+              }
             }
-            else {
-              const base64 = fileBuffer.toString('base64')
-              dataUri = `data:${mimeType};base64,${base64}`
+            if (!iconPrefix || !iconName)
+              continue
+
+            const resolved = await options.cssProvider.resolveIcon!(iconPrefix, iconName)
+            if (!resolved)
+              continue
+
+            // Parse attributes from raw string, excluding class (rebuilt below), name,
+            // and Vue dynamic bindings for style (:style/v-bind:style — the element is
+            // replaced with a static SVG wrapper so dynamic bindings can't be evaluated)
+            const attrs: Record<string, string> = {}
+            RE_HTML_ATTR.lastIndex = 0
+            let am
+            // eslint-disable-next-line no-cond-assign
+            while ((am = RE_HTML_ATTR.exec(attrsStr!)) !== null) {
+              if (am[1] && am[1] !== 'class' && am[1] !== ':style' && am[1] !== 'v-bind:style')
+                attrs[am[1]] = am[2] ?? ''
             }
 
-            replacements.push({ from: fullMatch, to: `src="${dataUri}"` })
-            hasChanges = true
+            // Keep non-icon classes
+            const otherClasses = classes.filter(c => !isIconClass(c))
+            if (otherClasses.length > 0)
+              attrs.class = otherClasses.join(' ')
+
+            const svgHtml = buildIconSvg(resolved, resolved.width, resolved.height, attrs)
+            replacements.push({ from: fullMatch, to: svgHtml })
           }
 
           for (const { from, to } of replacements) {
             template = template.replace(from, to)
+            hasChanges = true
           }
         }
-      }
 
-      // Inline <style> blocks into template elements at build time.
-      // Both satori and takumi need inline styles — <style> blocks aren't applied at render time.
-      {
-        const { descriptor } = parseSfc(code)
-        if (descriptor.styles.length > 0) {
-          for (const styleBlock of descriptor.styles) {
-            const rawCss = styleBlock.content
-            // Strip scoped data-v attribute selectors so we can match by class name alone
-            const scopeId = styleBlock.scoped
-              ? (rawCss.match(RE_SCOPED_DATA_V)?.[0] ?? null)
-              : null
-            const cleanCss = scopeId ? rawCss.replaceAll(scopeId, '') : rawCss
+        // Extract data-* attrs from the template root element for CSS var resolution
+        const rootAttrs: Record<string, string> = {}
+        const rootAttrMatch = template.match(RE_ROOT_ELEMENT)
+        if (rootAttrMatch?.[2]) {
+          RE_DATA_ATTR.lastIndex = 0
+          for (const m of rootAttrMatch[2].matchAll(RE_DATA_ATTR)) {
+            if (m[1] && m[2])
+              rootAttrs[`data-${m[1]}`] = m[2]
+          }
+        }
+        // Fallback: if no data-theme on root, use colorPreference from module config
+        if (!rootAttrs['data-theme'] && options.colorPreference)
+          rootAttrs['data-theme'] = options.colorPreference
 
-            const simplified = await simplifyCss(cleanCss)
-            const classMap = extractClassStyles(simplified, { skipPrefixes: [] })
+        // Detect dynamic :data-theme="<expr>" binding on root element. When present,
+        // resolve classes for both light and dark themes and emit paired rewrites so
+        // the runtime styleDirectives plugin can swap based on the colorMode prop.
+        const hasDynamicDataTheme = !!(rootAttrMatch?.[2] && RE_DYNAMIC_DATA_THEME.test(` ${rootAttrMatch[2]}`))
 
-            if (classMap.size > 0) {
-              // Walk template elements and merge matching styles
-              const wrappedTemplate = `<div>${template}</div>`
-              const doc = parseHtml(wrappedTemplate)
+        // Transform CSS utility classes to inline styles
+        if (options.cssProvider) {
+          options.beforeCssResolve?.()
+          try {
+            // Wrap current template back into full SFC for AST parsing
+            const fullCode = code.slice(0, templateStart) + template + code.slice(templateEnd)
 
-              walkSync(doc, (node) => {
-                if (node.type !== ELEMENT_NODE)
-                  return
-                const el = node as ElementNode
-                const classAttr = el.attributes?.class
-                if (!classAttr)
-                  return
+            const result = await transformVueTemplate(fullCode, {
+              resolveStyles: async (classes) => {
+                // Filter unsupported classes and icon classes (handled via SVG replacement)
+                const supported = classes.filter(cls => !isUnsupportedClass(cls) && !isIconClass(cls))
+                const unsupported = classes.filter(cls => isUnsupportedClass(cls))
 
-                const elClasses = classAttr.split(RE_WHITESPACE).filter(Boolean)
-                const matchedStyles: Record<string, string> = {}
-                const consumedClasses = new Set<string>()
-
-                for (const cls of elClasses) {
-                  const styles = classMap.get(cls)
-                  if (styles) {
-                    Object.assign(matchedStyles, styles)
-                    consumedClasses.add(cls)
-                  }
+                if (unsupported.length > 0) {
+                  const componentName = id.split('/').pop()
+                  logger.warn(`[nuxt-og-image] ${componentName}: Filtered unsupported classes: ${unsupported.join(', ')}`)
                 }
 
-                if (Object.keys(matchedStyles).length === 0)
-                  return
+                const componentName = id.split('/').pop()?.replace(RE_FILE_EXTENSION, '')
 
-                // Merge into existing inline style (inline style takes precedence)
-                const existingStyle = el.attributes?.style || ''
-                const existingProps: Record<string, string> = {}
-                for (const decl of splitCssDeclarations(existingStyle)) {
-                  const [prop, ...valParts] = decl.split(':')
-                  const value = valParts.join(':').trim()
-                  if (prop?.trim() && value)
-                    existingProps[prop.trim()] = value
+                if (hasDynamicDataTheme) {
+                  const lightAttrs = { ...rootAttrs, 'data-theme': 'light' }
+                  const darkAttrs = { ...rootAttrs, 'data-theme': 'dark' }
+                  const [lightResolved, darkResolved] = await Promise.all([
+                    options.cssProvider!.resolveClassesToStyles(supported, componentName, lightAttrs),
+                    options.cssProvider!.resolveClassesToStyles(supported, componentName, darkAttrs),
+                  ])
+                  return mergeThemePairs(supported, lightResolved, darkResolved)
                 }
 
-                const merged = { ...matchedStyles, ...existingProps }
-                // ultrahtml's serializer does not escape attribute values, so any literal
-                // `"` in a CSS value (e.g. `background-image: url("data:...")`) would close
-                // the `style="..."` attribute early and produce invalid HTML.
-                el.attributes.style = escapeAttrValue(
-                  Object.entries(merged)
-                    .map(([p, v]) => `${p}:${v}`)
-                    .join(';'),
-                )
+                return options.cssProvider!.resolveClassesToStyles(supported, componentName, rootAttrs)
+              },
+            })
 
-                // Remove consumed classes
-                const remaining = elClasses.filter(c => !consumedClasses.has(c))
-                if (remaining.length > 0)
-                  el.attributes.class = remaining.join(' ')
-                else
-                  delete el.attributes.class
+            if (result) {
+              const newBounds = getOuterTemplateBounds(result.code)
+              if (newBounds) {
+                template = result.code.slice(newBounds.templateStart, newBounds.templateEnd)
+                hasChanges = true
+              }
+            }
+          }
+          catch (err) {
+            const componentName = id.split('/').pop()
+            logger.warn(`[nuxt-og-image] ${componentName}: CSS template transform failed, using original template`, (err as Error).message)
+            // Continue without CSS transforms - Satori will try to handle classes via tw prop
+          }
+        }
 
-                // viewBox must be preserved (not kebab-cased)
-                if (el.attributes.viewbox) {
-                  el.attributes.viewBox = el.attributes.viewbox
-                  delete el.attributes.viewbox
+        // Resolve var() in HTML attributes and inline styles
+        if (template.includes('var(')) {
+          const vars = options.cssProvider?.getVars
+            ? await options.cssProvider.getVars(rootAttrs)
+            : new Map<string, string>()
+
+          // Extract inline CSS custom property definitions from static style attributes
+          RE_INLINE_STYLE.lastIndex = 0
+          for (const m of template.matchAll(RE_INLINE_STYLE)) {
+            RE_CSS_VAR_DEF.lastIndex = 0
+            for (const def of m[1]!.matchAll(RE_CSS_VAR_DEF)) {
+              const name = `--${def[1]}`
+              if (!vars.has(name))
+                vars.set(name, def[2]!.trim())
+            }
+          }
+
+          if (vars.size > 0) {
+            // Non-style, non-class attributes (e.g., SVG fill="var(--bg)").
+            // Track resolved values unescaped so downlevelColor can parse them; escape
+            // for HTML only at the final write.
+            const replacements: Array<{ from: string, to: string, attr: string, value: string }> = []
+            RE_NON_STYLE_VAR_ATTR.lastIndex = 0
+            template.replace(RE_NON_STYLE_VAR_ATTR, (match, attr, value) => {
+              const resolved = resolveCssVars(value, vars)
+              if (resolved !== value) {
+                replacements.push({ from: match, to: '', attr, value: resolved })
+              }
+              return match
+            })
+            // Downlevel modern colors (oklch, etc.) in color-related attributes
+            for (const r of replacements) {
+              let value = r.value
+              if (RE_COLOR_ATTR_NAME.test(r.attr)) {
+                value = await downlevelColor(r.attr, value)
+              }
+              r.to = `${r.attr}="${escapeAttrValue(value)}"`
+              template = template.replace(r.from, r.to)
+              hasChanges = true
+            }
+
+            // Inline style attributes: resolve var() and downlevel colors per-declaration.
+            // Hold resolved style content unescaped so downlevelColor / resolveColorMix can
+            // parse it; escape for HTML only when writing the attribute.
+            const styleReplacements: Array<{ from: string, content: string }> = []
+            RE_STYLE_VAR_ATTR.lastIndex = 0
+            template.replace(RE_STYLE_VAR_ATTR, (match, styleValue) => {
+              const resolved = resolveCssVars(styleValue, vars)
+              if (resolved !== styleValue)
+                styleReplacements.push({ from: match, content: resolved })
+              return match
+            })
+            for (const r of styleReplacements) {
+              const declarations = r.content.split(';').filter(Boolean)
+              const downleveled: string[] = []
+              for (const decl of declarations) {
+                const colonIdx = decl.indexOf(':')
+                if (colonIdx === -1) {
+                  downleveled.push(decl)
+                  continue
                 }
-              })
+                const prop = decl.slice(0, colonIdx).trim()
+                let value = decl.slice(colonIdx + 1).trim()
+                if (RE_COLOR_PROP_NAME.test(prop) && !value.includes('var(')) {
+                  value = await downlevelColor(prop, value)
+                  if (value.includes('color-mix('))
+                    value = resolveColorMix(value)
+                }
+                downleveled.push(`${prop}: ${value}`)
+              }
+              const to = `style="${escapeAttrValue(downleveled.join('; '))}"`
+              template = template.replace(r.from, to)
+              hasChanges = true
+            }
 
-              template = renderSync(doc).replace(RE_WRAPPER_DIV_START, '').replace(RE_WRAPPER_DIV_END, '')
+            // Dynamic :style bindings: resolve var() in Vue :style="..." attributes
+            RE_DYNAMIC_STYLE_VAR.lastIndex = 0
+            const dynamicReplacements: Array<{ from: string, to: string }> = []
+            template.replace(RE_DYNAMIC_STYLE_VAR, (match, styleExpr) => {
+              const resolved = resolveCssVars(styleExpr, vars)
+              if (resolved !== styleExpr)
+                dynamicReplacements.push({ from: match, to: `:style="${resolved}"` })
+              return match
+            })
+            for (const r of dynamicReplacements) {
+              template = template.replace(r.from, r.to)
               hasChanges = true
             }
           }
+        }
 
-          // Remove all <style> blocks from the SFC — styles are now inlined
-          for (const styleBlock of descriptor.styles) {
-            const styleStart = code.indexOf(styleBlock.loc.source) - '<style'.length
-            // Find the full <style...>...</style> tag
-            const fullTagStart = code.lastIndexOf('<style', styleStart + '<style'.length)
-            const fullTagEnd = code.indexOf('</style>', styleStart) + '</style>'.length
-            if (fullTagStart >= 0 && fullTagEnd > fullTagStart) {
-              s.remove(fullTagStart, fullTagEnd)
+        // Transform images: src="/path" or src="~/path" or src="@/path"
+        if (!template.includes('data-no-inline')) {
+          RE_IMAGE_SRC.lastIndex = 0
+          if (RE_IMAGE_SRC.test(template)) {
+            RE_IMAGE_SRC.lastIndex = 0
+
+            const componentDir = dirname(id)
+            const replacements: Array<{ from: string, to: string }> = []
+
+            let match
+            // eslint-disable-next-line no-cond-assign
+            while ((match = RE_IMAGE_SRC.exec(template)) !== null) {
+              const [fullMatch, srcPath, ext] = match
+              if (!srcPath || !ext)
+                continue
+
+              if (srcPath.startsWith('data:') || srcPath.startsWith('http'))
+                continue
+
+              let resolvedPath: string
+              if (srcPath.startsWith('/')) {
+                resolvedPath = join(options.publicDir, srcPath)
+              }
+              else if (srcPath.startsWith('~/') || srcPath.startsWith('@/')) {
+                resolvedPath = join(options.srcDir, srcPath.slice(2))
+              }
+              else if (!isAbsolute(srcPath)) {
+                resolvedPath = resolve(componentDir, srcPath)
+              }
+              else {
+                continue
+              }
+
+              const fileBuffer = await readFile(resolvedPath).catch(() => {
+                // Missing component assets remain unchanged in the transformed template.
+                return null
+              })
+              if (!fileBuffer)
+                continue
+
+              const mimeType = getMimeType(ext)
+              let dataUri: string
+              if (ext === 'svg') {
+                const svgContent = fileBuffer.toString('utf-8')
+                dataUri = `data:${mimeType},${encodeURIComponent(svgContent)}`
+              }
+              else {
+                const base64 = fileBuffer.toString('base64')
+                dataUri = `data:${mimeType};base64,${base64}`
+              }
+
+              replacements.push({ from: fullMatch, to: `src="${dataUri}"` })
+              hasChanges = true
+            }
+
+            for (const { from, to } of replacements) {
+              template = template.replace(from, to)
             }
           }
         }
-      }
 
-      // Extract font requirements from the original code (before transforms)
-      if (options.onFontRequirements) {
-        extractFontRequirementsFromVue(code).then((reqs) => {
-          options.onFontRequirements!(id, reqs)
-        })
-      }
+        // Inline <style> blocks into template elements at build time.
+        // Both satori and takumi need inline styles — <style> blocks aren't applied at render time.
+        {
+          const { descriptor } = parseSfc(code)
+          if (descriptor.styles.length > 0) {
+            for (const styleBlock of descriptor.styles) {
+              const rawCss = styleBlock.content
+              // Strip scoped data-v attribute selectors so we can match by class name alone
+              const scopeId = styleBlock.scoped
+                ? (rawCss.match(RE_SCOPED_DATA_V)?.[0] ?? null)
+                : null
+              const cleanCss = scopeId ? rawCss.replaceAll(scopeId, '') : rawCss
 
-      if (!hasChanges)
-        return
+              const simplified = await simplifyCss(cleanCss)
+              const classMap = extractClassStyles(simplified, { skipPrefixes: [] })
 
-      s.overwrite(templateStart, templateEnd, template)
+              if (classMap.size > 0) {
+                // Walk template elements and merge matching styles
+                const wrappedTemplate = `<div>${template}</div>`
+                const doc = parseHtml(wrappedTemplate)
 
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true }),
-      }
+                walkSync(doc, (node) => {
+                  if (node.type !== ELEMENT_NODE)
+                    return
+                  const el = node as ElementNode
+                  const classAttr = el.attributes?.class
+                  if (!classAttr)
+                    return
+
+                  const elClasses = classAttr.split(RE_WHITESPACE).filter(Boolean)
+                  const matchedStyles: Record<string, string> = {}
+                  const consumedClasses = new Set<string>()
+
+                  for (const cls of elClasses) {
+                    const styles = classMap.get(cls)
+                    if (styles) {
+                      Object.assign(matchedStyles, styles)
+                      consumedClasses.add(cls)
+                    }
+                  }
+
+                  if (Object.keys(matchedStyles).length === 0)
+                    return
+
+                  // Merge into existing inline style (inline style takes precedence)
+                  const existingStyle = el.attributes?.style || ''
+                  const existingProps: Record<string, string> = {}
+                  for (const decl of splitCssDeclarations(existingStyle)) {
+                    const [prop, ...valParts] = decl.split(':')
+                    const value = valParts.join(':').trim()
+                    if (prop?.trim() && value)
+                      existingProps[prop.trim()] = value
+                  }
+
+                  const merged = { ...matchedStyles, ...existingProps }
+                  // ultrahtml's serializer does not escape attribute values, so any literal
+                  // `"` in a CSS value (e.g. `background-image: url("data:...")`) would close
+                  // the `style="..."` attribute early and produce invalid HTML.
+                  el.attributes.style = escapeAttrValue(
+                    Object.entries(merged)
+                      .map(([p, v]) => `${p}:${v}`)
+                      .join(';'),
+                  )
+
+                  // Remove consumed classes
+                  const remaining = elClasses.filter(c => !consumedClasses.has(c))
+                  if (remaining.length > 0)
+                    el.attributes.class = remaining.join(' ')
+                  else
+                    delete el.attributes.class
+
+                  // viewBox must be preserved (not kebab-cased)
+                  if (el.attributes.viewbox) {
+                    el.attributes.viewBox = el.attributes.viewbox
+                    delete el.attributes.viewbox
+                  }
+                })
+
+                template = renderSync(doc).replace(RE_WRAPPER_DIV_START, '').replace(RE_WRAPPER_DIV_END, '')
+                hasChanges = true
+              }
+            }
+
+            // Remove all <style> blocks from the SFC — styles are now inlined
+            for (const styleBlock of descriptor.styles) {
+              const styleStart = code.indexOf(styleBlock.loc.source) - '<style'.length
+              // Find the full <style...>...</style> tag
+              const fullTagStart = code.lastIndexOf('<style', styleStart + '<style'.length)
+              const fullTagEnd = code.indexOf('</style>', styleStart) + '</style>'.length
+              if (fullTagStart >= 0 && fullTagEnd > fullTagStart) {
+                s.remove(fullTagStart, fullTagEnd)
+              }
+            }
+          }
+        }
+
+        // Extract font requirements from the original code (before transforms)
+        if (options.onFontRequirements) {
+          extractFontRequirementsFromVue(code).then((reqs) => {
+            options.onFontRequirements!(id, reqs)
+          })
+        }
+
+        if (!hasChanges)
+          return
+
+        s.overwrite(templateStart, templateEnd, template)
+
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true }),
+        }
+      },
     },
   }
 })

--- a/src/build/vite-component-import-rewrite.ts
+++ b/src/build/vite-component-import-rewrite.ts
@@ -203,6 +203,9 @@ const MAX_IMPORT_REWRITE_DEPTH = 5
 
 const RE_OG_IMAGE_QUERY = /\?og-image(?:-depth=(\d+))?$/
 const RE_VUE_IMPORT = /import\s+(\w+)\s+from\s+(['"])(.+?\.vue)\2/g
+// Ids carry a query in dev and for SFC blocks, so the extension match allows one. The
+// bundler applies this before the hook runs, which keeps the rest of the graph out.
+const RE_VUE_ID = /\.vue(?:\?|$)/
 
 /**
  * Injects explicit imports with ?og-image for nested components used in OG templates.
@@ -214,118 +217,124 @@ export const ComponentImportRewritePlugin = createUnplugin((options: ComponentIm
     name: 'nuxt-og-image:component-import-rewrite',
     enforce: 'pre',
 
-    transformInclude(id) {
-      // Allow cascading through ?og-image files up to a depth limit
-      const depthMatch = id.match(RE_OG_IMAGE_QUERY)
-      if (depthMatch) {
-        const depth = depthMatch[1] ? Number.parseInt(depthMatch[1]) : 0
-        return depth < MAX_IMPORT_REWRITE_DEPTH
-      }
-      if (!id.endsWith('.vue'))
-        return false
-      return options.ogComponentPaths.some(dir => id.startsWith(`${dir}/`) || id.startsWith(`${dir}\\`))
-    },
-
-    transform(code, rawId) {
-      // Parse current depth from ?og-image-depth=N
-      const depthMatch = rawId.match(RE_OG_IMAGE_QUERY)
-      const currentDepth = depthMatch?.[1] ? Number.parseInt(depthMatch[1]) : 0
-      const nextQuery = `?og-image-depth=${currentDepth + 1}`
-      const { descriptor } = parseSfc(code)
-      if (!descriptor.template?.ast) {
-        return
-      }
-
-      // Collect component tag names used in the template
-      const usedComponents = new Set<string>()
-      walkTemplateAst(descriptor.template.ast.children, (node) => {
-        // type 1 = NodeTypes.ELEMENT
-        if (node.type === 1 && !HTML_ELEMENTS.has((node as ElementNode).tag) && !BUILTIN_COMPONENTS.has((node as ElementNode).tag)) {
-          usedComponents.add((node as ElementNode).tag)
+    transform: {
+      filter: {
+        id: RE_VUE_ID,
+      },
+      handler(code, rawId) {
+        // Parse current depth from ?og-image-depth=N
+        const depthMatch = rawId.match(RE_OG_IMAGE_QUERY)
+        const currentDepth = depthMatch?.[1] ? Number.parseInt(depthMatch[1]) : 0
+        if (depthMatch) {
+          // Allow cascading through ?og-image files up to a depth limit
+          if (currentDepth >= MAX_IMPORT_REWRITE_DEPTH)
+            return
         }
-      })
-
-      if (usedComponents.size === 0) {
-        return
-      }
-
-      // Resolve component tags against the Nuxt component registry
-      const components = options.getComponents()
-      const newImports: Array<{ name: string, filePath: string }> = []
-
-      for (const tag of usedComponents) {
-        // Already handled by asset transform (Icon/UIcon → inline SVG)
-        if (tag === 'Icon' || tag === 'UIcon')
-          continue
-
-        const match = components.find(c => c.pascalName === tag || c.kebabName === tag)
-        if (match?.filePath && match.filePath.endsWith('.vue')) {
-          newImports.push({ name: tag, filePath: match.filePath })
+        else {
+          // Only a top-level OG template seeds the cascade. `RE_VUE_ID` also admits SFC
+          // block ids, which never carry the query and are not files we own.
+          if (!rawId.endsWith('.vue'))
+            return
+          if (!options.ogComponentPaths.some(dir => rawId.startsWith(`${dir}/`) || rawId.startsWith(`${dir}\\`)))
+            return
         }
-      }
+        const nextQuery = `?og-image-depth=${currentDepth + 1}`
+        const { descriptor } = parseSfc(code)
+        if (!descriptor.template?.ast) {
+          return
+        }
 
-      if (newImports.length === 0) {
-        return
-      }
+        // Collect component tag names used in the template
+        const usedComponents = new Set<string>()
+        walkTemplateAst(descriptor.template.ast.children, (node) => {
+          // type 1 = NodeTypes.ELEMENT
+          if (node.type === 1 && !HTML_ELEMENTS.has((node as ElementNode).tag) && !BUILTIN_COMPONENTS.has((node as ElementNode).tag)) {
+            usedComponents.add((node as ElementNode).tag)
+          }
+        })
 
-      const s = new MagicString(code)
+        if (usedComponents.size === 0) {
+          return
+        }
 
-      // Rewrite existing .vue imports to add ?og-image, collect which ones we handled
-      const rewritten = new Set<string>()
-      const scriptBlock = descriptor.scriptSetup || descriptor.script
-      if (scriptBlock) {
-        const scriptStart = scriptBlock.loc.start.offset
-        const scriptContent = scriptBlock.content
-        // Match: import Foo from './path.vue' or "path.vue"
-        for (const m of scriptContent.matchAll(RE_VUE_IMPORT)) {
-          const importName = m[1]
-          if (newImports.some(i => i.name === importName)) {
-            const source = m[3]!
-            // Replace the source path with ?og-image appended
-            const matchStart = scriptStart + m.index! + m[0].indexOf(source)
-            s.overwrite(matchStart, matchStart + source.length, `${source}${nextQuery}`)
-            rewritten.add(importName!)
+        // Resolve component tags against the Nuxt component registry
+        const components = options.getComponents()
+        const newImports: Array<{ name: string, filePath: string }> = []
+
+        for (const tag of usedComponents) {
+          // Already handled by asset transform (Icon/UIcon → inline SVG)
+          if (tag === 'Icon' || tag === 'UIcon')
+            continue
+
+          const match = components.find(c => c.pascalName === tag || c.kebabName === tag)
+          if (match?.filePath && match.filePath.endsWith('.vue')) {
+            newImports.push({ name: tag, filePath: match.filePath })
           }
         }
-      }
 
-      // Filter to only imports not already rewritten
-      const imports = newImports.filter(i => !rewritten.has(i.name))
+        if (newImports.length === 0) {
+          return
+        }
 
-      if (imports.length === 0) {
+        const s = new MagicString(code)
+
+        // Rewrite existing .vue imports to add ?og-image, collect which ones we handled
+        const rewritten = new Set<string>()
+        const scriptBlock = descriptor.scriptSetup || descriptor.script
+        if (scriptBlock) {
+          const scriptStart = scriptBlock.loc.start.offset
+          const scriptContent = scriptBlock.content
+          // Match: import Foo from './path.vue' or "path.vue"
+          for (const m of scriptContent.matchAll(RE_VUE_IMPORT)) {
+            const importName = m[1]
+            if (newImports.some(i => i.name === importName)) {
+              const source = m[3]!
+              // Replace the source path with ?og-image appended
+              const matchStart = scriptStart + m.index! + m[0].indexOf(source)
+              s.overwrite(matchStart, matchStart + source.length, `${source}${nextQuery}`)
+              rewritten.add(importName!)
+            }
+          }
+        }
+
+        // Filter to only imports not already rewritten
+        const imports = newImports.filter(i => !rewritten.has(i.name))
+
+        if (imports.length === 0) {
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: true }),
+          }
+        }
+
+        // Build import statements for new imports
+        const importStatements = imports
+          .map(i => `import ${i.name} from '${i.filePath}${nextQuery}'`)
+          .join('\n')
+
+        // Inject into existing <script setup> or create one
+        if (descriptor.scriptSetup) {
+          // Insert after the opening <script setup> tag
+          const scriptSetupStart = code.indexOf('<script setup')
+          const tagEnd = code.indexOf('>', scriptSetupStart) + 1
+          s.appendRight(tagEnd, `\n${importStatements}`)
+        }
+        else if (descriptor.script) {
+          // Insert after the opening <script> tag
+          const scriptStart = code.indexOf('<script')
+          const tagEnd = code.indexOf('>', scriptStart) + 1
+          s.appendRight(tagEnd, `\n${importStatements}`)
+        }
+        else {
+          // No script block — add one
+          s.prepend(`<script setup>\n${importStatements}\n</script>\n`)
+        }
+
         return {
           code: s.toString(),
           map: s.generateMap({ hires: true }),
         }
-      }
-
-      // Build import statements for new imports
-      const importStatements = imports
-        .map(i => `import ${i.name} from '${i.filePath}${nextQuery}'`)
-        .join('\n')
-
-      // Inject into existing <script setup> or create one
-      if (descriptor.scriptSetup) {
-        // Insert after the opening <script setup> tag
-        const scriptSetupStart = code.indexOf('<script setup')
-        const tagEnd = code.indexOf('>', scriptSetupStart) + 1
-        s.appendRight(tagEnd, `\n${importStatements}`)
-      }
-      else if (descriptor.script) {
-        // Insert after the opening <script> tag
-        const scriptStart = code.indexOf('<script')
-        const tagEnd = code.indexOf('>', scriptStart) + 1
-        s.appendRight(tagEnd, `\n${importStatements}`)
-      }
-      else {
-        // No script block — add one
-        s.prepend(`<script setup>\n${importStatements}\n</script>\n`)
-      }
-
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true }),
-      }
+      },
     },
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -860,7 +860,10 @@ export default defineNuxtModule<ModuleOptions>({
       })
 
       if (!nuxt.options.dev) {
-        addBuildPlugin(TreeShakeComposablesPlugin, { server: true, client: true, build: true })
+        // `addBuildPlugin`'s `build` option cannot express "build only": kit skips a plugin
+        // on `build: false`, and `nuxt.options.build` is always truthy. The `nuxt.options.dev`
+        // guard above is the real switch.
+        addBuildPlugin(TreeShakeComposablesPlugin, { server: true, client: true })
         setRuntimeAlias('#og-image-cache', resolve('./runtime/server/og-image/cache/mock'))
       }
     }

--- a/test/unit/asset-transform.test.ts
+++ b/test/unit/asset-transform.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'pathe'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { AssetTransformPlugin } from '../../src/build/vite-asset-transform'
+import { runTransform } from '../unplugin'
 
 const testDir = join(__dirname, '__fixtures__')
 const publicDir = join(testDir, 'public')
@@ -36,20 +37,31 @@ describe('asset-transform plugin', () => {
       rmSync(testDir, { recursive: true })
   })
 
-  // Transform include tests
-  it('should include OgImage components', () => {
-    expect(plugin.transformInclude?.(join(srcDir, 'components', 'OgImage', 'Test.vue'))).toBe(true)
-    expect(plugin.transformInclude?.(join(srcDir, 'components', 'og-image', 'Test.vue'))).toBe(true)
-    expect(plugin.transformInclude?.(join(srcDir, 'components', 'OgImageTemplate', 'Test.vue'))).toBe(true)
+  // Module scope tests
+  const imageTemplate = `<template>
+  <div>
+    <img src="/logo.png" alt="Logo" />
+  </div>
+</template>`
+
+  it('should transform OgImage components', async () => {
+    for (const id of [
+      join(srcDir, 'components', 'OgImage', 'Test.vue'),
+      join(srcDir, 'components', 'og-image', 'Test.vue'),
+      join(srcDir, 'components', 'OgImageTemplate', 'Test.vue'),
+    ]) {
+      expect(await runTransform(plugin, imageTemplate, id)).toBeDefined()
+    }
   })
 
-  it('should exclude non-OgImage components', () => {
-    expect(plugin.transformInclude?.(join(srcDir, 'components', 'Header.vue'))).toBe(false)
-    expect(plugin.transformInclude?.(join(srcDir, 'pages', 'index.vue'))).toBe(false)
-  })
-
-  it('should exclude node_modules', () => {
-    expect(plugin.transformInclude?.('node_modules/some-pkg/OgImage.vue')).toBe(false)
+  it('should leave non-OgImage components alone', async () => {
+    for (const id of [
+      join(srcDir, 'components', 'Header.vue'),
+      join(srcDir, 'pages', 'index.vue'),
+      'node_modules/some-pkg/OgImage.vue',
+    ]) {
+      expect(await runTransform(plugin, imageTemplate, id)).toBeUndefined()
+    }
   })
 
   // Icon transform tests
@@ -60,7 +72,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     expect(result?.code).not.toContain('<Icon')
@@ -73,7 +85,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     expect(result?.code).not.toContain('<UIcon')
@@ -86,7 +98,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('class="text-xl text-blue-500"')
     // Style is merged with display:flex for Satori compatibility
@@ -101,7 +113,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('<Icon :name="dynamicIcon"')
     expect(result?.code).toContain('<svg')
@@ -116,7 +128,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     const svgCount = (result?.code.match(/<svg/g) || []).length
     expect(svgCount).toBe(3)
@@ -130,7 +142,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('data:image/png;base64,')
     expect(result?.code).not.toContain('src="/logo.png"')
@@ -143,7 +155,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('data:image/svg+xml,')
     expect(result?.code).not.toContain('src="/icon.svg"')
@@ -156,7 +168,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('data:image/svg+xml,')
   })
@@ -168,7 +180,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('data:image/svg+xml,')
   })
@@ -181,7 +193,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain(':src="dynamicSrc"')
     expect(result?.code).toContain('data:image/png;base64,')
@@ -194,7 +206,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeUndefined()
   })
 
@@ -207,7 +219,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     expect(result?.code).toContain('data:image/png;base64,')
@@ -220,7 +232,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeUndefined()
   })
 
@@ -229,7 +241,7 @@ describe('asset-transform plugin', () => {
 const icon = 'carbon:home'
 </script>`
 
-    const result = await plugin.transform?.(code, join(componentDir, 'Test.vue'))
+    const result = await runTransform(plugin, code, join(componentDir, 'Test.vue'))
     expect(result).toBeUndefined()
   })
 })

--- a/test/unit/icon-class-resolution.test.ts
+++ b/test/unit/icon-class-resolution.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { clearUnoCache, createUnoProvider, setUnoConfig, setUnoRootDir } from '../../src/build/css/providers/uno'
 import { AssetTransformPlugin } from '../../src/build/vite-asset-transform'
+import { runTransform } from '../unplugin'
 
 // ============================================================================
 // resolveIcon: UnoCSS presetIcons custom collections
@@ -133,7 +134,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     expect(result?.code).toContain('viewBox')
@@ -147,7 +148,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     expect(result?.code).not.toContain('i-custom-star')
@@ -166,7 +167,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     // Vue directives must be preserved (not mangled by ultrahtml)
@@ -181,7 +182,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     expect(result?.code).toContain('v-if="hasIcon"')
@@ -194,7 +195,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     expect(result?.code).not.toContain('i-custom-star')
@@ -207,7 +208,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     expect(result).toBeDefined()
     expect(result?.code).toContain('<svg')
     // buildIconSvg merges existing style with display:flex
@@ -222,7 +223,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     // No replacement possible, no other transforms → undefined
     expect(result).toBeUndefined()
   })
@@ -234,7 +235,7 @@ describe('asset-transform icon class replacement', () => {
   </div>
 </template>`
 
-    const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+    const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
     // "italic" and "inline" start with "i" but don't match i-{prefix}-{name} pattern.
     // CSS provider may still resolve them as utilities, but they must NOT become SVGs.
     if (result) {

--- a/test/unit/tree-shake-composables.test.ts
+++ b/test/unit/tree-shake-composables.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { TreeShakeComposablesPlugin } from '../../src/build/tree-shake-plugin'
+import { runTransform } from '../unplugin'
+
+const plugin = TreeShakeComposablesPlugin.raw(undefined, { framework: 'vite' })
+
+const CALL = `defineOgImage({ component: 'Test' })`
+
+describe('tree-shake composables plugin', () => {
+  describe('module scope', () => {
+    it.each([
+      'app/og.ts',
+      'app/og.mts',
+      'app/og.cts',
+      'app/og.mjs',
+      'app/og.cjs',
+      'app/og.jsx',
+      'app/og.tsx',
+      'app/og.ts?t=1699999999999',
+      'app/Page.vue',
+      'app/Page.vue?vue&type=script&setup=true&lang.ts',
+      'app/Page.vue?macro=true',
+    ])('tree-shakes %s', async (id) => {
+      const result = await runTransform(plugin, CALL, id)
+      expect(result?.code).toBe(` import.meta.prerender && ${CALL}`)
+    })
+
+    it.each([
+      // Only the script block of an SFC is ours.
+      'app/Page.vue?vue&type=style&index=0&lang.css',
+      'app/Page.vue?vue&type=template',
+      'app/Page.vue?nuxt_component=async',
+      // The island registry re-exports every component and must stay intact.
+      'app/.nuxt/components.islands.mjs',
+      // Not a module the bundler hands us as JS.
+      'app/styles.css',
+    ])('leaves %s alone', async (id) => {
+      expect(await runTransform(plugin, CALL, id)).toBeUndefined()
+    })
+  })
+
+  describe('rewrite', () => {
+    it('guards every composable in the module', async () => {
+      const code = [
+        `defineOgImage({ component: 'A' })`,
+        `defineOgImageComponent('B')`,
+        `defineOgImageScreenshot()`,
+      ].join('\n')
+
+      const result = await runTransform(plugin, code, 'app/og.ts')
+      expect(result?.code).toBe([
+        ` import.meta.prerender && defineOgImage({ component: 'A' })`,
+        ` import.meta.prerender && defineOgImageComponent('B')`,
+        ` import.meta.prerender && defineOgImageScreenshot()`,
+      ].join('\n'))
+    })
+
+    it('leaves a module that only names the composable alone', async () => {
+      expect(await runTransform(plugin, `export const helper = defineOgImage`, 'app/og.ts')).toBeUndefined()
+    })
+
+    it('leaves a call inside a string literal alone', async () => {
+      expect(await runTransform(plugin, `export const doc = \`\ndefineOgImage({})\n\``, 'app/og.ts')).toBeUndefined()
+    })
+  })
+})

--- a/test/unit/tw4-class-resolution.test.ts
+++ b/test/unit/tw4-class-resolution.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { decodeCssClassName, extractClassStyles, isSimpleClassSelector, postProcessStyles, resolveCssVars } from '../../src/build/css/css-utils'
 import { clearTw4Cache, createTw4Provider, resolveClassesToStyles } from '../../src/build/css/providers/tw4'
 import { AssetTransformPlugin } from '../../src/build/vite-asset-transform'
+import { runTransform } from '../unplugin'
 
 // Minimal TW4 CSS entrypoint for the test compiler
 const CSS_CONTENT = '@import "tailwindcss";'
@@ -953,7 +954,7 @@ describe('assetTransformPlugin with TW4', () => {
     )
 
     const id = join(tmpDir, 'components', 'Brutalist.satori.vue')
-    const result = await plugin.transform?.(code, id)
+    const result = await runTransform(plugin, code, id)
 
     expect(result, 'transform should produce output').toBeDefined()
     expect(result!.code).toContain('rotate(45deg)')
@@ -977,7 +978,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
     const id = join(tmpDir, 'components', 'Test.vue')
-    const result = await plugin.transform?.(code, id)
+    const result = await runTransform(plugin, code, id)
 
     expect(result, 'transform should produce output').toBeDefined()
     // rotate-45 should be resolved to transform: rotate(45deg) in style
@@ -1003,7 +1004,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
     const id = join(tmpDir, 'components', 'ArbitraryValues.vue')
-    const result = await plugin.transform?.(code, id)
+    const result = await runTransform(plugin, code, id)
 
     expect(result, 'transform should produce output').toBeDefined()
     // Arbitrary values should be resolved and removed from class
@@ -1033,7 +1034,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
       const id = join(tmpDir, 'components', 'ResponsiveKeep.vue')
-      const result = await plugin.transform?.(code, id)
+      const result = await runTransform(plugin, code, id)
 
       expect(result, 'transform should produce output').toBeDefined()
       // Responsive-prefixed classes must remain in class attribute
@@ -1056,7 +1057,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
       const id = join(tmpDir, 'components', 'ResponsiveMixed.vue')
-      const result = await plugin.transform?.(code, id)
+      const result = await runTransform(plugin, code, id)
 
       expect(result, 'transform should produce output').toBeDefined()
       // Base classes stay in class (not inlined) since responsive variants override the same props
@@ -1082,7 +1083,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
       const id = join(tmpDir, 'components', 'AllBreakpoints.vue')
-      const result = await plugin.transform?.(code, id)
+      const result = await runTransform(plugin, code, id)
 
       expect(result, 'transform should produce output').toBeDefined()
       // All responsive-prefixed classes must remain
@@ -1109,7 +1110,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
       const id = join(tmpDir, 'components', 'ResponsiveResolved.vue')
-      const result = await plugin.transform?.(code, id)
+      const result = await runTransform(plugin, code, id)
 
       expect(result, 'transform should produce output').toBeDefined()
       // Base classes rewritten to arbitrary values (not inlined) due to responsive conflicts
@@ -1155,7 +1156,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
       const id = join(tmpDir, 'components', 'NpmxDefault.takumi.vue')
-      const result = await plugin.transform?.(code, id)
+      const result = await runTransform(plugin, code, id)
 
       expect(result, 'transform should produce output').toBeDefined()
       // Must not contain "in oklab" — Takumi can't parse it
@@ -1179,7 +1180,7 @@ describe('assetTransformPlugin with TW4', () => {
 </template>`
 
       const id = join(tmpDir, 'components', 'DarkMode.vue')
-      const result = await plugin.transform?.(code, id)
+      const result = await runTransform(plugin, code, id)
 
       expect(result, 'transform should produce output').toBeDefined()
       // dark: prefixed classes should remain for runtime colorMode handling

--- a/test/unit/vite-asset-transform.test.ts
+++ b/test/unit/vite-asset-transform.test.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
 import { describe, expect, it } from 'vitest'
 import { AssetTransformPlugin } from '../../src/build/vite-asset-transform'
+import { runTransform } from '../unplugin'
 
 // Minimal mock emoji icon set (real @iconify-json/noto is 25MB)
 const mockNotoIcons = {
@@ -33,19 +34,29 @@ describe('asset-transform plugin', () => {
       publicDir: '/test/public',
     }, { framework: 'vite' })
 
-    it('should include OgImage components', () => {
-      expect(plugin.transformInclude?.('/test/components/OgImage/Test.vue')).toBe(true)
-      expect(plugin.transformInclude?.('/test/components/og-image/Test.vue')).toBe(true)
-      expect(plugin.transformInclude?.('/test/components/OgImageTemplate/Test.vue')).toBe(true)
+    const emojiTemplate = `<template>
+  <div>Hello \u{1F44B}</div>
+</template>`
+
+    it.each([
+      '/test/components/OgImage/Test.vue',
+      '/test/components/og-image/Test.vue',
+      '/test/components/OgImageTemplate/Test.vue',
+      // Nested components carry the query added by ComponentImportRewritePlugin.
+      '/test/components/Shared/Badge.vue?og-image-depth=1',
+    ])('should transform %s', async (id) => {
+      expect(await runTransform(plugin, emojiTemplate, id)).toBeDefined()
     })
 
-    it('should exclude non-OgImage components', () => {
-      expect(plugin.transformInclude?.('/test/components/Header.vue')).toBe(false)
-      expect(plugin.transformInclude?.('/test/pages/index.vue')).toBe(false)
-    })
-
-    it('should exclude node_modules', () => {
-      expect(plugin.transformInclude?.('node_modules/some-pkg/OgImage.vue')).toBe(false)
+    it.each([
+      '/test/components/Header.vue',
+      '/test/pages/index.vue',
+      'node_modules/some-pkg/OgImage.vue',
+      // SFC blocks never carry the ?og-image query, so they are not ours.
+      '/test/components/OgImage/Test.vue?vue&type=style&index=0&lang.css',
+      '/test/components/OgImage/Test.vue?nuxt_component=async',
+    ])('should leave %s alone', async (id) => {
+      expect(await runTransform(plugin, emojiTemplate, id)).toBeUndefined()
     })
 
     it('should transform emojis in text content', async () => {
@@ -55,7 +66,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('<svg')
       expect(result?.code).not.toContain('👋')
@@ -69,7 +80,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       // Emoji in alt attribute should be preserved
       expect(result?.code).toContain('alt="👋 Wave emoji"')
@@ -85,7 +96,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       // Dynamic bindings should be preserved
       expect(result?.code).toContain('{{ emoji }}')
@@ -101,7 +112,7 @@ describe('asset-transform plugin', () => {
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeUndefined()
     })
 
@@ -110,7 +121,7 @@ describe('asset-transform plugin', () => {
 const msg = '👋'
 </script>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeUndefined()
     })
 
@@ -121,7 +132,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       // Should have at least 1 SVG (some emojis may not be in icon set)
       const svgCount = (result?.code.match(/<svg/g) || []).length
@@ -144,7 +155,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('<svg')
       expect(result?.code).toContain('viewBox')
@@ -158,7 +169,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('<svg')
       expect(result?.code).not.toContain('<UIcon')
@@ -171,7 +182,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('class="text-yellow-500"')
       expect(result?.code).toContain('style="')
@@ -184,7 +195,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       // Should return undefined since no static icons to transform
       expect(result).toBeUndefined()
     })
@@ -197,7 +208,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       // Static icon should be transformed
       expect(result?.code).toContain('<svg')
@@ -225,7 +236,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('caption-{{ x }}')
       expect(result?.code).toContain('<footer>sibling</footer>')
@@ -249,7 +260,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('<span>A</span>')
       expect(result?.code).toContain('<span>B</span>')
@@ -268,7 +279,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('<template lang="html">')
       expect(result?.code).toContain('<footer>sibling</footer>')
@@ -294,7 +305,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, testVuePath)
+      const result = await runTransform(plugin, code, testVuePath)
       expect(result).toBeDefined()
       expect(result?.code).toContain('data:image/png;base64,')
       expect(result?.code).not.toContain('src="/images/test.png"')
@@ -307,7 +318,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, testVuePath)
+      const result = await runTransform(plugin, code, testVuePath)
       expect(result).toBeDefined()
       expect(result?.code).toContain('data:image/png;base64,')
       expect(result?.code).not.toContain('src="~/assets/logo.png"')
@@ -320,7 +331,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, testVuePath)
+      const result = await runTransform(plugin, code, testVuePath)
       expect(result).toBeDefined()
       expect(result?.code).toContain('data:image/png;base64,')
       expect(result?.code).not.toContain('src="@/assets/logo.png"')
@@ -333,7 +344,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, testVuePath)
+      const result = await runTransform(plugin, code, testVuePath)
       // Should return undefined since transform is skipped
       expect(result).toBeUndefined()
     })
@@ -345,7 +356,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, testVuePath)
+      const result = await runTransform(plugin, code, testVuePath)
       // Should return undefined since no local images to transform
       expect(result).toBeUndefined()
     })
@@ -357,7 +368,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, testVuePath)
+      const result = await runTransform(plugin, code, testVuePath)
       // Should return undefined since :src is a binding
       expect(result).toBeUndefined()
     })
@@ -370,7 +381,7 @@ const msg = '👋'
   </div>
 </template>`
 
-      const result = await plugin.transform?.(code, testVuePath)
+      const result = await runTransform(plugin, code, testVuePath)
       expect(result).toBeDefined()
       // Should have 2 base64 images
       const base64Count = (result?.code.match(/data:image\/png;base64,/g) || []).length
@@ -397,7 +408,7 @@ const msg = '👋'
 }
 </style>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       const out = result!.code
 
@@ -420,7 +431,7 @@ const msg = '👋'
 }
 </style>`
 
-      const result = await plugin.transform?.(code, '/test/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/test/components/OgImage/Test.vue')
       expect(result).toBeDefined()
 
       const styleAttrMatch = result!.code.match(/style="([^"]*)"/)

--- a/test/unit/vite-component-import-rewrite.test.ts
+++ b/test/unit/vite-component-import-rewrite.test.ts
@@ -1,6 +1,7 @@
 import type { Component } from '@nuxt/schema'
 import { describe, expect, it } from 'vitest'
 import { ComponentImportRewritePlugin } from '../../src/build/vite-component-import-rewrite'
+import { runTransform } from '../unplugin'
 
 const mockComponents: Component[] = [
   { pascalName: 'OgBase', kebabName: 'og-base', filePath: '/app/components/Og/OgBase.vue' },
@@ -16,90 +17,95 @@ function createPlugin() {
   }, { framework: 'vite' })
 }
 
+const NESTED_TEMPLATE = `<template>
+  <div>
+    <OgTitle>Hello</OgTitle>
+  </div>
+</template>`
+
 describe('component-import-rewrite plugin', () => {
-  describe('transformInclude', () => {
+  describe('module scope', () => {
     const plugin = createPlugin()
 
-    it('includes OG template files', () => {
-      expect(plugin.transformInclude?.('/app/components/OgImage/Test.vue')).toBe(true)
+    it.each([
+      '/app/components/OgImage/Test.vue',
+      '/app/components/Og/OgBase.vue?og-image',
+      '/app/components/Og/OgBase.vue?og-image-depth=1',
+      '/app/components/Og/OgBase.vue?og-image-depth=4',
+    ])('rewrites %s', async (id) => {
+      expect(await runTransform(plugin, NESTED_TEMPLATE, id)).toBeDefined()
     })
 
-    it('excludes non-OG files', () => {
-      expect(plugin.transformInclude?.('/app/components/Other/Test.vue')).toBe(false)
-    })
-
-    it('includes ?og-image files (depth 0)', () => {
-      expect(plugin.transformInclude?.('/app/components/Og/OgBase.vue?og-image')).toBe(true)
-    })
-
-    it('includes ?og-image-depth=1 files', () => {
-      expect(plugin.transformInclude?.('/app/components/Og/OgBase.vue?og-image-depth=1')).toBe(true)
-    })
-
-    it('includes ?og-image-depth=4 files (under limit)', () => {
-      expect(plugin.transformInclude?.('/app/components/Og/OgBase.vue?og-image-depth=4')).toBe(true)
-    })
-
-    it('excludes ?og-image-depth=5 files (at limit)', () => {
-      expect(plugin.transformInclude?.('/app/components/Og/OgBase.vue?og-image-depth=5')).toBe(false)
+    it.each([
+      // Outside every OG template directory.
+      '/app/components/Other/Test.vue',
+      // At the cascade depth limit.
+      '/app/components/Og/OgBase.vue?og-image-depth=5',
+      // SFC blocks never carry the query and are not ours to rewrite.
+      '/app/components/OgImage/Test.vue?vue&type=style&index=0&lang.css',
+      '/app/components/OgImage/Test.vue?nuxt_component=async',
+      // Not a Vue file at all.
+      '/app/components/OgImage/Test.ts',
+    ])('leaves %s alone', async (id) => {
+      expect(await runTransform(plugin, NESTED_TEMPLATE, id)).toBeUndefined()
     })
   })
 
   describe('transform', () => {
     const plugin = createPlugin()
 
-    it('injects ?og-image-depth=1 imports for top-level OG templates', () => {
+    it('injects ?og-image-depth=1 imports for top-level OG templates', async () => {
       const code = `<template>
   <div>
     <OgBase>Hello</OgBase>
   </div>
 </template>`
 
-      const result = plugin.transform?.(code, '/app/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/app/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain(`import OgBase from '/app/components/Og/OgBase.vue?og-image-depth=1'`)
     })
 
-    it('cascades imports with incremented depth for ?og-image files', () => {
+    it('cascades imports with incremented depth for ?og-image files', async () => {
       const code = `<template>
   <div>
     <OgTitle>Hello</OgTitle>
   </div>
 </template>`
 
-      const result = plugin.transform?.(code, '/app/components/Og/OgBase.vue?og-image-depth=1')
+      const result = await runTransform(plugin, code, '/app/components/Og/OgBase.vue?og-image-depth=1')
       expect(result).toBeDefined()
       expect(result?.code).toContain(`import OgTitle from '/app/components/Og/OgTitle.vue?og-image-depth=2'`)
     })
 
-    it('skips files without components', () => {
+    it('skips files without components', async () => {
       const code = `<template>
   <div class="text-red">Hello</div>
 </template>`
 
-      const result = plugin.transform?.(code, '/app/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/app/components/OgImage/Test.vue')
       expect(result).toBeUndefined()
     })
 
-    it('skips Icon/UIcon components', () => {
+    it('skips Icon/UIcon components', async () => {
       const code = `<template>
   <div>
     <Icon name="test" />
   </div>
 </template>`
 
-      const result = plugin.transform?.(code, '/app/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/app/components/OgImage/Test.vue')
       expect(result).toBeUndefined()
     })
 
-    it('creates script setup block when none exists', () => {
+    it('creates script setup block when none exists', async () => {
       const code = `<template>
   <div>
     <OgTitle>Hello</OgTitle>
   </div>
 </template>`
 
-      const result = plugin.transform?.(code, '/app/components/OgImage/Test.vue')
+      const result = await runTransform(plugin, code, '/app/components/OgImage/Test.vue')
       expect(result).toBeDefined()
       expect(result?.code).toContain('<script setup>')
       expect(result?.code).toContain(`import OgTitle from '/app/components/Og/OgTitle.vue?og-image-depth=1'`)

--- a/test/unplugin.ts
+++ b/test/unplugin.ts
@@ -1,0 +1,58 @@
+import type { StringFilter, UnpluginOptions } from 'unplugin'
+
+type Pattern = string | RegExp
+
+export interface TransformOutput {
+  code: string
+  map?: unknown
+}
+
+/**
+ * unplugin treats a bare string `id` pattern as a glob and a bare string `code` pattern
+ * as a substring. This helper only implements the substring form, so a glob fails loudly
+ * instead of matching the wrong ids.
+ */
+function testPattern(pattern: Pattern, value: string, kind: 'id' | 'code'): boolean {
+  if (typeof pattern !== 'string')
+    return pattern.test(value)
+  if (kind === 'id')
+    throw new TypeError(`glob id filters are not supported by this helper: ${pattern}`)
+  return value.includes(pattern)
+}
+
+function testFilter(filter: StringFilter | undefined, value: string, kind: 'id' | 'code'): boolean {
+  if (!filter)
+    return true
+  if (typeof filter === 'string' || filter instanceof RegExp || Array.isArray(filter))
+    return [filter].flat().some(pattern => testPattern(pattern, value, kind))
+  const exclude = filter.exclude ? [filter.exclude].flat() : []
+  if (exclude.some(pattern => testPattern(pattern, value, kind)))
+    return false
+  const include = filter.include ? [filter.include].flat() : undefined
+  return !include || include.some(pattern => testPattern(pattern, value, kind))
+}
+
+/**
+ * Run an unplugin `transform` hook the way a bundler does: apply the declared filter
+ * first, then the handler. Returns undefined when the filter rejects the module, which
+ * is what a bundler does by never calling the hook.
+ */
+export async function runTransform(plugin: UnpluginOptions, code: string, id: string): Promise<TransformOutput | undefined> {
+  const hook = plugin.transform
+  if (!hook)
+    return undefined
+  let result
+  if (typeof hook === 'function') {
+    result = await hook.call({} as never, code, id)
+  }
+  else {
+    if (!testFilter(hook.filter?.id, id, 'id'))
+      return undefined
+    if (!testFilter(hook.filter?.code, code, 'code'))
+      return undefined
+    result = await hook.handler.call({} as never, code, id)
+  }
+  if (!result)
+    return undefined
+  return typeof result === 'string' ? { code: result } : result as TransformOutput
+}


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)

### 📚 Description

Build plugins currently run JavaScript filters for every module. unplugin 3 now passes those filters to the bundler. The corrected filter also covers `.mts` and `.cts` files under `zeroRuntime`.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).