### PR TITLE
fix: do not set headers on a finished response

### DIFF
--- a/src/runtime/server/util/eventHandlers.ts
+++ b/src/runtime/server/util/eventHandlers.ts
@@ -27,7 +27,7 @@ export async function imageEventHandler(e: H3Event) {
   finally {
     timings.record('total', performance.now() - reqStart)
     const header = timings.header()
-    if (header)
+    if (header && !e.handled && !e.node.res.headersSent)
       setHeader(e, 'Server-Timing', header)
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix a possible `Cannot set headers after they are sent to the client` error.

It happens when trying to fetch an image in the h3's cache which replies with a 304 and ends the response before the handler returns.
The finally block then calls setHeader on a finished response, and the error is thrown.
Sentry report:

<img width="844" height="713" alt="Screendrop_2026-09-11-16-24-55" src="https://github.com/user-attachments/assets/8e513442-2f77-44ce-8feb-ed6027f800e1" />

