### PR TITLE
fix(fonts): keep subset family names stable across renders

### DIFF
--- a/src/runtime/server/og-image/font-subsets.ts
+++ b/src/runtime/server/og-image/font-subsets.ts
@@ -9,8 +9,12 @@ import type { RuntimeFontConfig } from '../../types'
  * fontsource, each covering ~200 characters, this means only one subset's
  * glyphs render while the rest show as .notdef boxes.
  *
- * Fix: rename each subset to "Family__N" and use font-family fallback chains
- * so renderers try each subset in order per character.
+ * Fix: rename each subset to "Family__<stable suffix>" and use font-family
+ * fallback chains so renderers try each subset in order per character. The
+ * suffix is derived from the font's src so a given subset binary resolves to
+ * the same name in every render of a process. Renderers keep the first
+ * registration per name, so a name that flips binaries between renders
+ * would silently render against the stale binary.
  */
 export function renameSubsetFonts(fonts: RuntimeFontConfig[]): RuntimeFontConfig[] {
   // Group by family+weight+style identity
@@ -40,7 +44,7 @@ export function renameSubsetFonts(fonts: RuntimeFontConfig[]): RuntimeFontConfig
       result.push({
         ...f,
         originalFamily: f.originalFamily || f.family,
-        family: `${f.family}__${i}`,
+        family: `${f.family}__${stableSubsetSuffix(f) ?? i}`,
       })
     }
   }
@@ -48,8 +52,26 @@ export function renameSubsetFonts(fonts: RuntimeFontConfig[]): RuntimeFontConfig
 }
 
 /**
+ * Deterministic suffix identifying a subset binary by its source. Returns
+ * undefined only when the font carries no src or localPath to derive from.
+ */
+function stableSubsetSuffix(f: RuntimeFontConfig): string | undefined {
+  const s = f.src || f.localPath
+  if (!s)
+    return undefined
+  let h1 = 5381
+  let h2 = 2166136261
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i)
+    h1 = (((h1 << 5) + h1) ^ c) >>> 0
+    h2 = Math.imul(h2 ^ c, 16777619) >>> 0
+  }
+  return (BigInt(h1) << 32n | BigInt(h2)).toString(36)
+}
+
+/**
  * Build a mapping from original family names to their renamed subset chain.
- * E.g., "Noto Sans SC" → ["Noto Sans SC__0", "Noto Sans SC__1", ...]
+ * E.g., "Noto Sans SC" → ["Noto Sans SC__<hash-a>", "Noto Sans SC__<hash-b>", ...]
  */
 export function buildSubsetFamilyChain(fonts: RuntimeFontConfig[]): Map<string, string[]> {
   const chains = new Map<string, string[]>()

--- a/src/runtime/server/og-image/font-subsets.ts
+++ b/src/runtime/server/og-image/font-subsets.ts
@@ -31,9 +31,14 @@ export function renameSubsetFonts(fonts: RuntimeFontConfig[]): RuntimeFontConfig
   const result: RuntimeFontConfig[] = []
   let changed = false
   for (const members of groups.values()) {
-    // Only rename when multiple distinct data blobs exist (subset fonts)
-    const needsRename = members.length > 1
-      && new Set(members.map(f => f.cacheKey)).size > 1
+    // Rename when the group carries unicode-range subsets, even a single one.
+    // The codepoint filter can leave exactly one subset per render, and a bare
+    // family name that flips binaries between renders would render stale
+    // glyphs (renderers keep the first registration per name). Also rename
+    // when multiple distinct binaries share a family identity. Bare names are
+    // kept only for non-subset fonts.
+    const needsRename = members.some(f => f.unicodeRange)
+      || (members.length > 1 && new Set(members.map(f => f.cacheKey)).size > 1)
     if (!needsRename) {
       result.push(...members)
       continue

--- a/src/runtime/server/og-image/fonts.ts
+++ b/src/runtime/server/og-image/fonts.ts
@@ -311,7 +311,7 @@ export interface LoadFontsForRendererOptions extends LoadFontsOptions {
  *
  * When a font family has multiple unicode-range subsets loaded (e.g., CJK fonts
  * split into many small chunks), renames each subset to a unique family name
- * (e.g., "Noto Sans SC__0", "Noto Sans SC__1") so renderers use font-family
+ * (e.g., "Noto Sans SC__<stable hash per binary>") so renderers use font-family
  * fallback chains for per-character glyph coverage. Without this, both Satori
  * and Takumi pick the first font file and show .notdef for characters in other subsets.
  */

--- a/src/runtime/server/og-image/satori/renderer.ts
+++ b/src/runtime/server/og-image/satori/renderer.ts
@@ -159,7 +159,7 @@ async function createJpeg(event: OgImageRenderEventContext) {
 
 /**
  * Walk the satori VNode tree and rewrite fontFamily values to use subset chains.
- * E.g., `fontFamily: "Noto Sans SC"` → `fontFamily: "Noto Sans SC__0, Noto Sans SC__1, ..."`
+ * E.g., `fontFamily: "Noto Sans SC"` → `fontFamily: "Noto Sans SC__<hash-a>, Noto Sans SC__<hash-b>, ..."`
  */
 function rewriteVNodeFontFamilies(node: any, subsetChains: Map<string, string[]>) {
   const style = node.props?.style

--- a/test/unit/fonts.test.ts
+++ b/test/unit/fonts.test.ts
@@ -572,7 +572,7 @@ describe('extractCodepoints', () => {
 })
 
 describe('renameSubsetFonts', () => {
-  function makeFontConfig(overrides: Partial<{ family: string, weight: number, style: string, cacheKey: string, data: ArrayBuffer }>): any {
+  function makeFontConfig(overrides: Partial<{ family: string, weight: number, style: string, src: string, cacheKey: string, data: ArrayBuffer }>): any {
     return {
       family: 'Inter',
       weight: 400,
@@ -599,19 +599,38 @@ describe('renameSubsetFonts', () => {
 
   it('renames subset fonts with unique suffixes', () => {
     const fonts = [
-      makeFontConfig({ family: 'Noto Sans SC', cacheKey: 'noto-chunk0', data: new ArrayBuffer(10) }),
-      makeFontConfig({ family: 'Noto Sans SC', cacheKey: 'noto-chunk1', data: new ArrayBuffer(20) }),
-      makeFontConfig({ family: 'Noto Sans SC', cacheKey: 'noto-chunk2', data: new ArrayBuffer(30) }),
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-0.woff2', cacheKey: 'noto-chunk0', data: new ArrayBuffer(10) }),
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-1.woff2', cacheKey: 'noto-chunk1', data: new ArrayBuffer(20) }),
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-2.woff2', cacheKey: 'noto-chunk2', data: new ArrayBuffer(30) }),
     ]
     const result = renameSubsetFonts(fonts)
     expect(result).toHaveLength(3)
-    expect(result[0].family).toBe('Noto Sans SC__0')
-    expect(result[1].family).toBe('Noto Sans SC__1')
-    expect(result[2].family).toBe('Noto Sans SC__2')
+    const names = result.map(f => f.family)
+    expect(new Set(names).size).toBe(3)
+    for (const name of names)
+      expect(name.startsWith('Noto Sans SC__')).toBe(true)
     // All preserve original family name
     expect(result[0].originalFamily).toBe('Noto Sans SC')
     expect(result[1].originalFamily).toBe('Noto Sans SC')
     expect(result[2].originalFamily).toBe('Noto Sans SC')
+  })
+
+  it('gives the same subset binary the same name across renders with different filtered lists', () => {
+    // Render 1's codepoint filter keeps subsets A and B; B lands at index 1
+    const renderA = [
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-a.woff2', cacheKey: 'noto-a', data: new ArrayBuffer(10) }),
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-b.woff2', cacheKey: 'noto-b', data: new ArrayBuffer(20) }),
+    ]
+    // Render 2's codepoint filter keeps subsets B and C; B now lands at index 0
+    const renderB = [
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-b.woff2', cacheKey: 'noto-b', data: new ArrayBuffer(20) }),
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-c.woff2', cacheKey: 'noto-c', data: new ArrayBuffer(30) }),
+    ]
+    const a = renameSubsetFonts(renderA)
+    const b = renameSubsetFonts(renderB)
+    // Renderers keep the first registration per family name, so a name that
+    // flips binaries between renders renders stale glyphs as .notdef
+    expect(b[0].family).toBe(a[1].family)
   })
 
   it('does not rename when all fonts in a group have the same cacheKey', () => {
@@ -629,8 +648,8 @@ describe('renameSubsetFonts', () => {
   it('only renames the group that has multiple distinct fonts', () => {
     const fonts = [
       makeFontConfig({ family: 'Inter', cacheKey: 'inter-400' }),
-      makeFontConfig({ family: 'Noto Sans SC', cacheKey: 'noto-0' }),
-      makeFontConfig({ family: 'Noto Sans SC', cacheKey: 'noto-1' }),
+      makeFontConfig({ family: 'Noto Sans SC', src: '/noto-0.woff2', cacheKey: 'noto-0' }),
+      makeFontConfig({ family: 'Noto Sans SC', src: '/noto-1.woff2', cacheKey: 'noto-1' }),
     ]
     const result = renameSubsetFonts(fonts)
     expect(result).toHaveLength(3)
@@ -638,8 +657,9 @@ describe('renameSubsetFonts', () => {
     expect(result[0].family).toBe('Inter')
     expect(result[0].originalFamily).toBeUndefined()
     // Noto gets renamed
-    expect(result[1].family).toBe('Noto Sans SC__0')
-    expect(result[2].family).toBe('Noto Sans SC__1')
+    expect(result[1].family.startsWith('Noto Sans SC__')).toBe(true)
+    expect(result[2].family.startsWith('Noto Sans SC__')).toBe(true)
+    expect(result[1].family).not.toBe(result[2].family)
   })
 })
 

--- a/test/unit/fonts.test.ts
+++ b/test/unit/fonts.test.ts
@@ -572,7 +572,7 @@ describe('extractCodepoints', () => {
 })
 
 describe('renameSubsetFonts', () => {
-  function makeFontConfig(overrides: Partial<{ family: string, weight: number, style: string, src: string, cacheKey: string, data: ArrayBuffer }>): any {
+  function makeFontConfig(overrides: Partial<{ family: string, weight: number, style: string, src: string, cacheKey: string, data: ArrayBuffer, unicodeRange: string }>): any {
     return {
       family: 'Inter',
       weight: 400,
@@ -631,6 +631,27 @@ describe('renameSubsetFonts', () => {
     // Renderers keep the first registration per family name, so a name that
     // flips binaries between renders renders stale glyphs as .notdef
     expect(b[0].family).toBe(a[1].family)
+  })
+
+  it('renames a singleton subset font so its name stays bound to its binary', () => {
+    // The codepoint filter can leave exactly one subset loaded per render.
+    // Renderers keep the first registration per family name, so a bare name
+    // that flips binaries between renders renders stale glyphs as .notdef
+    const renderA = [
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-a.woff2', cacheKey: 'noto-a', unicodeRange: 'U+4E00-4EFF', data: new ArrayBuffer(10) }),
+    ]
+    const renderB = [
+      makeFontConfig({ family: 'Noto Sans SC', src: '/chunk-b.woff2', cacheKey: 'noto-b', unicodeRange: 'U+4F00-4FFF', data: new ArrayBuffer(20) }),
+    ]
+    const a1 = renameSubsetFonts(renderA)
+    const b1 = renameSubsetFonts(renderB)
+    expect(a1[0].family).not.toBe('Noto Sans SC')
+    expect(a1[0].family).not.toBe(b1[0].family)
+    expect(a1[0].originalFamily).toBe('Noto Sans SC')
+    expect(b1[0].originalFamily).toBe('Noto Sans SC')
+    // Repeat renders keep the same name per binary
+    expect(renameSubsetFonts(renderA)[0].family).toBe(a1[0].family)
+    expect(renameSubsetFonts(renderB)[0].family).toBe(b1[0].family)
   })
 
   it('does not rename when all fonts in a group have the same cacheKey', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Closes #677

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

CJK glyphs in #677 became missing-glyph boxes when earlier renders registered different subsets under the same family name.

Subset family names now identify their source fonts using Nuxt’s `fnv1a-64` dependency. Missing source paths fall back to font cache keys. Regular, bold, and italic faces stay grouped so renderers can select the requested face.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).